### PR TITLE
Security hardening, workflow features, and dev environment fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ test-results/
 
 # drizzle studio
 .drizzle/
+.env

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -6,8 +6,11 @@ services:
       - .:/app
       - /app/node_modules
       - /app/.next
+    env_file:
+      - .env.local
     environment:
       NODE_ENV: development
+      ANTHROPIC_API_KEY: ${SKILLAI_ANTHROPIC_API_KEY}
     command: npm run dev
   db:
     ports:

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,7 +10,7 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
-        source: '**',
+        source: '/(.*)',
         headers: [
           { key: 'X-Frame-Options', value: 'DENY' },
           { key: 'X-Content-Type-Options', value: 'nosniff' },

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,20 @@ const nextConfig: NextConfig = {
       bodySizeLimit: '11mb',
     },
   },
+  async headers() {
+    return [
+      {
+        source: '**',
+        headers: [
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'X-XSS-Protection', value: '1; mode=block' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+        ],
+      },
+    ]
+  },
 }
 
 export default nextConfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "bcryptjs": "^3.0.3",
         "dotenv": "^17.4.1",
         "drizzle-orm": "^0.45.2",
+        "file-type": "^22.0.1",
         "lucide-react": "^1.8.0",
         "mammoth": "^1.12.0",
         "next": "16.2.3",
@@ -432,6 +433,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -3303,6 +3314,29 @@
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
       }
+    },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -6867,6 +6901,24 @@
         "node": ">= 12"
       }
     },
+    "node_modules/file-type": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-22.0.1.tgz",
+      "integrity": "sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.5",
+        "token-types": "^6.1.2",
+        "uint8array-extras": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -7405,6 +7457,26 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -11316,6 +11388,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -11535,6 +11623,24 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/tough-cookie": {
@@ -12280,6 +12386,18 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "bcryptjs": "^3.0.3",
     "dotenv": "^17.4.1",
     "drizzle-orm": "^0.45.2",
+    "file-type": "^22.0.1",
     "lucide-react": "^1.8.0",
     "mammoth": "^1.12.0",
     "next": "16.2.3",

--- a/src/actions/agencies.ts
+++ b/src/actions/agencies.ts
@@ -1,11 +1,11 @@
 'use server'
 
-import { headers } from 'next/headers'
 import { z } from 'zod'
 import { eq, and } from 'drizzle-orm'
 import { withTenant } from '@/db'
 import { agencies } from '@/db/schema'
 import { redirect } from 'next/navigation'
+import { getActionContext } from '@/lib/auth/action-context'
 
 const AgencySchema = z.object({
   name: z.string().min(1, 'Name is required').max(150),
@@ -14,18 +14,13 @@ const AgencySchema = z.object({
   notes: z.string().optional(),
 })
 
-async function getTenantId(): Promise<string> {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  if (!tenantId) throw new Error('Not authenticated')
-  return tenantId
-}
-
 export async function createAgency(
   _prev: { error?: string } | null,
   formData: FormData
 ): Promise<{ error?: string }> {
-  const tenantId = await getTenantId()
+  const ctx = await getActionContext()
+  if (!ctx) throw new Error('Not authenticated')
+  const { tenantId } = ctx
 
   const parsed = AgencySchema.safeParse({
     name: formData.get('name'),
@@ -58,7 +53,9 @@ export async function updateAgency(
   _prev: { error?: string } | null,
   formData: FormData
 ): Promise<{ error?: string }> {
-  const tenantId = await getTenantId()
+  const ctx = await getActionContext()
+  if (!ctx) throw new Error('Not authenticated')
+  const { tenantId } = ctx
 
   const parsed = AgencySchema.safeParse({
     name: formData.get('name'),
@@ -89,7 +86,9 @@ export async function updateAgency(
 }
 
 export async function archiveAgency(agencyId: string): Promise<void> {
-  const tenantId = await getTenantId()
+  const ctx = await getActionContext()
+  if (!ctx) throw new Error('Not authenticated')
+  const { tenantId } = ctx
 
   await withTenant(tenantId, async (tx) => {
     await tx

--- a/src/actions/calendar.ts
+++ b/src/actions/calendar.ts
@@ -1,12 +1,13 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
-import { headers } from 'next/headers'
+import { after } from 'next/server'
 import { eq, and, desc } from 'drizzle-orm'
 import { z } from 'zod'
 import { db, withTenant } from '@/db'
 import { interviewSlots, calendarConnections } from '@/db/schema'
 import { syncSlotToCalendars, deleteSlotFromCalendars } from '@/lib/calendar/sync'
+import { getActionContext } from '@/lib/auth/action-context'
 import type { InterviewSlot } from '@/db/schema/interview-slots'
 
 const CreateSlotSchema = z.object({
@@ -29,11 +30,9 @@ export type CreateSlotState =
 export async function createInterviewSlot(
   data: z.infer<typeof CreateSlotSchema>
 ): Promise<CreateSlotState> {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  const userId = headersList.get('x-user-id')
-
-  if (!tenantId || !userId) return { success: false, error: 'Unauthorized' }
+  const ctx = await getActionContext()
+  if (!ctx) return { success: false, error: 'Unauthorized' }
+  const { tenantId, userId } = ctx
 
   const parsed = CreateSlotSchema.safeParse(data)
   if (!parsed.success) {
@@ -111,11 +110,9 @@ export async function cancelInterviewSlot(
   slotId: string,
   candidateId: string
 ): Promise<{ success: boolean; error?: string }> {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  const userId = headersList.get('x-user-id')
-
-  if (!tenantId || !userId) return { success: false, error: 'Unauthorized' }
+  const ctx = await getActionContext()
+  if (!ctx) return { success: false, error: 'Unauthorized' }
+  const { tenantId, userId } = ctx
 
   // Fetch slot to verify ownership and get calendar event IDs
   const [slot] = await withTenant(tenantId, async (tx) =>
@@ -162,9 +159,9 @@ export async function getSlots(tenantId: string, candidateId: string): Promise<I
 export async function disconnectCalendar(
   provider: 'google' | 'microsoft'
 ): Promise<void> {
-  const headersList = await headers()
-  const userId = headersList.get('x-user-id')
-  if (!userId) return
+  const ctx = await getActionContext()
+  if (!ctx) return
+  const { userId } = ctx
 
   await db
     .delete(calendarConnections)

--- a/src/actions/calendar.ts
+++ b/src/actions/calendar.ts
@@ -8,6 +8,7 @@ import { db, withTenant } from '@/db'
 import { interviewSlots, calendarConnections } from '@/db/schema'
 import { syncSlotToCalendars, deleteSlotFromCalendars } from '@/lib/calendar/sync'
 import { getActionContext } from '@/lib/auth/action-context'
+import { parseIcsFile } from '@/lib/ics-parser'
 import type { InterviewSlot } from '@/db/schema/interview-slots'
 
 const CreateSlotSchema = z.object({
@@ -189,4 +190,86 @@ export async function getCalendarConnections(
     google: providers.has('google'),
     microsoft: providers.has('microsoft'),
   }
+}
+
+// ---------------------------------------------------------------------------
+// ICS file import
+// ---------------------------------------------------------------------------
+
+export type IcsImportResult =
+  | { success: true; imported: number; skipped: number }
+  | { success: false; error: string }
+
+/** Maximum ICS file size accepted (500 KB as character count). */
+const MAX_ICS_CHARS = 500 * 1024
+
+/** Maximum number of events processed from a single file. */
+const MAX_EVENTS = 50
+
+/**
+ * Parse an ICS file's text content and insert valid future events as
+ * interview slots for the given candidate.
+ *
+ * @param candidateId - UUID of the target candidate
+ * @param roleId      - UUID of an associated role, or null
+ * @param fileContent - Raw text of the uploaded .ics file
+ */
+export async function importIcsSlots(
+  candidateId: string,
+  roleId: string | null,
+  fileContent: string
+): Promise<IcsImportResult> {
+  const ctx = await getActionContext()
+  if (!ctx) return { success: false, error: 'Unauthorized' }
+  const { tenantId, userId } = ctx
+
+  if (!fileContent || fileContent.length === 0) {
+    return { success: false, error: 'File is empty' }
+  }
+  if (fileContent.length > MAX_ICS_CHARS) {
+    return { success: false, error: 'File is too large (max 500 KB)' }
+  }
+
+  const events = parseIcsFile(fileContent)
+
+  if (events.length === 0) {
+    return { success: false, error: 'No valid events found in file' }
+  }
+
+  const now = new Date()
+  let imported = 0
+  let skipped = 0
+
+  for (const event of events.slice(0, MAX_EVENTS)) {
+    // Skip events that are already in the past
+    if (event.start <= now) {
+      skipped++
+      continue
+    }
+
+    try {
+      await withTenant(tenantId, async (tx) =>
+        tx.insert(interviewSlots).values({
+          tenantId,
+          candidateId,
+          roleId: roleId ?? null,
+          title: event.summary,
+          scheduledAt: event.start,
+          durationMinutes: event.durationMinutes,
+          location: event.location ?? null,
+          meetingUrl: event.meetingUrl ?? null,
+          slotNotes: event.description ? 'Imported from calendar file' : null,
+          status: 'scheduled',
+          createdBy: userId,
+        })
+      )
+      imported++
+    } catch {
+      skipped++
+    }
+  }
+
+  revalidatePath(`/dashboard/candidates/${candidateId}`)
+
+  return { success: true, imported, skipped }
 }

--- a/src/actions/candidates.ts
+++ b/src/actions/candidates.ts
@@ -3,7 +3,6 @@
 import { writeFile, mkdir } from 'fs/promises'
 import { join, extname } from 'path'
 import { randomUUID } from 'crypto'
-import { headers } from 'next/headers'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 import { after } from 'next/server'
@@ -15,8 +14,8 @@ import { parseFile, ParseError } from '@/lib/parsers'
 import { triggerScoring } from '@/lib/ai/scoring'
 import { requireRole } from '@/lib/auth/require-role'
 import { writeAuditLog } from '@/lib/audit'
+import { getActionContext } from '@/lib/auth/action-context'
 import type { FileType } from '@/lib/parsers'
-import type { UserRole } from '@/lib/auth/types'
 import type { CandidateStatus } from '@/db/schema/candidates'
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10 MB
@@ -58,14 +57,10 @@ export async function createCandidate(
   formData: FormData
 ): Promise<CreateCandidateState> {
   // -- Auth context from middleware headers --
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  const userId = headersList.get('x-user-id')
-  const userRole = headersList.get('x-user-role')
+  const ctx = await getActionContext()
+  if (!ctx) return { success: false, error: 'Unauthorized' }
+  const { tenantId, userId, userRole } = ctx
 
-  if (!tenantId || !userId) {
-    return { success: false, error: 'Unauthorized' }
-  }
   if (userRole === 'viewer') {
     return { success: false, error: 'Forbidden: recruiters and admins only' }
   }
@@ -195,11 +190,9 @@ export async function updateCandidateStatus(
   candidateId: string,
   status: CandidateStatus
 ): Promise<void> {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  const userRole = headersList.get('x-user-role') as UserRole | null
-
-  if (!tenantId) throw new Error('Unauthorized')
+  const ctx = await getActionContext()
+  if (!ctx) throw new Error('Unauthorized')
+  const { tenantId, userRole } = ctx
 
   requireRole(userRole ?? undefined, 'recruiter')
 
@@ -233,11 +226,9 @@ export async function bulkUpdateCandidateStatus(
   candidateIds: string[],
   status: CandidateStatus
 ): Promise<{ success: boolean; updated: number; error?: string }> {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  const userRole = headersList.get('x-user-role') as UserRole | null
-
-  if (!tenantId) return { success: false, updated: 0, error: 'Unauthorized' }
+  const ctx = await getActionContext()
+  if (!ctx) return { success: false, updated: 0, error: 'Unauthorized' }
+  const { tenantId, userRole } = ctx
 
   try {
     requireRole(userRole ?? undefined, 'recruiter')
@@ -299,11 +290,9 @@ export async function updateCandidateDetails(
   _prev: UpdateCandidateState | null,
   formData: FormData
 ): Promise<UpdateCandidateState> {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  const userRole = headersList.get('x-user-role') as UserRole | null
-
-  if (!tenantId) return { success: false, error: 'Unauthorized' }
+  const ctx = await getActionContext()
+  if (!ctx) return { success: false, error: 'Unauthorized' }
+  const { tenantId, userRole } = ctx
 
   try {
     requireRole(userRole ?? undefined, 'recruiter')
@@ -353,11 +342,9 @@ export async function updateCandidateAgency(
   candidateId: string,
   agencyId: string | null
 ): Promise<{ success: boolean; error?: string }> {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  const userRole = headersList.get('x-user-role') as UserRole | null
-
-  if (!tenantId) return { success: false, error: 'Unauthorized' }
+  const ctx = await getActionContext()
+  if (!ctx) return { success: false, error: 'Unauthorized' }
+  const { tenantId, userRole } = ctx
 
   try {
     requireRole(userRole ?? undefined, 'recruiter')
@@ -381,11 +368,9 @@ export async function updateCandidateAgency(
 // ---------------------------------------------------------------------------
 
 export async function archiveCandidate(candidateId: string): Promise<void> {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  const userRole = headersList.get('x-user-role') as UserRole | null
-
-  if (!tenantId) throw new Error('Unauthorized')
+  const ctx = await getActionContext()
+  if (!ctx) throw new Error('Unauthorized')
+  const { tenantId, userRole } = ctx
 
   requireRole(userRole ?? undefined, 'recruiter')
 

--- a/src/actions/candidates.ts
+++ b/src/actions/candidates.ts
@@ -6,7 +6,7 @@ import { randomUUID } from 'crypto'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 import { after } from 'next/server'
-import { eq, and, inArray } from 'drizzle-orm'
+import { eq, and, inArray, or, ilike, notInArray } from 'drizzle-orm'
 import { z } from 'zod'
 import { db, withTenant } from '@/db'
 import { candidates, scores } from '@/db/schema'
@@ -389,4 +389,62 @@ export async function archiveCandidate(candidateId: string): Promise<void> {
   })
 
   redirect('/dashboard/candidates')
+}
+
+// ---------------------------------------------------------------------------
+// searchCandidatesForRole — find active candidates not yet scored for a role
+// ---------------------------------------------------------------------------
+
+export type CandidateSearchResult = {
+  id: string
+  firstName: string
+  lastName: string
+  email: string | null
+  status: string
+}
+
+export async function searchCandidatesForRole(
+  roleId: string,
+  query: string
+): Promise<CandidateSearchResult[]> {
+  const ctx = await getActionContext()
+  if (!ctx) return []
+
+  const { tenantId } = ctx
+  const trimmed = query.trim()
+  if (trimmed.length < 1) return []
+
+  // Subquery: candidate IDs already scored for this role
+  const alreadyScoredSubquery = db
+    .select({ candidateId: scores.candidateId })
+    .from(scores)
+    .where(eq(scores.roleId, roleId))
+
+  const results = await withTenant(tenantId, async (tx) =>
+    tx
+      .select({
+        id: candidates.id,
+        firstName: candidates.firstName,
+        lastName: candidates.lastName,
+        email: candidates.email,
+        status: candidates.status,
+      })
+      .from(candidates)
+      .where(
+        and(
+          eq(candidates.tenantId, tenantId),
+          eq(candidates.isActive, true),
+          or(
+            ilike(candidates.firstName, `%${trimmed}%`),
+            ilike(candidates.lastName, `%${trimmed}%`),
+            ilike(candidates.email, `%${trimmed}%`)
+          ),
+          notInArray(candidates.id, alreadyScoredSubquery)
+        )
+      )
+      .orderBy(candidates.lastName, candidates.firstName)
+      .limit(20)
+  )
+
+  return results
 }

--- a/src/actions/customers.ts
+++ b/src/actions/customers.ts
@@ -1,13 +1,12 @@
 'use server'
 
-import { headers } from 'next/headers'
 import { revalidatePath } from 'next/cache'
 import { z } from 'zod'
 import { eq, and } from 'drizzle-orm'
 import { withTenant } from '@/db'
 import { customers } from '@/db/schema'
 import { requireRole } from '@/lib/auth/require-role'
-import type { UserRole } from '@/lib/auth/types'
+import { getActionContext } from '@/lib/auth/action-context'
 import { redirect } from 'next/navigation'
 
 const CustomerSchema = z.object({
@@ -26,24 +25,13 @@ export type CreateCustomerState = {
   customerId?: string
 }
 
-async function getTenantId(): Promise<string> {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  if (!tenantId) throw new Error('Not authenticated')
-  return tenantId
-}
-
-async function getUserRole(): Promise<UserRole | undefined> {
-  const headersList = await headers()
-  return (headersList.get('x-user-role') as UserRole | null) ?? undefined
-}
-
 export async function createCustomer(
   _prev: CreateCustomerState | null,
   formData: FormData
 ): Promise<CreateCustomerState> {
-  const tenantId = await getTenantId()
-  const userRole = await getUserRole()
+  const ctx = await getActionContext()
+  if (!ctx) throw new Error('Not authenticated')
+  const { tenantId, userRole } = ctx
 
   try {
     requireRole(userRole, 'recruiter')
@@ -90,8 +78,9 @@ export async function updateCustomer(
   _prev: CreateCustomerState | null,
   formData: FormData
 ): Promise<CreateCustomerState> {
-  const tenantId = await getTenantId()
-  const userRole = await getUserRole()
+  const ctx = await getActionContext()
+  if (!ctx) throw new Error('Not authenticated')
+  const { tenantId, userRole } = ctx
 
   try {
     requireRole(userRole, 'recruiter')
@@ -137,8 +126,9 @@ export async function updateCustomer(
 }
 
 export async function archiveCustomer(customerId: string): Promise<void> {
-  const tenantId = await getTenantId()
-  const userRole = await getUserRole()
+  const ctx = await getActionContext()
+  if (!ctx) throw new Error('Not authenticated')
+  const { tenantId, userRole } = ctx
 
   try {
     requireRole(userRole, 'admin')

--- a/src/actions/enrichment.ts
+++ b/src/actions/enrichment.ts
@@ -1,17 +1,10 @@
 'use server'
 
-import { headers } from 'next/headers'
 import { eq, and } from 'drizzle-orm'
 import { withTenant } from '@/db'
 import { candidates, candidateEnrichments } from '@/db/schema'
+import { getActionContext } from '@/lib/auth/action-context'
 import type { WebHit, GitHubProfile } from '@/db/schema/candidate-enrichments'
-
-async function getTenantAndUserId() {
-  const h = await headers()
-  const tenantId = h.get('x-tenant-id')
-  if (!tenantId) throw new Error('Not authenticated')
-  return tenantId
-}
 
 // ─── Brave Search ─────────────────────────────────────────────────────────────
 
@@ -117,7 +110,9 @@ export type EnrichmentResult =
   | { success: false; error: string }
 
 export async function enrichCandidate(candidateId: string): Promise<EnrichmentResult> {
-  const tenantId = await getTenantAndUserId()
+  const ctx = await getActionContext()
+  if (!ctx) throw new Error('Not authenticated')
+  const { tenantId } = ctx
 
   // Load candidate
   const [candidate] = await withTenant(tenantId, (tx) =>
@@ -203,7 +198,9 @@ export async function updateCandidateLinks(
   linkedinUrl: string | null,
   githubUsername: string | null
 ): Promise<{ success: boolean; error?: string }> {
-  const tenantId = await getTenantAndUserId()
+  const ctx = await getActionContext()
+  if (!ctx) throw new Error('Not authenticated')
+  const { tenantId } = ctx
 
   await withTenant(tenantId, (tx) =>
     tx

--- a/src/actions/frameworks.ts
+++ b/src/actions/frameworks.ts
@@ -1,6 +1,5 @@
 'use server'
 
-import { headers } from 'next/headers'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 import { z } from 'zod'
@@ -8,18 +7,8 @@ import { eq, and } from 'drizzle-orm'
 import { withTenant } from '@/db'
 import { customerFrameworks, roles } from '@/db/schema'
 import { requireRole } from '@/lib/auth/require-role'
-import type { UserRole } from '@/lib/auth/types'
+import { getActionContext } from '@/lib/auth/action-context'
 import type { FrameworkLevel } from '@/db/schema/customer-frameworks'
-
-async function getTenantId(): Promise<string | null> {
-  const headersList = await headers()
-  return headersList.get('x-tenant-id')
-}
-
-async function getUserRole(): Promise<UserRole | undefined> {
-  const headersList = await headers()
-  return (headersList.get('x-user-role') as UserRole | null) ?? undefined
-}
 
 const FrameworkLevelSchema = z.object({
   id: z.string().min(1).max(50),
@@ -46,10 +35,9 @@ export async function saveCustomerFramework(
   _prev: FrameworkState | null,
   formData: FormData
 ): Promise<FrameworkState> {
-  const tenantId = await getTenantId()
-  const userRole = await getUserRole()
-
-  if (!tenantId) return { success: false, error: 'Not authenticated' }
+  const ctx = await getActionContext()
+  if (!ctx) return { success: false, error: 'Not authenticated' }
+  const { tenantId, userRole } = ctx
 
   try {
     requireRole(userRole, 'recruiter')
@@ -105,10 +93,10 @@ export async function saveCustomerFramework(
 }
 
 export async function deleteCustomerFramework(customerId: string): Promise<void> {
-  const tenantId = await getTenantId()
-  const userRole = await getUserRole()
+  const ctx = await getActionContext()
+  if (!ctx) return
 
-  if (!tenantId) return
+  const { tenantId, userRole } = ctx
 
   try {
     requireRole(userRole, 'admin')

--- a/src/actions/interview.ts
+++ b/src/actions/interview.ts
@@ -1,7 +1,6 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
-import { headers } from 'next/headers'
 import { after } from 'next/server'
 import { eq, and } from 'drizzle-orm'
 import { z } from 'zod'
@@ -18,7 +17,7 @@ import { requireRole } from '@/lib/auth/require-role'
 import { extractCvProfile } from '@/lib/ai/interview'
 import { generateQuestions } from '@/lib/ai/interview'
 import { inferExperienceLevel, inferLanguage } from '@/lib/ai/interview-helpers'
-import type { UserRole } from '@/lib/auth/types'
+import { getActionContext } from '@/lib/auth/action-context'
 
 const CreatePackSchema = z.object({
   candidateId: z.string().uuid(),
@@ -34,12 +33,10 @@ export async function createInterviewPack(
   _prev: CreatePackState | null,
   formData: FormData
 ): Promise<CreatePackState> {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  const userId = headersList.get('x-user-id')
-  const userRole = headersList.get('x-user-role') as UserRole | null
+  const ctx = await getActionContext()
+  if (!ctx) return { success: false, error: 'Unauthorized' }
+  const { tenantId, userId, userRole } = ctx
 
-  if (!tenantId || !userId) return { success: false, error: 'Unauthorized' }
   try { requireRole(userRole ?? undefined, 'recruiter') } catch {
     return { success: false, error: 'Forbidden' }
   }
@@ -88,11 +85,10 @@ export async function createInterviewPack(
 }
 
 export async function retryInterviewPack(packId: string): Promise<{ success: boolean; error?: string }> {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  const userRole = headersList.get('x-user-role') as UserRole | null
+  const ctx = await getActionContext()
+  if (!ctx) return { success: false, error: 'Unauthorized' }
+  const { tenantId, userRole } = ctx
 
-  if (!tenantId) return { success: false, error: 'Unauthorized' }
   try { requireRole(userRole ?? undefined, 'recruiter') } catch {
     return { success: false, error: 'Forbidden' }
   }
@@ -121,11 +117,10 @@ export async function retryInterviewPack(packId: string): Promise<{ success: boo
 }
 
 export async function deleteInterviewPack(packId: string): Promise<{ success: boolean; error?: string }> {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  const userRole = headersList.get('x-user-role') as UserRole | null
+  const ctx = await getActionContext()
+  if (!ctx) return { success: false, error: 'Unauthorized' }
+  const { tenantId, userRole } = ctx
 
-  if (!tenantId) return { success: false, error: 'Unauthorized' }
   try { requireRole(userRole ?? undefined, 'recruiter') } catch {
     return { success: false, error: 'Forbidden' }
   }
@@ -148,9 +143,9 @@ export async function updateQuestionNotes(
   questionId: string,
   notes: string
 ): Promise<{ success: boolean; error?: string }> {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  if (!tenantId) return { success: false, error: 'Unauthorized' }
+  const ctx = await getActionContext()
+  if (!ctx) return { success: false, error: 'Unauthorized' }
+  const { tenantId } = ctx
 
   // Verify question belongs to tenant via pack
   const [question] = await db

--- a/src/actions/invitations.ts
+++ b/src/actions/invitations.ts
@@ -122,8 +122,8 @@ const AcceptInvitationSchema = z
     token: z.string().min(1, 'Invalid invitation token'),
     name: z.string().min(1, 'Name is required').max(100, 'Name must be 100 characters or fewer'),
     email: z.string().email('Valid email is required'),
-    password: z.string().min(8, 'Password must be at least 8 characters'),
-    confirmPassword: z.string().min(1, 'Please confirm your password'),
+    password: z.string().min(12, 'Password must be at least 12 characters'),
+    confirmPassword: z.string().min(12, 'Please confirm your password'),
   })
   .refine((d) => d.password === d.confirmPassword, {
     message: 'Passwords do not match',

--- a/src/actions/matching.ts
+++ b/src/actions/matching.ts
@@ -1,10 +1,10 @@
 'use server'
 
-import { headers } from 'next/headers'
 import { withTenant } from '@/db'
 import { scores } from '@/db/schema'
 import { eq, sql } from 'drizzle-orm'
 import { generateEmbedding } from '@/lib/ai/embeddings'
+import { getActionContext } from '@/lib/auth/action-context'
 
 export async function getSuggestedCandidates(
   roleId: string,
@@ -17,9 +17,9 @@ export async function getSuggestedCandidates(
   email: string | null
   similarity: number
 }>> {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  if (!tenantId) return []
+  const ctx = await getActionContext()
+  if (!ctx) return []
+  const { tenantId } = ctx
 
   try {
     // Generate embedding for the role text

--- a/src/actions/matching.ts
+++ b/src/actions/matching.ts
@@ -1,10 +1,11 @@
 'use server'
 
 import { withTenant } from '@/db'
-import { scores } from '@/db/schema'
-import { eq, sql } from 'drizzle-orm'
+import { candidates, roles, scores } from '@/db/schema'
+import { and, eq, notInArray, sql } from 'drizzle-orm'
 import { generateEmbedding } from '@/lib/ai/embeddings'
 import { getActionContext } from '@/lib/auth/action-context'
+import { analyseRoleFitForCandidate, type RoleFitResult } from '@/lib/ai/role-fit'
 
 export async function getSuggestedCandidates(
   roleId: string,
@@ -66,6 +67,108 @@ export async function getSuggestedCandidates(
     }))
   } catch (err) {
     console.error('[matching] getSuggestedCandidates failed:', err)
+    return []
+  }
+}
+
+export type RoleFitSuggestion = {
+  role: { id: string; title: string; requirements: string }
+  fit: RoleFitResult
+}
+
+/**
+ * Analyse which active roles (not yet scored) are a good fit for a given candidate.
+ *
+ * Uses Claude structured output to generate per-role fit scores, pros, cons, and
+ * a one-sentence headline for each role. Returns results sorted by fitScore descending.
+ *
+ * @param candidateId - UUID of the candidate to analyse
+ * @returns Up to 8 role fit suggestions, or an empty array if the candidate has no CV text
+ */
+export async function getRoleFitSuggestionsForCandidate(
+  candidateId: string
+): Promise<RoleFitSuggestion[]> {
+  const ctx = await getActionContext()
+  if (!ctx) return []
+  const { tenantId } = ctx
+
+  try {
+    // Fetch the candidate — we need cvText and the full name for the prompt
+    const [candidate] = await withTenant(tenantId, async (tx) =>
+      tx
+        .select({
+          id: candidates.id,
+          firstName: candidates.firstName,
+          lastName: candidates.lastName,
+          cvText: candidates.cvText,
+          embedding: candidates.embedding,
+        })
+        .from(candidates)
+        .where(and(eq(candidates.id, candidateId), eq(candidates.tenantId, tenantId)))
+        .limit(1)
+    )
+
+    if (!candidate || !candidate.cvText) return []
+
+    // Find roles this candidate has already been scored against so we can exclude them
+    const alreadyScoredRows = await withTenant(tenantId, async (tx) =>
+      tx
+        .select({ roleId: scores.roleId })
+        .from(scores)
+        .where(eq(scores.candidateId, candidateId))
+    )
+    const alreadyScoredRoleIds = alreadyScoredRows.map((s) => s.roleId)
+
+    // Fetch active roles the candidate has NOT yet been scored against (max 10 for Claude)
+    const activeRoles = await withTenant(tenantId, async (tx) => {
+      const baseQuery = tx
+        .select({
+          id: roles.id,
+          title: roles.title,
+          requirements: roles.requirements,
+        })
+        .from(roles)
+        .where(
+          alreadyScoredRoleIds.length > 0
+            ? and(eq(roles.isActive, true), notInArray(roles.id, alreadyScoredRoleIds))
+            : eq(roles.isActive, true)
+        )
+        .limit(10)
+
+      return baseQuery
+    })
+
+    if (activeRoles.length === 0) return []
+
+    const roleInputs = activeRoles.map((r) => ({
+      roleId: r.id,
+      roleTitle: r.title,
+      roleRequirements: r.requirements,
+    }))
+
+    const candidateName = `${candidate.firstName} ${candidate.lastName}`
+    const fitResults = await analyseRoleFitForCandidate(
+      candidateName,
+      candidate.cvText,
+      roleInputs,
+      tenantId
+    )
+
+    // Join results back to role metadata and sort by fitScore descending
+    const roleMap = new Map(activeRoles.map((r) => [r.id, r]))
+
+    const suggestions: RoleFitSuggestion[] = fitResults
+      .flatMap((fit) => {
+        const role = roleMap.get(fit.roleId)
+        if (!role) return []
+        return [{ role: { id: role.id, title: role.title, requirements: role.requirements }, fit }]
+      })
+      .sort((a, b) => b.fit.fitScore - a.fit.fitScore)
+      .slice(0, 8)
+
+    return suggestions
+  } catch (err) {
+    console.error('[matching] getRoleFitSuggestionsForCandidate failed:', err)
     return []
   }
 }

--- a/src/actions/notes.ts
+++ b/src/actions/notes.ts
@@ -1,12 +1,11 @@
 'use server'
 
-import { headers } from 'next/headers'
 import { revalidatePath } from 'next/cache'
 import { eq, and } from 'drizzle-orm'
 import { z } from 'zod'
-import { db, withTenant } from '@/db'
+import { withTenant } from '@/db'
 import { notes } from '@/db/schema'
-import type { UserRole } from '@/lib/auth/types'
+import { getActionContext } from '@/lib/auth/action-context'
 
 const BodySchema = z.string().min(1, 'Note cannot be empty').max(5000, 'Note too long (max 5000 chars)')
 
@@ -19,14 +18,10 @@ export async function createNote(
   candidateId: string,
   body: string
 ): Promise<NoteActionResult> {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  const userId = headersList.get('x-user-id')
-  const userRole = headersList.get('x-user-role') as UserRole | null
+  const ctx = await getActionContext()
+  if (!ctx) return { success: false, error: 'Unauthorized' }
+  const { tenantId, userId, userRole } = ctx
 
-  if (!tenantId || !userId) {
-    return { success: false, error: 'Unauthorized' }
-  }
   if (userRole === 'viewer') {
     return { success: false, error: 'Forbidden: recruiters and admins only' }
   }
@@ -57,14 +52,10 @@ export async function updateNote(
   candidateId: string,
   body: string
 ): Promise<NoteActionResult> {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  const userId = headersList.get('x-user-id')
-  const userRole = headersList.get('x-user-role') as UserRole | null
+  const ctx = await getActionContext()
+  if (!ctx) return { success: false, error: 'Unauthorized' }
+  const { tenantId, userId, userRole } = ctx
 
-  if (!tenantId || !userId) {
-    return { success: false, error: 'Unauthorized' }
-  }
   if (userRole === 'viewer') {
     return { success: false, error: 'Forbidden: recruiters and admins only' }
   }
@@ -112,14 +103,9 @@ export async function deleteNote(
   noteId: string,
   candidateId: string
 ): Promise<NoteActionResult> {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  const userId = headersList.get('x-user-id')
-  const userRole = headersList.get('x-user-role') as UserRole | null
-
-  if (!tenantId || !userId) {
-    return { success: false, error: 'Unauthorized' }
-  }
+  const ctx = await getActionContext()
+  if (!ctx) return { success: false, error: 'Unauthorized' }
+  const { tenantId, userId, userRole } = ctx
 
   // Verify note belongs to this tenant
   const [existing] = await withTenant(tenantId, async (tx) =>

--- a/src/actions/roles.ts
+++ b/src/actions/roles.ts
@@ -2,7 +2,6 @@
 
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
-import { headers } from 'next/headers'
 import { after } from 'next/server'
 import { eq, and } from 'drizzle-orm'
 import { z } from 'zod'
@@ -11,7 +10,7 @@ import { roles } from '@/db/schema'
 import { requireRole } from '@/lib/auth/require-role'
 import { writeAuditLog } from '@/lib/audit'
 import { extractRoleTags } from '@/lib/ai/role-tags'
-import type { UserRole } from '@/lib/auth/types'
+import { getActionContext } from '@/lib/auth/action-context'
 
 const CreateRoleSchema = z.object({
   title: z.string().min(1, 'Title is required').max(200),
@@ -30,12 +29,9 @@ export async function createRole(
   _prev: CreateRoleState | null,
   formData: FormData
 ): Promise<CreateRoleState> {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  const userId = headersList.get('x-user-id')
-  const userRole = headersList.get('x-user-role') as UserRole | null
-
-  if (!tenantId || !userId) return { success: false, error: 'Unauthorized' }
+  const ctx = await getActionContext()
+  if (!ctx) return { success: false, error: 'Unauthorized' }
+  const { tenantId, userId, userRole } = ctx
 
   try {
     requireRole(userRole ?? undefined, 'recruiter')
@@ -117,11 +113,9 @@ export async function updateRole(
   _prev: UpdateRoleState | null,
   formData: FormData
 ): Promise<UpdateRoleState> {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  const userRole = headersList.get('x-user-role') as UserRole | null
-
-  if (!tenantId) return { success: false, error: 'Unauthorized' }
+  const ctx = await getActionContext()
+  if (!ctx) return { success: false, error: 'Unauthorized' }
+  const { tenantId, userRole } = ctx
 
   try {
     requireRole(userRole ?? undefined, 'recruiter')
@@ -176,11 +170,10 @@ export async function updateRole(
 export async function regenerateRoleTags(
   roleId: string
 ): Promise<{ success: boolean; error?: string }> {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  const userRole = headersList.get('x-user-role') as UserRole | null
+  const ctx = await getActionContext()
+  if (!ctx) return { success: false, error: 'Unauthorized' }
+  const { tenantId, userRole } = ctx
 
-  if (!tenantId) return { success: false, error: 'Unauthorized' }
   try { requireRole(userRole ?? undefined, 'recruiter') } catch {
     return { success: false, error: 'Forbidden' }
   }
@@ -203,11 +196,9 @@ export async function regenerateRoleTags(
 // ---------------------------------------------------------------------------
 
 export async function archiveRole(roleId: string): Promise<void> {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  const userRole = headersList.get('x-user-role') as UserRole | null
-
-  if (!tenantId) throw new Error('Unauthorized')
+  const ctx = await getActionContext()
+  if (!ctx) throw new Error('Unauthorized')
+  const { tenantId, userRole } = ctx
 
   requireRole(userRole ?? undefined, 'recruiter')
 

--- a/src/actions/scores.ts
+++ b/src/actions/scores.ts
@@ -1,6 +1,5 @@
 'use server'
 
-import { headers } from 'next/headers'
 import { eq, and } from 'drizzle-orm'
 import { withTenant } from '@/db'
 import { scores } from '@/db/schema'
@@ -8,19 +7,15 @@ import { triggerScoring } from '@/lib/ai/scoring'
 import { requireRole } from '@/lib/auth/require-role'
 import { writeAuditLog } from '@/lib/audit'
 import { revalidatePath } from 'next/cache'
-import type { UserRole } from '@/lib/auth/types'
+import { getActionContext } from '@/lib/auth/action-context'
 
 export async function rescoreCandidate(
   candidateId: string,
   roleId: string
 ): Promise<{ success: boolean; error?: string }> {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  const userRole = headersList.get('x-user-role') as UserRole | null
-
-  if (!tenantId) {
-    return { success: false, error: 'Unauthorized' }
-  }
+  const ctx = await getActionContext()
+  if (!ctx) return { success: false, error: 'Unauthorized' }
+  const { tenantId, userRole } = ctx
 
   try {
     requireRole(userRole ?? undefined, 'recruiter')
@@ -81,11 +76,10 @@ export async function removeCandidateFromRole(
   scoreId: string,
   roleId: string
 ): Promise<void> {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  const userRole = headersList.get('x-user-role') as UserRole | null
+  const ctx = await getActionContext()
+  if (!ctx) throw new Error('Unauthorized')
+  const { tenantId, userRole } = ctx
 
-  if (!tenantId) throw new Error('Unauthorized')
   requireRole(userRole ?? undefined, 'recruiter')
 
   await withTenant(tenantId, async (tx) => {

--- a/src/actions/settings.ts
+++ b/src/actions/settings.ts
@@ -1,14 +1,13 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
-import { headers } from 'next/headers'
 import { eq, and, notInArray } from 'drizzle-orm'
 import { z } from 'zod'
 import { withTenant } from '@/db'
 import { tenantSettings } from '@/db/schema'
 import { requireRole } from '@/lib/auth/require-role'
 import { encrypt } from '@/lib/crypto'
-import type { UserRole } from '@/lib/auth/types'
+import { getActionContext } from '@/lib/auth/action-context'
 
 const ALLOWED_KEYS = [
   'anthropic_api_key',
@@ -35,12 +34,10 @@ export async function saveApiKey(
   _prev: SettingsState | null,
   formData: FormData
 ): Promise<SettingsState> {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  const userId = headersList.get('x-user-id')
-  const userRole = headersList.get('x-user-role') as UserRole | null
+  const ctx = await getActionContext()
+  if (!ctx) return { success: false, error: 'Unauthorized' }
+  const { tenantId, userId, userRole } = ctx
 
-  if (!tenantId || !userId) return { success: false, error: 'Unauthorized' }
   try { requireRole(userRole ?? undefined, 'admin') } catch {
     return { success: false, error: 'Only admins can manage API keys' }
   }
@@ -72,11 +69,10 @@ export async function removeApiKey(
   _prev: SettingsState | null,
   formData: FormData
 ): Promise<SettingsState> {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  const userRole = headersList.get('x-user-role') as UserRole | null
+  const ctx = await getActionContext()
+  if (!ctx) return { success: false, error: 'Unauthorized' }
+  const { tenantId, userRole } = ctx
 
-  if (!tenantId) return { success: false, error: 'Unauthorized' }
   try { requireRole(userRole ?? undefined, 'admin') } catch {
     return { success: false, error: 'Only admins can manage API keys' }
   }
@@ -127,12 +123,10 @@ export async function saveGeneralSetting(
   _prev: GeneralSettingsState | null,
   formData: FormData
 ): Promise<GeneralSettingsState> {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  const userId = headersList.get('x-user-id')
-  const userRole = headersList.get('x-user-role') as UserRole | null
+  const ctx = await getActionContext()
+  if (!ctx) return { success: false, error: 'Unauthorized' }
+  const { tenantId, userId, userRole } = ctx
 
-  if (!tenantId || !userId) return { success: false, error: 'Unauthorized' }
   try { requireRole(userRole ?? undefined, 'admin') } catch {
     return { success: false, error: 'Only admins can manage settings' }
   }

--- a/src/actions/shortlist-summary.ts
+++ b/src/actions/shortlist-summary.ts
@@ -1,17 +1,17 @@
 'use server'
 
-import { headers } from 'next/headers'
 import { withTenant } from '@/db'
 import { scores, candidates, roles } from '@/db/schema'
 import { eq, desc } from 'drizzle-orm'
 import { generateShortlistSummary } from '@/lib/ai/shortlist-summary'
+import { getActionContext } from '@/lib/auth/action-context'
 
 export async function getShortlistSummary(
   roleId: string
 ): Promise<{ summary: string } | { error: string }> {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  if (!tenantId) return { error: 'Unauthorized' }
+  const ctx = await getActionContext()
+  if (!ctx) return { error: 'Unauthorized' }
+  const { tenantId } = ctx
 
   try {
     const [role] = await withTenant(tenantId, async (tx) =>

--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -1,7 +1,6 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
-import { headers } from 'next/headers'
 import { eq, and } from 'drizzle-orm'
 import { z } from 'zod'
 import bcrypt from 'bcryptjs'
@@ -9,6 +8,7 @@ import { withTenant } from '@/db'
 import { users } from '@/db/schema'
 import { auth } from '@/lib/auth'
 import { requireRole } from '@/lib/auth/require-role'
+import { getActionContext } from '@/lib/auth/action-context'
 import type { UserRole } from '@/lib/auth/types'
 import type { User } from '@/db/schema/users'
 
@@ -152,11 +152,10 @@ export async function changePassword(
 // ---------------------------------------------------------------------------
 
 export async function listTenantUsers(): Promise<User[]> {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  const userRole = headersList.get('x-user-role') as UserRole | null
+  const ctx = await getActionContext()
+  if (!ctx) return []
+  const { tenantId, userRole } = ctx
 
-  if (!tenantId) return []
   try { requireRole(userRole ?? undefined, 'admin') } catch {
     return []
   }

--- a/src/app/(dashboard)/dashboard/candidates/[candidateId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/candidates/[candidateId]/page.tsx
@@ -43,20 +43,68 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
   )
   if (!candidate) notFound()
 
+  // agency depends on candidate.agencyId — must remain sequential after the candidate fetch
   const [agency] = candidate.agencyId
     ? await withTenant(tenantId, async (tx) =>
         tx.select().from(agencies).where(eq(agencies.id, candidate.agencyId!)).limit(1)
       )
     : [null]
 
-  const candidateScores = await withTenant(tenantId, async (tx) =>
-    tx
-      .select({ score: scores, role: roles })
-      .from(scores)
-      .innerJoin(roles, eq(scores.roleId, roles.id))
-      .where(eq(scores.candidateId, candidateId))
-      .orderBy(desc(scores.updatedAt))
-  )
+  // All remaining queries are independent of each other and of the agency result.
+  // They only need candidateId, tenantId, or userId — all available before any DB call.
+  const userId = session.user.id
+  const [
+    candidateScores,
+    candidateNotes,
+    allRoles,
+    allAgencies,
+    rawSlots,
+    calendarConns,
+    [enrichmentRow],
+  ] = await Promise.all([
+    withTenant(tenantId, async (tx) =>
+      tx
+        .select({ score: scores, role: roles })
+        .from(scores)
+        .innerJoin(roles, eq(scores.roleId, roles.id))
+        .where(eq(scores.candidateId, candidateId))
+        .orderBy(desc(scores.updatedAt))
+    ),
+    withTenant(tenantId, async (tx) =>
+      tx
+        .select()
+        .from(notes)
+        .where(eq(notes.candidateId, candidateId))
+        .orderBy(desc(notes.createdAt))
+    ),
+    withTenant(tenantId, async (tx) =>
+      tx.select({ id: roles.id, title: roles.title }).from(roles).where(eq(roles.isActive, true))
+    ),
+    withTenant(tenantId, async (tx) =>
+      tx.select({ id: agencies.id, name: agencies.name }).from(agencies).where(eq(agencies.isActive, true))
+    ),
+    // Load interview slots for this candidate
+    withTenant(tenantId, async (tx) =>
+      tx
+        .select()
+        .from(interviewSlots)
+        .where(eq(interviewSlots.candidateId, candidateId))
+        .orderBy(desc(interviewSlots.scheduledAt))
+    ),
+    // Check which calendar providers are connected for the current user
+    db
+      .select({ provider: calendarConnections.provider })
+      .from(calendarConnections)
+      .where(eq(calendarConnections.userId, userId)),
+    // Load existing enrichment data
+    withTenant(tenantId, async (tx) =>
+      tx
+        .select()
+        .from(candidateEnrichments)
+        .where(eq(candidateEnrichments.candidateId, candidateId))
+        .limit(1)
+    ),
+  ])
 
   const activeScore = roleId
     ? candidateScores.find((s) => s.score.roleId === roleId)
@@ -75,31 +123,6 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
     scoredAt: s.score.updatedAt,
   }))
 
-  const candidateNotes = await withTenant(tenantId, async (tx) =>
-    tx
-      .select()
-      .from(notes)
-      .where(eq(notes.candidateId, candidateId))
-      .orderBy(desc(notes.createdAt))
-  )
-
-  const allRoles = await withTenant(tenantId, async (tx) =>
-    tx.select({ id: roles.id, title: roles.title }).from(roles).where(eq(roles.isActive, true))
-  )
-
-  const allAgencies = await withTenant(tenantId, async (tx) =>
-    tx.select({ id: agencies.id, name: agencies.name }).from(agencies).where(eq(agencies.isActive, true))
-  )
-
-  // Load interview slots for this candidate
-  const rawSlots = await withTenant(tenantId, async (tx) =>
-    tx
-      .select()
-      .from(interviewSlots)
-      .where(eq(interviewSlots.candidateId, candidateId))
-      .orderBy(desc(interviewSlots.scheduledAt))
-  )
-
   const initialSlots = rawSlots.map((s) => ({
     id: s.id,
     title: s.title,
@@ -110,24 +133,9 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
     meetingUrl: s.meetingUrl ?? null,
   }))
 
-  // Check which calendar providers are connected for the current user
-  const userId = session.user.id
-  const calendarConns = await db
-    .select({ provider: calendarConnections.provider })
-    .from(calendarConnections)
-    .where(eq(calendarConnections.userId, userId))
   const connectedProviders = new Set(calendarConns.map((c) => c.provider))
   const hasGoogleCalendar = connectedProviders.has('google')
   const hasMicrosoftCalendar = connectedProviders.has('microsoft')
-
-  // Load existing enrichment data
-  const [enrichmentRow] = await withTenant(tenantId, async (tx) =>
-    tx
-      .select()
-      .from(candidateEnrichments)
-      .where(eq(candidateEnrichments.candidateId, candidateId))
-      .limit(1)
-  )
 
   const initialEnrichment = enrichmentRow
     ? {

--- a/src/app/(dashboard)/dashboard/candidates/[candidateId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/candidates/[candidateId]/page.tsx
@@ -17,6 +17,7 @@ import { StatusSelector } from '@/components/candidates/status-selector'
 import { CvDisplay } from '@/components/candidates/cv-display'
 import { EditDetailsForm } from '@/components/candidates/edit-details-form'
 import { InterviewCalendar } from '@/components/candidates/interview-calendar'
+import { IcsImportButton } from '@/components/candidates/ics-import-button'
 import { RoleHistoryPanel } from '@/components/candidates/role-history-panel'
 import { MatchingRolesPanel } from '@/components/candidates/matching-roles-panel'
 import { archiveCandidate } from '@/actions/candidates'
@@ -309,6 +310,11 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
       {/* Interview Schedule */}
       <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-6 mb-6">
         <h2 className="font-semibold text-zinc-100 mb-4">Interview Schedule</h2>
+        {canEdit && (
+          <div className="mb-4">
+            <IcsImportButton candidateId={candidateId} roleId={roleId ?? null} />
+          </div>
+        )}
         <InterviewCalendar
           candidateId={candidateId}
           candidateName={`${candidate.firstName} ${candidate.lastName}`}

--- a/src/app/(dashboard)/dashboard/candidates/[candidateId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/candidates/[candidateId]/page.tsx
@@ -18,6 +18,7 @@ import { CvDisplay } from '@/components/candidates/cv-display'
 import { EditDetailsForm } from '@/components/candidates/edit-details-form'
 import { InterviewCalendar } from '@/components/candidates/interview-calendar'
 import { RoleHistoryPanel } from '@/components/candidates/role-history-panel'
+import { MatchingRolesPanel } from '@/components/candidates/matching-roles-panel'
 import { archiveCandidate } from '@/actions/candidates'
 import { hasRole } from '@/lib/auth/require-role'
 import type { WebHit, GitHubProfile } from '@/db/schema/candidate-enrichments'
@@ -260,6 +261,9 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
           )}
         </div>
       ) : null}
+
+      {/* Matching roles — AI-powered suggestions for active roles not yet scored */}
+      <MatchingRolesPanel candidateId={candidateId} />
 
       {/* Role history */}
       <RoleHistoryPanel roleHistory={roleHistory} />

--- a/src/app/(dashboard)/dashboard/roles/[roleId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/roles/[roleId]/page.tsx
@@ -12,6 +12,7 @@ import { hasRole } from '@/lib/auth/require-role'
 import { RoleTagsPanel } from '@/components/roles/role-tags-panel'
 import { RoleCandidateCard } from '@/components/roles/role-candidate-card'
 import { SuggestCandidatesPanel } from '@/components/roles/suggest-candidates-panel'
+import { AddCandidatePanel } from '@/components/roles/add-candidate-panel'
 import { ShortlistSummaryPanel } from '@/components/roles/shortlist-summary-panel'
 
 type Props = { params: Promise<{ roleId: string }> }
@@ -170,6 +171,9 @@ export default async function RoleDetailPage({ params }: Props) {
         roleId={roleId}
         roleText={[role.title, role.description, role.requirements].filter(Boolean).join('\n')}
       />
+
+      {/* Manually add an existing candidate from the archive */}
+      <AddCandidatePanel roleId={roleId} canEdit={canEdit} />
 
       {/* Candidates shortlist */}
       <div>

--- a/src/app/api/candidates/[candidateId]/interview-packs/route.ts
+++ b/src/app/api/candidates/[candidateId]/interview-packs/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
-import { headers } from 'next/headers'
 import { eq, desc, count } from 'drizzle-orm'
+import { auth } from '@/lib/auth'
 import { withTenant } from '@/db'
 import { interviewPacks, interviewQuestions, roles } from '@/db/schema'
 
@@ -8,9 +8,11 @@ export async function GET(
   _req: Request,
   { params }: { params: Promise<{ candidateId: string }> }
 ) {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  if (!tenantId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const session = await auth()
+  if (!session?.user?.tenantId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const tenantId = session.user.tenantId
 
   const { candidateId } = await params
 

--- a/src/app/api/candidates/[candidateId]/score-status/route.ts
+++ b/src/app/api/candidates/[candidateId]/score-status/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
-import { headers } from 'next/headers'
 import { eq, and } from 'drizzle-orm'
+import { auth } from '@/lib/auth'
 import { withTenant } from '@/db'
 import { scores } from '@/db/schema'
 
@@ -8,9 +8,11 @@ export async function GET(
   request: Request,
   { params }: { params: Promise<{ candidateId: string }> }
 ) {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  if (!tenantId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const session = await auth()
+  if (!session?.user?.tenantId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const tenantId = session.user.tenantId
 
   const { candidateId } = await params
   const { searchParams } = new URL(request.url)

--- a/src/app/api/candidates/bulk-upload/route.ts
+++ b/src/app/api/candidates/bulk-upload/route.ts
@@ -3,10 +3,12 @@ import { writeFile, mkdir } from 'fs/promises'
 import { join, extname } from 'path'
 import { randomUUID } from 'crypto'
 import { eq } from 'drizzle-orm'
-import { db, withTenant } from '@/db'
+import { withTenant } from '@/db'
 import { candidates, scores } from '@/db/schema'
 import { parseFile, ParseError } from '@/lib/parsers'
 import { triggerScoring } from '@/lib/ai/scoring'
+import { auth } from '@/lib/auth'
+import { fileTypeFromBuffer } from 'file-type'
 import type { FileType } from '@/lib/parsers'
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10 MB
@@ -31,12 +33,12 @@ const EXT_TO_TYPE: Record<string, FileType> = {
 }
 
 export async function POST(request: NextRequest) {
-  const tenantId = request.headers.get('x-tenant-id')
-  const userId = request.headers.get('x-user-id')
-
-  if (!tenantId || !userId) {
+  const session = await auth()
+  if (!session?.user?.tenantId) {
     return Response.json({ success: false, error: 'Unauthorized' }, { status: 401 })
   }
+  const tenantId = session.user.tenantId
+  const userId = session.user.id
 
   try {
     const formData = await request.formData()
@@ -78,6 +80,23 @@ export async function POST(request: NextRequest) {
 
     // Parse CV text from file buffer
     const buffer = Buffer.from(await file.arrayBuffer())
+
+    // Magic-byte file type validation — reject clearly wrong types (executables, images, etc.)
+    const detectedType = await fileTypeFromBuffer(buffer)
+    const allowedMimes = [
+      'application/pdf',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      'text/plain',
+      'application/rtf',
+      'application/vnd.oasis.opendocument.text',
+    ]
+    if (detectedType && !allowedMimes.includes(detectedType.mime)) {
+      return Response.json(
+        { success: false, error: `Invalid file type detected: ${detectedType.mime}` },
+        { status: 400 }
+      )
+    }
+
     let cvText: string
     try {
       cvText = await parseFile(buffer, fileType)

--- a/src/app/api/candidates/route.ts
+++ b/src/app/api/candidates/route.ts
@@ -1,13 +1,15 @@
 import { NextResponse } from 'next/server'
-import { headers } from 'next/headers'
 import { desc, eq, and, gte, count } from 'drizzle-orm'
+import { auth } from '@/lib/auth'
 import { withTenant } from '@/db'
 import { candidates, scores, agencies } from '@/db/schema'
 
 export async function GET(request: Request) {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  if (!tenantId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const session = await auth()
+  if (!session?.user?.tenantId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const tenantId = session.user.tenantId
 
   const { searchParams } = new URL(request.url)
   const roleId = searchParams.get('roleId')

--- a/src/app/api/candidates/semantic-search/route.ts
+++ b/src/app/api/candidates/semantic-search/route.ts
@@ -1,11 +1,13 @@
 import { sql } from 'drizzle-orm'
 import { withTenant } from '@/db'
+import { auth } from '@/lib/auth'
 
 export async function POST(request: Request) {
-  const tenantId = request.headers.get('x-tenant-id')
-  if (!tenantId) {
+  const session = await auth()
+  if (!session?.user?.tenantId) {
     return Response.json({ error: 'Unauthorized' }, { status: 401 })
   }
+  const tenantId = session.user.tenantId
 
   let query: string
   let limit: number

--- a/src/app/api/export/candidate/[candidateId]/route.ts
+++ b/src/app/api/export/candidate/[candidateId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
-import { headers } from 'next/headers'
 import { eq, and } from 'drizzle-orm'
+import { auth } from '@/lib/auth'
 import React from 'react'
 import { renderToBuffer } from '@react-pdf/renderer'
 import { withTenant } from '@/db'
@@ -11,9 +11,11 @@ export async function GET(
   req: Request,
   { params }: { params: Promise<{ candidateId: string }> }
 ) {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  if (!tenantId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const session = await auth()
+  if (!session?.user?.tenantId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const tenantId = session.user.tenantId
 
   const { candidateId } = await params
   const { searchParams } = new URL(req.url)

--- a/src/app/api/export/interview-pack/[packId]/route.ts
+++ b/src/app/api/export/interview-pack/[packId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
-import { headers } from 'next/headers'
 import { eq, asc, and } from 'drizzle-orm'
+import { auth } from '@/lib/auth'
 import React from 'react'
 import { renderToBuffer } from '@react-pdf/renderer'
 import { withTenant } from '@/db'
@@ -11,9 +11,11 @@ export async function GET(
   _req: Request,
   { params }: { params: Promise<{ packId: string }> }
 ) {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  if (!tenantId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const session = await auth()
+  if (!session?.user?.tenantId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const tenantId = session.user.tenantId
 
   const { packId } = await params
 

--- a/src/app/api/export/role/[roleId]/route.ts
+++ b/src/app/api/export/role/[roleId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
-import { headers } from 'next/headers'
 import { eq, and } from 'drizzle-orm'
+import { auth } from '@/lib/auth'
 import React from 'react'
 import { renderToBuffer } from '@react-pdf/renderer'
 import { withTenant } from '@/db'
@@ -11,9 +11,11 @@ export async function GET(
   _req: Request,
   { params }: { params: Promise<{ roleId: string }> }
 ) {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  if (!tenantId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const session = await auth()
+  if (!session?.user?.tenantId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const tenantId = session.user.tenantId
 
   const { roleId } = await params
 

--- a/src/app/api/export/shortlist/[roleId]/route.ts
+++ b/src/app/api/export/shortlist/[roleId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
-import { headers } from 'next/headers'
 import { eq, and, desc } from 'drizzle-orm'
+import { auth } from '@/lib/auth'
 import React from 'react'
 import { renderToBuffer } from '@react-pdf/renderer'
 import { withTenant } from '@/db'
@@ -11,9 +11,11 @@ export async function GET(
   _req: Request,
   { params }: { params: Promise<{ roleId: string }> }
 ) {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  if (!tenantId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const session = await auth()
+  if (!session?.user?.tenantId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const tenantId = session.user.tenantId
 
   const { roleId } = await params
 

--- a/src/app/api/extract/candidate/route.ts
+++ b/src/app/api/extract/candidate/route.ts
@@ -12,6 +12,8 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import Anthropic from '@anthropic-ai/sdk'
 import { parseFile } from '@/lib/parsers'
+import { auth } from '@/lib/auth'
+import { fileTypeFromBuffer } from 'file-type'
 import type { FileType } from '@/lib/parsers'
 
 const anthropic = new Anthropic({
@@ -52,6 +54,11 @@ const EXT_MAP: Record<string, FileType> = {
 }
 
 export async function POST(req: NextRequest) {
+  const session = await auth()
+  if (!session?.user?.tenantId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
   try {
     const formData = await req.formData()
     const file = formData.get('file')
@@ -71,6 +78,19 @@ export async function POST(req: NextRequest) {
     }
 
     const buffer = Buffer.from(await file.arrayBuffer())
+
+    // Magic-byte file type validation — reject clearly wrong types (executables, images, etc.)
+    const detectedType = await fileTypeFromBuffer(buffer)
+    const allowedMimes = [
+      'application/pdf',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      'text/plain',
+      'application/rtf',
+    ]
+    if (detectedType && !allowedMimes.includes(detectedType.mime)) {
+      return NextResponse.json({ error: `Invalid file type detected: ${detectedType.mime}` }, { status: 400 })
+    }
+
     const text = await parseFile(buffer, fileType)
 
     if (!text || text.length < 20) {

--- a/src/app/api/extract/role/route.ts
+++ b/src/app/api/extract/role/route.ts
@@ -12,6 +12,7 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import Anthropic from '@anthropic-ai/sdk'
 import { parseFile } from '@/lib/parsers'
+import { auth } from '@/lib/auth'
 import type { FileType } from '@/lib/parsers'
 
 const anthropic = new Anthropic({
@@ -56,6 +57,11 @@ const EXT_MAP: Record<string, FileType> = {
 }
 
 export async function POST(req: NextRequest) {
+  const session = await auth()
+  if (!session?.user?.tenantId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
   try {
     const formData = await req.formData()
     const file = formData.get('file')

--- a/src/app/api/interview-packs/[packId]/route.ts
+++ b/src/app/api/interview-packs/[packId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
-import { headers } from 'next/headers'
 import { eq, asc } from 'drizzle-orm'
+import { auth } from '@/lib/auth'
 import { withTenant } from '@/db'
 import { interviewPacks, interviewQuestions, codeChallenges } from '@/db/schema'
 
@@ -8,9 +8,11 @@ export async function GET(
   _req: Request,
   { params }: { params: Promise<{ packId: string }> }
 ) {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  if (!tenantId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const session = await auth()
+  if (!session?.user?.tenantId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const tenantId = session.user.tenantId
 
   const { packId } = await params
 

--- a/src/app/api/roles/route.ts
+++ b/src/app/api/roles/route.ts
@@ -1,16 +1,15 @@
 import { NextResponse } from 'next/server'
-import { headers } from 'next/headers'
 import { desc, eq } from 'drizzle-orm'
+import { auth } from '@/lib/auth'
 import { withTenant } from '@/db'
 import { roles, users } from '@/db/schema'
 
 export async function GET() {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-
-  if (!tenantId) {
+  const session = await auth()
+  if (!session?.user?.tenantId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
+  const tenantId = session.user.tenantId
 
   const result = await withTenant(tenantId, async (tx) => {
     return tx

--- a/src/app/api/settings/integrations/route.ts
+++ b/src/app/api/settings/integrations/route.ts
@@ -1,15 +1,17 @@
 import { NextResponse } from 'next/server'
-import { headers } from 'next/headers'
 import { eq } from 'drizzle-orm'
+import { auth } from '@/lib/auth'
 import { withTenant } from '@/db'
 import { tenantSettings } from '@/db/schema'
 
 const ALLOWED_KEYS = ['anthropic_api_key', 'google_ai_api_key'] as const
 
 export async function GET() {
-  const headersList = await headers()
-  const tenantId = headersList.get('x-tenant-id')
-  if (!tenantId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const session = await auth()
+  if (!session?.user?.tenantId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const tenantId = session.user.tenantId
 
   const rows = await withTenant(tenantId, async (tx) =>
     tx

--- a/src/components/candidates/ics-import-button.tsx
+++ b/src/components/candidates/ics-import-button.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { useRef, useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { CalendarIcon, Loader2Icon } from 'lucide-react'
+import { importIcsSlots } from '@/actions/calendar'
+
+type Props = {
+  candidateId: string
+  roleId?: string | null
+}
+
+/**
+ * "Import from file" button that accepts a .ics calendar file, reads it in
+ * the browser, and calls the importIcsSlots server action.
+ *
+ * On success the page is refreshed via router.refresh() so the calendar grid
+ * shows the newly created slots without a full navigation.
+ */
+export function IcsImportButton({ candidateId, roleId }: Props) {
+  const router = useRouter()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [isPending, startTransition] = useTransition()
+  const [feedback, setFeedback] = useState<{ ok: boolean; message: string } | null>(null)
+
+  // Clear any existing feedback after 3 seconds
+  const showFeedback = (ok: boolean, message: string) => {
+    setFeedback({ ok, message })
+    setTimeout(() => setFeedback(null), 3000)
+  }
+
+  const handleClick = () => {
+    // Reset the input so the same file can be re-selected after an error
+    if (fileInputRef.current) {
+      fileInputRef.current.value = ''
+    }
+    fileInputRef.current?.click()
+  }
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    const reader = new FileReader()
+
+    reader.onload = (event) => {
+      const content = event.target?.result
+      if (typeof content !== 'string') {
+        showFeedback(false, 'Could not read file')
+        return
+      }
+
+      startTransition(async () => {
+        const result = await importIcsSlots(candidateId, roleId ?? null, content)
+
+        if (result.success) {
+          showFeedback(true, `Imported ${result.imported} slot${result.imported === 1 ? '' : 's'}`)
+          router.refresh()
+        } else {
+          showFeedback(false, result.error)
+        }
+      })
+    }
+
+    reader.onerror = () => {
+      showFeedback(false, 'Failed to read file')
+    }
+
+    reader.readAsText(file)
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      {/* Hidden file input — triggered programmatically */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".ics,text/calendar"
+        className="hidden"
+        onChange={handleFileChange}
+      />
+
+      <button
+        onClick={handleClick}
+        disabled={isPending}
+        className="flex items-center gap-1.5 px-3 py-1 text-xs font-medium text-zinc-400
+                   border border-zinc-700 rounded-md hover:text-zinc-200 hover:border-zinc-600
+                   transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {isPending ? (
+          <Loader2Icon className="h-3.5 w-3.5 animate-spin" />
+        ) : (
+          <CalendarIcon className="h-3.5 w-3.5" />
+        )}
+        {isPending ? 'Importing…' : 'Import from file'}
+      </button>
+
+      {/* Inline feedback message — fades after 3 s via state reset */}
+      {feedback && (
+        <span
+          className={`text-xs font-medium ${
+            feedback.ok ? 'text-emerald-400' : 'text-red-400'
+          }`}
+        >
+          {feedback.ok ? `\u2713 ${feedback.message}` : feedback.message}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/src/components/candidates/matching-roles-panel.tsx
+++ b/src/components/candidates/matching-roles-panel.tsx
@@ -1,0 +1,221 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import Link from 'next/link'
+import {
+  BriefcaseIcon,
+  SparklesIcon,
+  Loader2Icon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+  ZapIcon,
+} from 'lucide-react'
+import { getRoleFitSuggestionsForCandidate, type RoleFitSuggestion } from '@/actions/matching'
+import { rescoreCandidate } from '@/actions/scores'
+
+type Props = {
+  candidateId: string
+}
+
+function FitScoreBadge({ score }: { score: number }) {
+  const colorClass =
+    score >= 75
+      ? 'bg-green-900 border-green-700 text-green-300'
+      : score >= 50
+        ? 'bg-blue-900 border-blue-700 text-blue-300'
+        : 'bg-zinc-800 border-zinc-600 text-zinc-400'
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-lg border px-2.5 py-0.5 text-xs font-bold ${colorClass}`}
+    >
+      {score}/100
+    </span>
+  )
+}
+
+function RoleFitCard({
+  suggestion,
+  candidateId,
+}: {
+  suggestion: RoleFitSuggestion
+  candidateId: string
+}) {
+  const [addedState, setAddedState] = useState<'idle' | 'pending' | 'done'>('idle')
+
+  async function handleAdd() {
+    setAddedState('pending')
+    try {
+      await rescoreCandidate(candidateId, suggestion.role.id)
+      setAddedState('done')
+    } catch {
+      setAddedState('idle')
+    }
+  }
+
+  return (
+    <div className="rounded-lg bg-zinc-800/60 border border-zinc-700 px-4 py-4">
+      {/* Card header: title + score + add button */}
+      <div className="flex flex-wrap items-center justify-between gap-3 mb-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <Link
+            href={`/dashboard/roles/${suggestion.role.id}`}
+            className="text-sm font-semibold text-zinc-100 hover:text-blue-300 transition-colors truncate"
+          >
+            {suggestion.role.title}
+          </Link>
+          <FitScoreBadge score={suggestion.fit.fitScore} />
+        </div>
+
+        <div className="flex-shrink-0">
+          {addedState === 'done' ? (
+            <span className="text-xs font-medium text-green-400">Added — scoring queued</span>
+          ) : (
+            <button
+              onClick={handleAdd}
+              disabled={addedState === 'pending'}
+              className="flex items-center gap-1.5 rounded-md bg-zinc-700 text-zinc-200 text-xs
+                         font-medium px-3 py-1.5 hover:bg-zinc-600 transition-colors
+                         disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {addedState === 'pending' ? (
+                <Loader2Icon className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <ZapIcon className="h-3.5 w-3.5" />
+              )}
+              Add to this role
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Headline */}
+      <p className="text-xs italic text-zinc-400 mb-3">{suggestion.fit.headline}</p>
+
+      {/* Pros */}
+      {suggestion.fit.pros.length > 0 && (
+        <ul className="mb-2 space-y-1">
+          {suggestion.fit.pros.map((pro, i) => (
+            <li key={i} className="flex items-start gap-1.5 text-xs text-zinc-300">
+              <span className="mt-px text-emerald-400 flex-shrink-0">&#10003;</span>
+              {pro}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* Cons */}
+      {suggestion.fit.cons.length > 0 && (
+        <ul className="space-y-1">
+          {suggestion.fit.cons.map((con, i) => (
+            <li key={i} className="flex items-start gap-1.5 text-xs text-zinc-400">
+              <span className="mt-px text-amber-400 flex-shrink-0">&#9888;</span>
+              {con}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+/**
+ * MatchingRolesPanel
+ *
+ * Displays a collapsible panel on the candidate profile page. When the recruiter
+ * clicks "Find matching roles", it calls the Claude-powered server action and
+ * renders a card per active role with fit score, pros, cons, and an option to
+ * queue the candidate for scoring against that role.
+ */
+export function MatchingRolesPanel({ candidateId }: Props) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [suggestions, setSuggestions] = useState<RoleFitSuggestion[] | null>(null)
+  const [isPending, startTransition] = useTransition()
+  const [hasSearched, setHasSearched] = useState(false)
+
+  function handleFind() {
+    startTransition(async () => {
+      const results = await getRoleFitSuggestionsForCandidate(candidateId)
+      setSuggestions(results)
+      setHasSearched(true)
+    })
+  }
+
+  return (
+    <div className="bg-zinc-900 border border-zinc-700 rounded-xl mb-6 overflow-hidden">
+      {/* Collapsible toggle */}
+      <button
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        className="w-full flex items-center justify-between px-4 py-4 text-left
+                   hover:bg-zinc-800/50 transition-colors"
+      >
+        <div className="flex items-center gap-2">
+          <BriefcaseIcon className="h-4 w-4 text-violet-400 flex-shrink-0" />
+          <span className="font-semibold text-zinc-100">Matching Roles</span>
+        </div>
+        {isOpen ? (
+          <ChevronUpIcon className="h-4 w-4 text-zinc-500" />
+        ) : (
+          <ChevronDownIcon className="h-4 w-4 text-zinc-500" />
+        )}
+      </button>
+
+      {isOpen && (
+        <div className="px-4 pb-5 border-t border-zinc-800">
+          {/* Analyse button */}
+          <div className="flex items-center justify-between py-4">
+            <p className="text-sm text-zinc-500">
+              {hasSearched
+                ? suggestions && suggestions.length > 0
+                  ? `${suggestions.length} role${suggestions.length !== 1 ? 's' : ''} analysed`
+                  : 'Analysis complete'
+                : 'Click to find roles that match this candidate.'}
+            </p>
+            <button
+              onClick={handleFind}
+              disabled={isPending}
+              className="flex items-center gap-2 rounded-md bg-violet-700 text-white text-sm
+                         font-medium px-4 py-2 hover:bg-violet-600 transition-colors
+                         disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isPending ? (
+                <Loader2Icon className="h-4 w-4 animate-spin" />
+              ) : (
+                <SparklesIcon className="h-4 w-4" />
+              )}
+              {isPending ? 'Analysing…' : 'Find matching roles'}
+            </button>
+          </div>
+
+          {/* Loading state */}
+          {isPending && (
+            <p className="text-sm text-zinc-500 mb-4">
+              Analysing candidate against active roles…
+            </p>
+          )}
+
+          {/* Empty state after search */}
+          {!isPending && hasSearched && suggestions !== null && suggestions.length === 0 && (
+            <p className="text-sm text-zinc-500">
+              No active roles found, or candidate profile needs more data.
+            </p>
+          )}
+
+          {/* Results */}
+          {!isPending && suggestions !== null && suggestions.length > 0 && (
+            <div className="space-y-3">
+              {suggestions.map((s) => (
+                <RoleFitCard
+                  key={s.role.id}
+                  suggestion={s}
+                  candidateId={candidateId}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/roles/add-candidate-panel.tsx
+++ b/src/components/roles/add-candidate-panel.tsx
@@ -1,0 +1,155 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import { UserPlusIcon, ZapIcon, Loader2Icon, ChevronDownIcon, ChevronUpIcon } from 'lucide-react'
+import { searchCandidatesForRole, type CandidateSearchResult } from '@/actions/candidates'
+import { rescoreCandidate } from '@/actions/scores'
+
+type Props = {
+  roleId: string
+  canEdit: boolean
+}
+
+type AddingState = 'idle' | 'pending' | 'done'
+
+export function AddCandidatePanel({ roleId, canEdit }: Props) {
+  const [expanded, setExpanded] = useState(false)
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<CandidateSearchResult[]>([])
+  const [searched, setSearched] = useState(false)
+  const [addingState, setAddingState] = useState<Record<string, AddingState>>({})
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Debounced search — fires 300ms after the user stops typing
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+
+    if (query.trim().length < 1) {
+      setResults([])
+      setSearched(false)
+      return
+    }
+
+    debounceRef.current = setTimeout(async () => {
+      const found = await searchCandidatesForRole(roleId, query)
+      setResults(found)
+      setSearched(true)
+    }, 300)
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+    }
+  }, [query, roleId])
+
+  async function handleAdd(candidateId: string) {
+    setAddingState((prev) => ({ ...prev, [candidateId]: 'pending' }))
+    try {
+      await rescoreCandidate(candidateId, roleId)
+      setAddingState((prev) => ({ ...prev, [candidateId]: 'done' }))
+      // Remove the candidate row from the list after a brief confirmation delay
+      setTimeout(() => {
+        setResults((prev) => prev.filter((c) => c.id !== candidateId))
+        setAddingState((prev) => {
+          const next = { ...prev }
+          delete next[candidateId]
+          return next
+        })
+      }, 1500)
+    } catch {
+      // On failure revert so the user can retry
+      setAddingState((prev) => ({ ...prev, [candidateId]: 'idle' }))
+    }
+  }
+
+  if (!canEdit) return null
+
+  return (
+    <div className="bg-zinc-900 rounded-xl border border-zinc-700 mb-6">
+      {/* Toggle header */}
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="w-full flex items-center justify-between px-6 py-4 text-left
+                   hover:bg-zinc-800 transition-colors rounded-xl"
+      >
+        <div className="flex items-center gap-2">
+          <UserPlusIcon className="h-4 w-4 text-blue-400" />
+          <span className="font-semibold text-zinc-100">Add from archive</span>
+        </div>
+        {expanded ? (
+          <ChevronUpIcon className="h-4 w-4 text-zinc-500" />
+        ) : (
+          <ChevronDownIcon className="h-4 w-4 text-zinc-500" />
+        )}
+      </button>
+
+      {expanded && (
+        <div className="px-6 pb-6">
+          {/* Search input */}
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search by name or email…"
+            className="w-full rounded-lg bg-zinc-800 border border-zinc-700 text-zinc-100
+                       placeholder:text-zinc-500 text-sm px-4 py-2.5 mb-3
+                       focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent"
+          />
+
+          {/* Results */}
+          {searched && results.length === 0 && (
+            <p className="text-zinc-500 text-sm">No candidates found.</p>
+          )}
+
+          {results.length > 0 && (
+            <div className="grid gap-2">
+              {results.map((c) => {
+                const state = addingState[c.id] ?? 'idle'
+                return (
+                  <div
+                    key={c.id}
+                    className="flex items-center justify-between rounded-lg bg-zinc-800
+                               border border-zinc-700 px-4 py-3 gap-3"
+                  >
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium text-zinc-100 truncate">
+                        {c.firstName} {c.lastName}
+                      </p>
+                      {c.email && (
+                        <p className="text-xs text-zinc-500 truncate">{c.email}</p>
+                      )}
+                    </div>
+
+                    <div className="flex-shrink-0">
+                      {state === 'done' ? (
+                        <span className="text-xs text-green-400 font-medium">
+                          Added — scoring queued
+                        </span>
+                      ) : (
+                        <button
+                          type="button"
+                          onClick={() => handleAdd(c.id)}
+                          disabled={state === 'pending'}
+                          className="flex items-center gap-1.5 rounded-md bg-blue-700 text-white
+                                     text-xs font-medium px-3 py-1.5 hover:bg-blue-600
+                                     transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                          {state === 'pending' ? (
+                            <Loader2Icon className="h-3.5 w-3.5 animate-spin" />
+                          ) : (
+                            <ZapIcon className="h-3.5 w-3.5" />
+                          )}
+                          Add &amp; Score
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/ai/claude.ts
+++ b/src/lib/ai/claude.ts
@@ -84,7 +84,7 @@ type ScoringInput = {
 export async function scoreCandidateWithClaude(input: ScoringInput): Promise<CandidateScore> {
   const response = await anthropic.messages.create({
     model: 'claude-sonnet-4-6',
-    max_tokens: 1024,
+    max_tokens: 2048,
     tools: [SCORING_TOOL],
     tool_choice: { type: 'any' },
     messages: [

--- a/src/lib/ai/role-fit.ts
+++ b/src/lib/ai/role-fit.ts
@@ -1,0 +1,146 @@
+import Anthropic from '@anthropic-ai/sdk'
+import { resolveAnthropicKey } from './keys'
+
+type RoleInput = {
+  roleId: string
+  roleTitle: string
+  roleRequirements: string
+}
+
+export type RoleFitResult = {
+  roleId: string
+  fitScore: number       // 0-100
+  pros: string[]         // 2-4 items
+  cons: string[]         // 1-3 items
+  headline: string       // one-sentence summary, e.g. "Strong technical fit, limited leadership experience"
+}
+
+// Shape returned by the tool_use block
+type ToolResultPayload = {
+  results: Array<{
+    roleId: string
+    fitScore: number
+    headline: string
+    pros: string[]
+    cons: string[]
+  }>
+}
+
+/**
+ * Analyse how well a candidate's CV fits a set of active roles.
+ *
+ * Sends a single Claude request using forced tool calling so the response is
+ * always a structured JSON array — no unstructured text parsing required.
+ *
+ * @param candidateName - Full name of the candidate (used in prompt for readability)
+ * @param cvText        - Raw CV text extracted from the uploaded file
+ * @param roles         - Active roles the candidate has NOT yet been scored against
+ * @param tenantId      - Used to resolve the correct Anthropic API key
+ * @returns             - Sorted array of RoleFitResult (Claude may omit roles it cannot analyse)
+ */
+export async function analyseRoleFitForCandidate(
+  candidateName: string,
+  cvText: string,
+  roles: RoleInput[],
+  tenantId: string
+): Promise<RoleFitResult[]> {
+  if (roles.length === 0) return []
+
+  const apiKey = await resolveAnthropicKey(tenantId)
+  const client = new Anthropic({ apiKey })
+
+  const rolesBlock = roles
+    .map(
+      (r, i) =>
+        `${i + 1}. ${r.roleTitle} (id: ${r.roleId})\nRequirements: ${r.roleRequirements.slice(0, 500)}`
+    )
+    .join('\n\n')
+
+  const userPrompt = `You are a senior recruiter. Analyse how well this candidate fits each of the following roles.
+
+CANDIDATE: ${candidateName}
+CV (excerpt):
+${cvText.slice(0, 6000)}
+
+ROLES TO ANALYSE:
+${rolesBlock}
+
+For each role, return:
+- fitScore: 0-100 overall fit
+- headline: one-sentence summary of the fit
+- pros: 2-4 specific strengths from the CV that match this role
+- cons: 1-3 gaps or weaknesses relative to this role's requirements
+
+Be specific and reference the CV content. Use the submit_role_fits tool.`
+
+  const message = await client.messages.create({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 2048,
+    tool_choice: { type: 'tool', name: 'submit_role_fits' },
+    tools: [
+      {
+        name: 'submit_role_fits',
+        description: 'Submit the role-fit analysis results for all evaluated roles.',
+        input_schema: {
+          type: 'object' as const,
+          properties: {
+            results: {
+              type: 'array' as const,
+              items: {
+                type: 'object' as const,
+                properties: {
+                  roleId: { type: 'string' as const },
+                  fitScore: { type: 'integer' as const, minimum: 0, maximum: 100 },
+                  headline: { type: 'string' as const },
+                  pros: { type: 'array' as const, items: { type: 'string' as const } },
+                  cons: { type: 'array' as const, items: { type: 'string' as const } },
+                },
+                required: ['roleId', 'fitScore', 'headline', 'pros', 'cons'],
+              },
+            },
+          },
+          required: ['results'],
+        },
+      },
+    ],
+    messages: [{ role: 'user', content: userPrompt }],
+  })
+
+  // Extract the tool_use block from the response
+  const toolUseBlock = message.content.find((block) => block.type === 'tool_use')
+  if (!toolUseBlock || toolUseBlock.type !== 'tool_use') {
+    console.error('[role-fit] Claude did not return a tool_use block')
+    return []
+  }
+
+  const payload = toolUseBlock.input as ToolResultPayload
+
+  if (!Array.isArray(payload.results)) {
+    console.error('[role-fit] Tool payload missing results array')
+    return []
+  }
+
+  // Validate and normalise each result; silently drop malformed entries
+  const results: RoleFitResult[] = payload.results.flatMap((r) => {
+    if (
+      typeof r.roleId !== 'string' ||
+      typeof r.fitScore !== 'number' ||
+      typeof r.headline !== 'string' ||
+      !Array.isArray(r.pros) ||
+      !Array.isArray(r.cons)
+    ) {
+      return []
+    }
+    return [
+      {
+        roleId: r.roleId,
+        fitScore: Math.min(100, Math.max(0, Math.round(r.fitScore))),
+        headline: r.headline,
+        pros: r.pros.filter((p): p is string => typeof p === 'string'),
+        cons: r.cons.filter((c): c is string => typeof c === 'string'),
+      },
+    ]
+  })
+
+  return results
+}

--- a/src/lib/ai/schema.ts
+++ b/src/lib/ai/schema.ts
@@ -20,7 +20,7 @@ export const CandidateScoreSchema = z.object({
     cultural_fit: DimensionSchema,
     communication: DimensionSchema,
   }),
-  summary: z.string().min(10),
+  summary: z.string().min(1).optional().default(''),
 })
 
 export type CandidateScore = z.infer<typeof CandidateScoreSchema>

--- a/src/lib/auth/action-context.ts
+++ b/src/lib/auth/action-context.ts
@@ -1,0 +1,22 @@
+import { headers } from 'next/headers'
+import type { UserRole } from '@/lib/auth/types'
+
+export type ActionContext = {
+  tenantId: string
+  userId: string
+  userRole: UserRole
+}
+
+/**
+ * Extracts tenant/user context from middleware-injected headers.
+ * Returns null if the request is unauthenticated (no tenant ID).
+ * Safe to use in server actions — headers are set by Next.js middleware from JWT.
+ */
+export async function getActionContext(): Promise<ActionContext | null> {
+  const headersList = await headers()
+  const tenantId = headersList.get('x-tenant-id')
+  const userId = headersList.get('x-user-id') ?? ''
+  const userRole = (headersList.get('x-user-role') ?? 'viewer') as UserRole
+  if (!tenantId) return null
+  return { tenantId, userId, userRole }
+}

--- a/src/lib/ics-parser.ts
+++ b/src/lib/ics-parser.ts
@@ -1,0 +1,239 @@
+/**
+ * Lightweight ICS (iCalendar) file parser.
+ *
+ * Handles RFC 5545 line folding, DTSTART/DTEND with TZID parameters,
+ * date-only values, UTC and local datetime formats, and meeting URL
+ * extraction from URL, LOCATION, and DESCRIPTION fields.
+ *
+ * No external dependencies required — ICS is plain text.
+ */
+
+export type ParsedIcsEvent = {
+  uid: string
+  summary: string
+  start: Date
+  end: Date
+  durationMinutes: number
+  location: string | null
+  meetingUrl: string | null
+  description: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Unfold RFC 5545 line folding: any line whose continuation starts with
+ * a SPACE or TAB is joined to the previous line (the whitespace character
+ * itself is consumed).
+ */
+function unfoldLines(content: string): string[] {
+  // Normalise CRLF → LF
+  const normalised = content.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+  const folded = normalised.split('\n')
+  const result: string[] = []
+
+  for (const line of folded) {
+    if ((line.startsWith(' ') || line.startsWith('\t')) && result.length > 0) {
+      result[result.length - 1] += line.slice(1)
+    } else {
+      result.push(line)
+    }
+  }
+
+  return result
+}
+
+/**
+ * Parse a single ICS datetime string into a Date.
+ *
+ * Supported formats:
+ *   - `20240415T140000Z`   → UTC
+ *   - `20240415T140000`    → local (parsed as-is via new Date)
+ *   - `20240415`           → date-only → midnight UTC
+ */
+function parseIcsDateTime(value: string): Date | null {
+  const v = value.trim()
+
+  // Date-only: exactly 8 numeric chars
+  if (/^\d{8}$/.test(v)) {
+    const iso = `${v.slice(0, 4)}-${v.slice(4, 6)}-${v.slice(6, 8)}T00:00:00Z`
+    const d = new Date(iso)
+    return isNaN(d.getTime()) ? null : d
+  }
+
+  // DateTime with or without trailing Z
+  if (/^\d{8}T\d{6}(Z?)$/.test(v)) {
+    const year = v.slice(0, 4)
+    const month = v.slice(4, 6)
+    const day = v.slice(6, 8)
+    const hour = v.slice(9, 11)
+    const min = v.slice(11, 13)
+    const sec = v.slice(13, 15)
+    const utc = v.endsWith('Z') ? 'Z' : ''
+    const iso = `${year}-${month}-${day}T${hour}:${min}:${sec}${utc}`
+    const d = new Date(iso)
+    return isNaN(d.getTime()) ? null : d
+  }
+
+  return null
+}
+
+/**
+ * Extract the raw value from an ICS property line, stripping any parameters.
+ *
+ * Examples:
+ *   `DTSTART;TZID=Europe/London:20240415T140000`  → `20240415T140000`
+ *   `DTSTART:20240415T140000Z`                     → `20240415T140000Z`
+ */
+function extractValue(line: string): string {
+  const colonIdx = line.indexOf(':')
+  if (colonIdx === -1) return ''
+  return line.slice(colonIdx + 1)
+}
+
+/**
+ * Strip the property name and any parameters, return only the value portion.
+ * Also decodes ICS text escaping: `\n` → newline, `\\` → `\`, `\,` → `,`.
+ */
+function decodeText(raw: string): string {
+  return raw
+    .replace(/\\n/g, '\n')
+    .replace(/\\N/g, '\n')
+    .replace(/\\\\/g, '\\')
+    .replace(/\\,/g, ',')
+    .replace(/\\;/g, ';')
+}
+
+/**
+ * Try to extract a meeting URL from a string (LOCATION or DESCRIPTION).
+ * Checks for Teams, Zoom, and Google Meet patterns first; falls back to any
+ * https:// URL.
+ */
+function extractUrlFromText(text: string): string | null {
+  if (!text) return null
+
+  // Meeting-specific patterns (in priority order)
+  const meetingPatterns = [
+    /https:\/\/[^\s"<>]*teams\.microsoft\.com\/l\/meetup-join[^\s"<>]*/i,
+    /https:\/\/[^\s"<>]*zoom\.us\/j\/[^\s"<>]*/i,
+    /https:\/\/meet\.google\.com\/[^\s"<>]*/i,
+  ]
+
+  for (const pattern of meetingPatterns) {
+    const match = text.match(pattern)
+    if (match) return match[0]
+  }
+
+  // Fall back to first https:// URL found
+  const genericMatch = text.match(/https:\/\/[^\s"<>]+/i)
+  return genericMatch ? genericMatch[0] : null
+}
+
+/**
+ * Check whether a string value looks like a URL (used for the LOCATION field).
+ */
+function isHttpsUrl(value: string): boolean {
+  return value.trimStart().startsWith('https://')
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse an ICS file's text content and return an array of calendar events.
+ *
+ * Events missing a SUMMARY or DTSTART are silently skipped.
+ * Malformed datetime values cause the event to be skipped rather than thrown.
+ */
+export function parseIcsFile(content: string): ParsedIcsEvent[] {
+  const lines = unfoldLines(content)
+  const events: ParsedIcsEvent[] = []
+
+  let inEvent = false
+  // Raw field accumulator for the current VEVENT
+  let fields: Record<string, string> = {}
+
+  for (const line of lines) {
+    const upper = line.toUpperCase()
+
+    if (upper === 'BEGIN:VEVENT') {
+      inEvent = true
+      fields = {}
+      continue
+    }
+
+    if (upper === 'END:VEVENT') {
+      inEvent = false
+
+      // Extract field values
+      const summary = fields['SUMMARY'] ? decodeText(fields['SUMMARY']) : null
+      const dtStartRaw = fields['DTSTART'] ?? null
+      const dtEndRaw = fields['DTEND'] ?? null
+      const uid = fields['UID'] ? decodeText(fields['UID']) : `generated-${Math.random()}`
+      const locationRaw = fields['LOCATION'] ? decodeText(fields['LOCATION']) : null
+      const descriptionRaw = fields['DESCRIPTION'] ? decodeText(fields['DESCRIPTION']) : null
+      const urlRaw = fields['URL'] ? fields['URL'].trim() : null
+
+      // Required fields — skip event if missing
+      if (!summary || !dtStartRaw) continue
+
+      const start = parseIcsDateTime(dtStartRaw)
+      if (!start) continue
+
+      // END is optional; default to start + 60 min if absent
+      const end = dtEndRaw ? (parseIcsDateTime(dtEndRaw) ?? new Date(start.getTime() + 60 * 60_000)) : new Date(start.getTime() + 60 * 60_000)
+
+      const rawDuration = (end.getTime() - start.getTime()) / 60_000
+      const durationMinutes = Math.max(15, Math.min(480, Math.round(rawDuration)))
+
+      // Meeting URL resolution (priority: URL field → LOCATION URL → DESCRIPTION URL)
+      let meetingUrl: string | null = null
+      if (urlRaw && isHttpsUrl(urlRaw)) {
+        meetingUrl = urlRaw
+      } else if (locationRaw && isHttpsUrl(locationRaw)) {
+        meetingUrl = extractUrlFromText(locationRaw)
+      }
+      if (!meetingUrl && descriptionRaw) {
+        meetingUrl = extractUrlFromText(descriptionRaw)
+      }
+
+      // LOCATION: use the raw value only if it is not a bare URL (that goes into meetingUrl)
+      const location = locationRaw && !isHttpsUrl(locationRaw) ? locationRaw : null
+
+      events.push({
+        uid,
+        summary,
+        start,
+        end,
+        durationMinutes,
+        location,
+        meetingUrl,
+        description: descriptionRaw,
+      })
+
+      continue
+    }
+
+    if (!inEvent) continue
+
+    // Parse property name (strip parameters after semicolon) and value
+    const colonIdx = line.indexOf(':')
+    if (colonIdx === -1) continue
+
+    const propFull = line.slice(0, colonIdx).toUpperCase()
+    // Strip TZID= and other parameters — take only the base property name
+    const propName = propFull.split(';')[0]
+    const value = extractValue(line)
+
+    // Store the first occurrence of each property (later duplicates like
+    // DTSTART with multiple TZID params are rare in practice and skipped)
+    if (propName && !(propName in fields)) {
+      fields[propName] = value
+    }
+  }
+
+  return events
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -33,7 +33,7 @@ export default auth((req) => {
     return NextResponse.next()
   }
 
-  if (!session) {
+  if (!session?.user?.tenantId) {
     if (isProtectedApi) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
@@ -45,8 +45,8 @@ export default auth((req) => {
   // Forward tenant + role as request headers for downstream handlers
   const requestHeaders = new Headers(req.headers)
   requestHeaders.set('x-tenant-id', session.user.tenantId)
-  requestHeaders.set('x-user-role', session.user.role)
-  requestHeaders.set('x-user-id', session.user.id)
+  requestHeaders.set('x-user-role', session.user.role ?? 'viewer')
+  requestHeaders.set('x-user-id', session.user.id ?? '')
 
   return NextResponse.next({ request: { headers: requestHeaders } })
 })


### PR DESCRIPTION
## Summary

A full security audit followed by three new recruiter workflow features, AI scoring fixes, and Docker dev environment stabilisation.

---

## Security Hardening

- **Critical: Tenant ID forgery fixed** — all 14 API route handlers were reading `x-tenant-id` from HTTP headers (forgeable by any authenticated user). Replaced with `auth()` session lookup everywhere.
- **Critical: Unauthenticated AI endpoints** — `extract/candidate` and `extract/role` routes had zero auth. Anyone could call them and burn API credits. Now gated on session.
- **File upload magic-byte validation** — upload routes now inspect actual file content using `file-type` to reject executables/images disguised as documents.
- **HTTP security headers** — `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `X-XSS-Protection`, `Referrer-Policy`, `Permissions-Policy` applied to all routes.
- **Password minimum raised** — invitation acceptance now requires 12-character minimum (was 8).
- **Middleware session guard** — `proxy.ts` now checks `session?.user?.tenantId` to prevent crashes on stale sessions.

## Refactoring

- **`getActionContext()` helper** — extracted repeated header-reading boilerplate from all 14 server action files into a single helper at `src/lib/auth/action-context.ts`.
- **Candidate detail page parallelisation** — 9 sequential DB queries reduced to 2 sequential + 7 parallel (`Promise.all`).

## New Features

### Add Existing Candidate to Role
Search the candidate archive by name/email from a role page and add them for scoring — no re-upload needed.

### Matching Roles Panel on Candidate Profile
Collapsible panel analyses the candidate CV against up to 10 active roles in a single Claude call, returning fit score, headline, pros, and cons for each.

### ICS Calendar File Import
Upload `.ics` files (Outlook/Teams/Google Calendar/Zoom) to create interview slots without OAuth. Zero-dependency parser handles line folding, timezones, and auto-extracts meeting URLs.

## Bug Fixes

- AI scoring 401 — isolated project API key from shell environment via `SKILLAI_ANTHROPIC_API_KEY`
- Scoring schema validation — `max_tokens` 1024 → 2048; `summary` made optional
- `audit_logs` table created in database (was missing despite schema existing)
- Security headers `source` pattern fixed (`**` → `/(.*))

## Test Plan

- [ ] Log in — no MissingSecret errors in container logs
- [ ] Upload CV → scoring completes (not 401)
- [ ] Role page → Add from archive → search → Add & Score
- [ ] Candidate profile → Matching Roles → Find → pros/cons appear
- [ ] Candidate profile → Import from file → upload `.ics` → slots created
- [ ] `/dashboard/audit` loads without error
- [ ] `curl -I http://localhost:3000` shows `X-Frame-Options: DENY`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)