### PR TITLE
feat: Manager priority keywords on roles (Epic #42)

### DIFF
--- a/src/actions/matching.ts
+++ b/src/actions/matching.ts
@@ -129,6 +129,7 @@ export async function getRoleFitSuggestionsForCandidate(
           id: roles.id,
           title: roles.title,
           requirements: roles.requirements,
+          priorityKeywords: roles.priorityKeywords,
         })
         .from(roles)
         .where(
@@ -147,6 +148,7 @@ export async function getRoleFitSuggestionsForCandidate(
       roleId: r.id,
       roleTitle: r.title,
       roleRequirements: r.requirements,
+      priorityKeywords: r.priorityKeywords,
     }))
 
     const candidateName = `${candidate.firstName} ${candidate.lastName}`

--- a/src/actions/roles.ts
+++ b/src/actions/roles.ts
@@ -12,6 +12,24 @@ import { writeAuditLog } from '@/lib/audit'
 import { extractRoleTags } from '@/lib/ai/role-tags'
 import { getActionContext } from '@/lib/auth/action-context'
 
+// Preprocess priorityKeywords: form sends a JSON-stringified array via FormData.
+// Accepts an actual array (programmatic call) OR a JSON string (FormData);
+// invalid/empty strings normalise to [].
+const priorityKeywordsField = z.preprocess(
+  (raw) => {
+    if (Array.isArray(raw)) return raw
+    if (typeof raw !== 'string') return []
+    if (raw.trim() === '') return []
+    try {
+      const parsed = JSON.parse(raw)
+      return Array.isArray(parsed) ? parsed : []
+    } catch {
+      return []
+    }
+  },
+  z.array(z.string().min(2).max(120)).max(15).default([])
+)
+
 const CreateRoleSchema = z.object({
   title: z.string().min(1, 'Title is required').max(200),
   description: z.string().min(10, 'Description must be at least 10 characters'),
@@ -28,6 +46,7 @@ const CreateRoleSchema = z.object({
   customerPortalPath: z.string().max(500).optional().or(z.literal('')),
   customerDayRate: z.coerce.number().min(0).optional().or(z.literal('')),
   rateCurrency: z.string().max(3).toUpperCase().optional().or(z.literal('')),
+  priorityKeywords: priorityKeywordsField,
 }).refine(
   (data) => {
     const hasRate = typeof data.customerDayRate === 'number'
@@ -71,6 +90,7 @@ export async function createRole(
     customerPortalPath: formData.get('customerPortalPath') || undefined,
     customerDayRate: formData.get('customerDayRate') || undefined,
     rateCurrency: formData.get('rateCurrency') || undefined,
+    priorityKeywords: formData.get('priorityKeywords') ?? undefined,
   })
 
   if (!parsed.success) {
@@ -104,6 +124,8 @@ export async function createRole(
         customerPortalPath: parsed.data.customerPortalPath || null,
         customerDayRate: typeof parsed.data.customerDayRate === 'number' ? String(parsed.data.customerDayRate) : null,
         rateCurrency: parsed.data.rateCurrency || null,
+        priorityKeywords: parsed.data.priorityKeywords,
+        priorityKeywordsUpdatedAt: parsed.data.priorityKeywords.length > 0 ? new Date() : null,
         isActive: true,
       })
       .returning({ id: roles.id })
@@ -145,6 +167,7 @@ const UpdateRoleSchema = z.object({
   customerPortalPath: z.string().max(500).optional().or(z.literal('')),
   customerDayRate: z.coerce.number().min(0).optional().or(z.literal('')),
   rateCurrency: z.string().max(3).toUpperCase().optional().or(z.literal('')),
+  priorityKeywords: priorityKeywordsField,
 }).refine(
   (data) => {
     const hasRate = typeof data.customerDayRate === 'number'
@@ -191,6 +214,7 @@ export async function updateRole(
     customerPortalPath: formData.get('customerPortalPath') || undefined,
     customerDayRate: formData.get('customerDayRate') || undefined,
     rateCurrency: formData.get('rateCurrency') || undefined,
+    priorityKeywords: formData.get('priorityKeywords') ?? undefined,
   })
 
   if (!parsed.success) {
@@ -200,6 +224,30 @@ export async function updateRole(
       fieldErrors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
     }
   }
+
+  // Load existing role so we can diff priorityKeywords and only bump
+  // priorityKeywordsUpdatedAt when the set actually changes.
+  const [existingRole] = await withTenant(tenantId, async (tx) =>
+    tx
+      .select({
+        title: roles.title,
+        priorityKeywords: roles.priorityKeywords,
+      })
+      .from(roles)
+      .where(and(eq(roles.id, roleId), eq(roles.tenantId, tenantId)))
+      .limit(1)
+  )
+  if (!existingRole) {
+    return { success: false, error: 'Role not found' }
+  }
+
+  const oldKeywords = existingRole.priorityKeywords ?? []
+  const newKeywords = parsed.data.priorityKeywords
+  const oldSet = new Set(oldKeywords)
+  const newSet = new Set(newKeywords)
+  const added = newKeywords.filter((k) => !oldSet.has(k))
+  const removed = oldKeywords.filter((k) => !newSet.has(k))
+  const keywordsChanged = added.length > 0 || removed.length > 0
 
   await withTenant(tenantId, async (tx) => {
     await tx
@@ -222,9 +270,24 @@ export async function updateRole(
         customerPortalPath: parsed.data.customerPortalPath || null,
         customerDayRate: typeof parsed.data.customerDayRate === 'number' ? String(parsed.data.customerDayRate) : null,
         rateCurrency: parsed.data.rateCurrency || null,
+        priorityKeywords: newKeywords,
+        ...(keywordsChanged ? { priorityKeywordsUpdatedAt: new Date() } : {}),
       })
       .where(and(eq(roles.id, roleId), eq(roles.tenantId, tenantId)))
   })
+
+  // Audit: only emit when priorityKeywords actually changed. Mirrors the
+  // existing pattern in createRole / archiveRole (writeAuditLog with
+  // action / entityType / entityId / entityLabel + optional metadata).
+  if (keywordsChanged) {
+    await writeAuditLog(tenantId, {
+      action: 'role.updated',
+      entityType: 'role',
+      entityId: roleId,
+      entityLabel: parsed.data.title,
+      metadata: { field: 'priorityKeywords', added, removed },
+    })
+  }
 
   after(async () => {
     await _saveRoleTags(roleId, tenantId, parsed.data.title, parsed.data.description, parsed.data.requirements)

--- a/src/actions/shortlist-summary.ts
+++ b/src/actions/shortlist-summary.ts
@@ -54,7 +54,8 @@ export async function getShortlistSummary(
         communicationScore: c.communicationScore,
         aiSummary: c.aiSummary,
       })),
-      tenantId
+      tenantId,
+      role.priorityKeywords
     )
 
     return { summary }

--- a/src/app/(dashboard)/dashboard/candidates/[candidateId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/candidates/[candidateId]/page.tsx
@@ -25,7 +25,10 @@ import { MatchingRolesPanel } from '@/components/candidates/matching-roles-panel
 import { CvFilePanel } from '@/components/candidates/cv-file-panel'
 import { TranscriptSection } from '@/components/transcripts/transcript-section'
 import { archiveCandidate } from '@/actions/candidates'
+import { rescoreCandidate } from '@/actions/scores'
 import { hasRole } from '@/lib/auth/require-role'
+import { StaleScorePill } from '@/components/roles/priority-keywords-panel'
+import { isScoreOutdatedAgainstPriorities } from '@/lib/scores/staleness'
 import type { WebHit, GitHubProfile } from '@/db/schema/candidate-enrichments'
 
 type Props = { params: Promise<{ candidateId: string }>; searchParams: Promise<{ roleId?: string }> }
@@ -339,7 +342,16 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
       ) : activeScore?.score.scoreStatus === 'complete' ? (
         <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-6 mb-6">
           <div className="flex items-center justify-between mb-4">
-            <h2 className="font-semibold text-zinc-100">Score for: {activeScore.role.title}</h2>
+            <div className="flex items-center gap-3 flex-wrap">
+              <h2 className="font-semibold text-zinc-100">Score for: {activeScore.role.title}</h2>
+              {isScoreOutdatedAgainstPriorities(activeScore.score, activeScore.role) && canEdit && (
+                <StaleScorePill
+                  candidateId={candidateId}
+                  roleId={activeScore.score.roleId}
+                  rescoreAction={rescoreCandidate}
+                />
+              )}
+            </div>
             {canEdit && (
               <RescoreButton
                 candidateId={candidateId}

--- a/src/app/(dashboard)/dashboard/roles/[roleId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/roles/[roleId]/page.tsx
@@ -7,7 +7,7 @@ import { withTenant } from '@/db'
 import { roles, scores, candidates, customers, agencies } from '@/db/schema'
 import { DownloadPdfButton } from '@/components/export/download-pdf-button'
 import { archiveRole, regenerateRoleTags } from '@/actions/roles'
-import { removeCandidateFromRole } from '@/actions/scores'
+import { removeCandidateFromRole, rescoreCandidate } from '@/actions/scores'
 import { hasRole } from '@/lib/auth/require-role'
 import { RoleTagsPanel } from '@/components/roles/role-tags-panel'
 import { RoleMetaBar } from '@/components/roles/role-meta-bar'
@@ -17,6 +17,11 @@ import { SuggestCandidatesPanel } from '@/components/roles/suggest-candidates-pa
 import { AddCandidatePanel } from '@/components/roles/add-candidate-panel'
 import { ShortlistSummaryPanel } from '@/components/roles/shortlist-summary-panel'
 import { DownloadCvsButton } from '@/components/roles/download-cvs-button'
+import {
+  PriorityKeywordsPanel,
+  StaleScorePill,
+} from '@/components/roles/priority-keywords-panel'
+import { isScoreOutdatedAgainstPriorities } from '@/lib/scores/staleness'
 
 type Props = { params: Promise<{ roleId: string }> }
 
@@ -64,6 +69,7 @@ export default async function RoleDetailPage({ params }: Props) {
         experienceScore: scores.experienceScore,
         culturalFitScore: scores.culturalFitScore,
         communicationScore: scores.communicationScore,
+        scoreUpdatedAt: scores.updatedAt,
         firstName: candidates.firstName,
         lastName: candidates.lastName,
         email: candidates.email,
@@ -209,6 +215,13 @@ export default async function RoleDetailPage({ params }: Props) {
 
       <RoleMetaBar role={role} customer={customer} portalUrl={portalUrl} />
 
+      {/* Manager priority keywords — soft signal surfaced in AI scoring */}
+      <PriorityKeywordsPanel
+        keywords={role.priorityKeywords}
+        canEdit={canEdit}
+        roleEditHref={`/dashboard/roles/${roleId}/edit`}
+      />
+
       {/* Tags panel */}
       <RoleTagsPanel
         roleId={roleId}
@@ -252,31 +265,47 @@ export default async function RoleDetailPage({ params }: Props) {
           <p className="text-zinc-500 text-sm">No candidates scored for this role yet.</p>
         ) : (
           <div className="grid gap-2">
-            {scoredCandidates.map((c) => (
-              <RoleCandidateCard
-                key={c.scoreId}
-                scoreId={c.scoreId}
-                roleId={roleId}
-                candidateId={c.candidateId}
-                firstName={c.firstName}
-                lastName={c.lastName}
-                email={c.email}
-                scoreStatus={c.scoreStatus}
-                overallScore={c.overallScore}
-                technicalScore={c.technicalScore}
-                experienceScore={c.experienceScore}
-                culturalFitScore={c.culturalFitScore}
-                communicationScore={c.communicationScore}
-                filePath={c.filePath ?? null}
-                roleDayRate={role.customerDayRate}
-                roleCurrency={role.rateCurrency}
-                candidateRate={c.candidateRate}
-                candidateCurrency={c.candidateCurrency}
-                isInternal={Boolean(c.agencyIsInternal)}
-                canEdit={canEdit}
-                removeAction={removeCandidateFromRole}
-              />
-            ))}
+            {scoredCandidates.map((c) => {
+              const isStale = isScoreOutdatedAgainstPriorities(
+                { updatedAt: c.scoreUpdatedAt },
+                { priorityKeywordsUpdatedAt: role.priorityKeywordsUpdatedAt },
+              )
+              return (
+                <div key={c.scoreId} className="space-y-1">
+                  <RoleCandidateCard
+                    scoreId={c.scoreId}
+                    roleId={roleId}
+                    candidateId={c.candidateId}
+                    firstName={c.firstName}
+                    lastName={c.lastName}
+                    email={c.email}
+                    scoreStatus={c.scoreStatus}
+                    overallScore={c.overallScore}
+                    technicalScore={c.technicalScore}
+                    experienceScore={c.experienceScore}
+                    culturalFitScore={c.culturalFitScore}
+                    communicationScore={c.communicationScore}
+                    filePath={c.filePath ?? null}
+                    roleDayRate={role.customerDayRate}
+                    roleCurrency={role.rateCurrency}
+                    candidateRate={c.candidateRate}
+                    candidateCurrency={c.candidateCurrency}
+                    isInternal={Boolean(c.agencyIsInternal)}
+                    canEdit={canEdit}
+                    removeAction={removeCandidateFromRole}
+                  />
+                  {isStale && canEdit && (
+                    <div className="flex justify-end pr-2">
+                      <StaleScorePill
+                        candidateId={c.candidateId}
+                        roleId={roleId}
+                        rescoreAction={rescoreCandidate}
+                      />
+                    </div>
+                  )}
+                </div>
+              )
+            })}
           </div>
         )}
       </div>

--- a/src/components/roles/priority-keywords-panel.tsx
+++ b/src/components/roles/priority-keywords-panel.tsx
@@ -1,0 +1,116 @@
+'use client'
+
+import { useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { SparklesIcon, RefreshCwIcon } from 'lucide-react'
+
+interface PriorityKeywordsPanelProps {
+  keywords: string[] | null
+  canEdit: boolean
+  /** Where to send the recruiter to edit priorities (the existing role edit page). */
+  roleEditHref: string
+}
+
+/**
+ * Renders the role's manager priority keywords as soft-signal chips.
+ * Edits flow through the existing role edit page — there is no inline edit here.
+ */
+export function PriorityKeywordsPanel({
+  keywords,
+  canEdit,
+  roleEditHref,
+}: PriorityKeywordsPanelProps) {
+  const items = (keywords ?? []).filter((k) => k.trim().length > 0)
+  const empty = items.length === 0
+
+  return (
+    <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-6 mb-6">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="font-semibold text-zinc-100 flex items-center gap-2">
+          <SparklesIcon className="h-4 w-4 text-yellow-400" />
+          Manager Priorities
+        </h2>
+        {canEdit && (
+          <a
+            href={roleEditHref}
+            className="text-xs text-zinc-400 border border-zinc-600 rounded-md px-3 py-1.5
+                       hover:bg-zinc-800 transition-colors"
+          >
+            {empty ? 'Add priorities' : 'Edit'}
+          </a>
+        )}
+      </div>
+
+      {empty ? (
+        <p className="text-sm text-zinc-500">
+          {canEdit
+            ? 'No manager priorities recorded for this role. Click "Add priorities" to record what the hiring manager cares about most.'
+            : 'No manager priorities recorded for this role.'}
+        </p>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          {items.map((kw) => (
+            <span
+              key={kw}
+              className="inline-flex items-center rounded-full bg-yellow-950 border border-yellow-800
+                         text-yellow-300 text-xs font-medium px-3 py-1"
+            >
+              {kw}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <p className="mt-3 text-[11px] text-zinc-500">
+        Soft-signal priorities surfaced in AI scoring summaries. Not a numeric dimension.
+      </p>
+    </div>
+  )
+}
+
+interface StaleScorePillProps {
+  candidateId: string
+  roleId: string
+  rescoreAction: (
+    candidateId: string,
+    roleId: string,
+  ) => Promise<{ success: boolean; error?: string }>
+}
+
+/**
+ * Pill rendered alongside an outdated score. Clicking it triggers a rescore
+ * via the existing `rescoreCandidate` action and refreshes the route.
+ */
+export function StaleScorePill({
+  candidateId,
+  roleId,
+  rescoreAction,
+}: StaleScorePillProps) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+
+  function handleClick(e: React.MouseEvent) {
+    e.preventDefault()
+    e.stopPropagation()
+    startTransition(async () => {
+      const result = await rescoreAction(candidateId, roleId)
+      if (result.success) router.refresh()
+    })
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={isPending}
+      title="Manager priorities have changed since this score was generated. Click to rescore."
+      className="inline-flex items-center gap-1 rounded-full border border-yellow-700
+                 bg-yellow-900/40 px-2 py-0.5 text-[10px] font-medium text-yellow-200
+                 hover:bg-yellow-900/70 hover:text-yellow-100
+                 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+    >
+      <RefreshCwIcon className={`h-2.5 w-2.5 ${isPending ? 'animate-spin' : ''}`} />
+      {isPending ? 'Rescoring…' : 'Priorities updated · rescore'}
+    </button>
+  )
+}

--- a/src/components/roles/role-edit-form.tsx
+++ b/src/components/roles/role-edit-form.tsx
@@ -6,6 +6,7 @@ import { useEffect } from 'react'
 import { Loader2 } from 'lucide-react'
 import { updateRole } from '@/actions/roles'
 import type { UpdateRoleState } from '@/actions/roles'
+import { ChipInput } from '@/components/ui/chip-input'
 
 interface RoleData {
   id: string
@@ -20,6 +21,7 @@ interface RoleData {
   customerPortalPath?: string | null
   customerDayRate?: string | null
   rateCurrency?: string | null
+  priorityKeywords?: string[] | null
 }
 
 type FrameworkLevelOption = {
@@ -45,7 +47,20 @@ export function RoleEditForm({ role, customers = [], frameworks = {} }: RoleEdit
     null
   )
 
-  const [fields, setFields] = useState({
+  const [fields, setFields] = useState<{
+    title: string
+    description: string
+    requirements: string
+    customerId: string
+    frameworkLevelId: string
+    frameworkLevelLabel: string
+    targetFillDate: string
+    cutoffDate: string
+    customerPortalPath: string
+    customerDayRate: string
+    rateCurrency: string
+    priorityKeywords: string[]
+  }>({
     title: role.title,
     description: role.description,
     requirements: role.requirements,
@@ -57,6 +72,7 @@ export function RoleEditForm({ role, customers = [], frameworks = {} }: RoleEdit
     customerPortalPath: role.customerPortalPath ?? '',
     customerDayRate: role.customerDayRate ?? '',
     rateCurrency: role.rateCurrency ?? '',
+    priorityKeywords: role.priorityKeywords ?? [],
   })
 
   useEffect(() => {
@@ -81,6 +97,7 @@ export function RoleEditForm({ role, customers = [], frameworks = {} }: RoleEdit
         fd.set('customerPortalPath', fields.customerPortalPath)
         fd.set('customerDayRate', fields.customerDayRate)
         fd.set('rateCurrency', fields.rateCurrency)
+        fd.set('priorityKeywords', JSON.stringify(fields.priorityKeywords))
         action(fd)
       }}
       className="space-y-6 max-w-2xl"
@@ -228,6 +245,31 @@ export function RoleEditForm({ role, customers = [], frameworks = {} }: RoleEdit
         />
         {fieldErrors?.requirements && (
           <p className="mt-1 text-xs text-red-400">{fieldErrors.requirements[0]}</p>
+        )}
+      </div>
+
+      {/* Manager Priorities */}
+      <div className="border-t border-zinc-800 pt-4 mt-2">
+        <label htmlFor="priorityKeywords" className="block text-sm font-medium text-zinc-300 mb-1">
+          Manager Priorities <span className="text-zinc-500 font-normal">(optional)</span>
+        </label>
+        <p id="priorityKeywords-help" className="text-xs text-zinc-500 mb-2">
+          Soft-signal phrases the hiring manager wants prioritised. E.g.{' '}
+          <span className="text-zinc-400">&quot;Self-starting&quot;</span>,{' '}
+          <span className="text-zinc-400">&quot;Engineer who codes&quot;</span>.
+        </p>
+        <ChipInput
+          id="priorityKeywords"
+          aria-describedby="priorityKeywords-help"
+          value={fields.priorityKeywords}
+          onChange={(next) => setFields((f) => ({ ...f, priorityKeywords: next }))}
+          placeholder="Type a phrase, press Enter…"
+          maxChips={15}
+          maxLength={120}
+          disabled={pending}
+        />
+        {fieldErrors?.priorityKeywords && (
+          <p className="mt-1 text-xs text-red-400">{fieldErrors.priorityKeywords[0]}</p>
         )}
       </div>
 

--- a/src/components/roles/role-form.tsx
+++ b/src/components/roles/role-form.tsx
@@ -6,6 +6,7 @@ import { useEffect } from 'react'
 import { Loader2, Sparkles, UploadCloud, X } from 'lucide-react'
 import { createRole } from '@/actions/roles'
 import type { CreateRoleState } from '@/actions/roles'
+import { ChipInput } from '@/components/ui/chip-input'
 
 interface RoleFields {
   title: string
@@ -23,6 +24,7 @@ interface RoleFields {
   customerPortalPath: string
   customerDayRate: string
   rateCurrency: string
+  priorityKeywords: string[]
 }
 
 type FrameworkLevelOption = {
@@ -61,6 +63,7 @@ export function RoleForm({ customers = [], frameworks = {} }: RoleFormProps) {
     customerPortalPath: '',
     customerDayRate: '',
     rateCurrency: '',
+    priorityKeywords: [],
   })
 
   const [importFile, setImportFile] = useState<File | null>(null)
@@ -202,6 +205,7 @@ export function RoleForm({ customers = [], frameworks = {} }: RoleFormProps) {
         fd.set('customerId', fields.customerId)
         fd.set('frameworkLevelId', fields.frameworkLevelId)
         fd.set('frameworkLevelLabel', fields.frameworkLevelLabel)
+        fd.set('priorityKeywords', JSON.stringify(fields.priorityKeywords))
         action(fd)
       }} className="space-y-6">
         {state && !state.success && !state.fieldErrors && (
@@ -347,6 +351,31 @@ export function RoleForm({ customers = [], frameworks = {} }: RoleFormProps) {
           />
           {fieldErrors?.requirements && (
             <p className="mt-1 text-xs text-red-400">{fieldErrors.requirements[0]}</p>
+          )}
+        </div>
+
+        {/* Manager Priorities */}
+        <div className="border-t border-zinc-800 pt-4 mt-2">
+          <label htmlFor="priorityKeywords" className="block text-sm font-medium text-zinc-300 mb-1">
+            Manager Priorities <span className="text-zinc-500 font-normal">(optional)</span>
+          </label>
+          <p id="priorityKeywords-help" className="text-xs text-zinc-500 mb-2">
+            Soft-signal phrases the hiring manager wants prioritised. E.g.{' '}
+            <span className="text-zinc-400">&quot;Self-starting&quot;</span>,{' '}
+            <span className="text-zinc-400">&quot;Engineer who codes&quot;</span>.
+          </p>
+          <ChipInput
+            id="priorityKeywords"
+            aria-describedby="priorityKeywords-help"
+            value={fields.priorityKeywords}
+            onChange={(next) => setFields((f) => ({ ...f, priorityKeywords: next }))}
+            placeholder="Type a phrase, press Enter…"
+            maxChips={15}
+            maxLength={120}
+            disabled={pending || importing}
+          />
+          {fieldErrors?.priorityKeywords && (
+            <p className="mt-1 text-xs text-red-400">{fieldErrors.priorityKeywords[0]}</p>
           )}
         </div>
 

--- a/src/components/ui/chip-input.tsx
+++ b/src/components/ui/chip-input.tsx
@@ -1,0 +1,141 @@
+'use client'
+
+import { useCallback, useMemo, useState, type KeyboardEvent } from 'react'
+import { X } from 'lucide-react'
+
+interface ChipInputProps {
+  value: string[]
+  onChange: (next: string[]) => void
+  placeholder?: string
+  /** Maximum number of chips. Defaults to 15. */
+  maxChips?: number
+  /** Maximum length of a single chip (HTML maxLength on the input). Defaults to 120. */
+  maxLength?: number
+  disabled?: boolean
+  className?: string
+  /** id on the underlying input — useful for label association */
+  id?: string
+  'aria-describedby'?: string
+}
+
+/**
+ * Generic, controlled chip-input.
+ *
+ * Parent owns the array via `value` + `onChange`. The component holds only the
+ * draft text being typed.
+ *
+ * Commit triggers: Enter or comma. Whitespace-only drafts are rejected.
+ * Duplicates are rejected case-insensitively. Backspace on an empty input
+ * removes the last chip. When `maxChips` is reached, the input is hidden and
+ * a small "Max reached" hint is shown.
+ *
+ * Style intentionally uses the yellow palette — this is the manager-priority
+ * colour from Epic #42 and the chips will be reused for must-have / nice-to-have
+ * keyword inputs on roles.
+ */
+export function ChipInput({
+  value,
+  onChange,
+  placeholder,
+  maxChips = 15,
+  maxLength = 120,
+  disabled = false,
+  className,
+  id,
+  'aria-describedby': ariaDescribedBy,
+}: ChipInputProps) {
+  const [draft, setDraft] = useState('')
+
+  const lowerSet = useMemo(
+    () => new Set(value.map((v) => v.trim().toLowerCase())),
+    [value]
+  )
+
+  const atLimit = value.length >= maxChips
+  const inputHidden = atLimit
+
+  const commit = useCallback(
+    (raw: string) => {
+      const trimmed = raw.trim()
+      if (!trimmed) return false
+      if (lowerSet.has(trimmed.toLowerCase())) return false
+      if (value.length >= maxChips) return false
+      onChange([...value, trimmed])
+      return true
+    },
+    [lowerSet, maxChips, onChange, value]
+  )
+
+  const removeAt = useCallback(
+    (index: number) => {
+      const next = value.slice()
+      next.splice(index, 1)
+      onChange(next)
+    },
+    [onChange, value]
+  )
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter' || e.key === ',') {
+        e.preventDefault()
+        if (commit(draft)) {
+          setDraft('')
+        }
+        return
+      }
+      if (e.key === 'Backspace' && draft === '' && value.length > 0) {
+        e.preventDefault()
+        removeAt(value.length - 1)
+      }
+    },
+    [commit, draft, removeAt, value.length]
+  )
+
+  return (
+    <div
+      className={
+        'flex flex-wrap items-center gap-1.5 min-h-[36px] rounded-md border border-zinc-700 bg-zinc-900 px-2 py-1.5' +
+        (disabled ? ' opacity-60' : '') +
+        (className ? ` ${className}` : '')
+      }
+    >
+      {value.map((chip, idx) => (
+        <span
+          key={`${chip}-${idx}`}
+          className="inline-flex items-center gap-1 rounded-full border border-yellow-700 bg-yellow-900/40 px-2 py-0.5 text-xs text-yellow-100"
+        >
+          <span>{chip}</span>
+          <button
+            type="button"
+            aria-label={`Remove ${chip}`}
+            disabled={disabled}
+            onClick={() => removeAt(idx)}
+            className="text-yellow-300 hover:text-yellow-100 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <X className="h-3 w-3" aria-hidden="true" />
+          </button>
+        </span>
+      ))}
+
+      {inputHidden ? (
+        <span className="text-xs text-zinc-500" aria-live="polite">
+          Max reached
+        </span>
+      ) : (
+        <input
+          id={id}
+          type="text"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          maxLength={maxLength}
+          disabled={disabled}
+          aria-describedby={ariaDescribedBy}
+          className="flex-1 min-w-[120px] bg-transparent text-sm text-zinc-100 placeholder-zinc-500 focus:outline-none disabled:opacity-50"
+        />
+      )}
+    </div>
+  )
+}

--- a/src/db/migrations/0014_priority_keywords.sql
+++ b/src/db/migrations/0014_priority_keywords.sql
@@ -1,0 +1,12 @@
+-- Migration: Manager priority keywords on roles
+-- Part of Epic #42. Adds two columns to the roles table:
+--   priority_keywords: manager-supplied soft-signal phrases (e.g. "Self-starting",
+--                      "Engineer who codes, not a developer who knows infra"). Used
+--                      as a soft signal in the cached AI role-context block per
+--                      DEC-009 pattern. NOT a fifth scored dimension.
+--   priority_keywords_updated_at: timestamp of the last edit; used by the stale-score
+--                                 pill to detect outdated scores after priorities change.
+
+ALTER TABLE "roles"
+  ADD COLUMN IF NOT EXISTS "priority_keywords" text[] NOT NULL DEFAULT '{}',
+  ADD COLUMN IF NOT EXISTS "priority_keywords_updated_at" timestamp;

--- a/src/db/schema/roles.ts
+++ b/src/db/schema/roles.ts
@@ -30,6 +30,8 @@ export const roles = pgTable(
     languageRequirements: text('language_requirements').array().notNull().default(sql`'{}'::text[]`),
     keySkills: text('key_skills').array().notNull().default(sql`'{}'::text[]`),
     topRequirements: text('top_requirements').array().notNull().default(sql`'{}'::text[]`),
+    priorityKeywords: text('priority_keywords').array().notNull().default(sql`'{}'::text[]`),
+    priorityKeywordsUpdatedAt: timestamp('priority_keywords_updated_at'),
     targetFillDate: date('target_fill_date'),
     cutoffDate: date('cutoff_date'),
     customerPortalPath: varchar('customer_portal_path', { length: 500 }),

--- a/src/lib/ai/claude.ts
+++ b/src/lib/ai/claude.ts
@@ -8,6 +8,7 @@
 
 import Anthropic from '@anthropic-ai/sdk'
 import { CandidateScoreSchema, type CandidateScore } from './schema'
+import { formatManagerPriorities } from './priorities'
 
 const anthropic = new Anthropic({
   apiKey: process.env.ANTHROPIC_API_KEY,
@@ -82,6 +83,7 @@ type ScoringInput = {
   candidateName: string
   frameworkContext?: string
   budgetContext?: string
+  priorityKeywords?: readonly string[]
 }
 
 export async function scoreCandidateWithClaude(input: ScoringInput): Promise<CandidateScore> {
@@ -109,7 +111,7 @@ DESCRIPTION:
 ${input.roleDescription}
 
 REQUIREMENTS:
-${input.roleRequirements}${input.frameworkContext ? `\n\nHIRING FRAMEWORK CONTEXT:\n${input.frameworkContext}` : ''}`,
+${input.roleRequirements}${input.frameworkContext ? `\n\nHIRING FRAMEWORK CONTEXT:\n${input.frameworkContext}` : ''}${formatManagerPriorities(input.priorityKeywords)}`,
             cache_control: { type: 'ephemeral' },
           },
           {

--- a/src/lib/ai/gemini.ts
+++ b/src/lib/ai/gemini.ts
@@ -10,6 +10,7 @@
 import { GoogleGenerativeAI, SchemaType, type Schema } from '@google/generative-ai'
 import { resolveGoogleKey } from './keys'
 import { CandidateScoreSchema, type CandidateScore } from './schema'
+import { formatManagerPriorities } from './priorities'
 
 const GEMINI_MODEL = 'models/gemini-2.0-flash'
 
@@ -75,6 +76,7 @@ type ScoringInput = {
   tenantId: string
   frameworkContext?: string
   budgetContext?: string
+  priorityKeywords?: readonly string[]
 }
 
 export async function scoreCandidateWithGemini(input: ScoringInput): Promise<CandidateScore> {
@@ -97,7 +99,7 @@ DESCRIPTION:
 ${input.roleDescription}
 
 REQUIREMENTS:
-${input.roleRequirements}${input.frameworkContext ? `\n\nHIRING FRAMEWORK CONTEXT:\n${input.frameworkContext}` : ''}
+${input.roleRequirements}${input.frameworkContext ? `\n\nHIRING FRAMEWORK CONTEXT:\n${input.frameworkContext}` : ''}${formatManagerPriorities(input.priorityKeywords)}
 
 CANDIDATE: ${input.candidateName}
 ${input.budgetContext ? `\n${input.budgetContext}\n` : ''}

--- a/src/lib/ai/interview.ts
+++ b/src/lib/ai/interview.ts
@@ -14,6 +14,7 @@ import {
   type InterviewPackOutput,
 } from './interview-schemas'
 import { inferExperienceLevel, inferLanguage } from './interview-helpers'
+import { formatManagerPriorities } from './priorities'
 
 export { inferExperienceLevel, inferLanguage }
 
@@ -105,7 +106,7 @@ ${cvText.slice(0, 6000)}`,
 
 export async function generateQuestions(
   cvProfile: CvProfile,
-  role: { title: string; description: string; requirements: string },
+  role: { title: string; description: string; requirements: string; priorityKeywords?: readonly string[] },
   options: { includeCodeChallenge: boolean; language?: string; packType?: 'full' | 'pre_screening' }
 ): Promise<InterviewPackOutput> {
   const language = options.language ?? inferLanguage(cvProfile.technical_skills)
@@ -182,7 +183,7 @@ export async function generateQuestions(
             text: `ROLE: ${role.title}
 DESCRIPTION: ${role.description}
 REQUIREMENTS:
-${role.requirements}`,
+${role.requirements}${formatManagerPriorities(role.priorityKeywords)}`,
             cache_control: { type: 'ephemeral' },
           },
           {

--- a/src/lib/ai/priorities.ts
+++ b/src/lib/ai/priorities.ts
@@ -1,0 +1,36 @@
+/**
+ * Manager priority keywords — soft-signal prompt block builder.
+ *
+ * Used by every role-aware AI helper (CV scoring, interview transcript analysis,
+ * interview pack generation, role-fit batch, shortlist summary) to insert the
+ * recruiter/manager-supplied priorities into the cached role-context block.
+ *
+ * Pattern mirrors DEC-009: priorities are SOFT SIGNALS that influence the AI's
+ * reasoning text and summary, but never directly drag the four scored dimensions
+ * (technical_skills, experience_level, cultural_fit, communication). The prompt
+ * explicitly tells the model not to penalise/boost overall_score for priorities
+ * alone.
+ *
+ * Empty array returns an empty string so prompts on roles WITHOUT priorities are
+ * byte-identical to the pre-feature baseline (regression-safe).
+ */
+
+/**
+ * Build the manager priorities block for a role's cached prompt context.
+ *
+ * @param keywords  The role.priorityKeywords array (may be empty)
+ * @returns         Empty string if no keywords; otherwise a prefixed bulleted
+ *                  block with a soft-signal instruction.
+ */
+export function formatManagerPriorities(keywords: readonly string[] | null | undefined): string {
+  if (!keywords || keywords.length === 0) return ''
+  const cleaned = keywords.map((k) => k.trim()).filter((k) => k.length > 0)
+  if (cleaned.length === 0) return ''
+  const bullets = cleaned.map((k) => `- ${k}`).join('\n')
+  return `
+
+MANAGER PRIORITIES (soft signals — not scored dimensions):
+${bullets}
+
+When evaluating this candidate, treat the priorities above as soft signals: mention in your summary how the candidate aligns or doesn't align with each, but do NOT directly penalize or boost overall_score on the basis of priorities alone — the four scored dimensions remain the source of the numeric score.`
+}

--- a/src/lib/ai/role-fit.ts
+++ b/src/lib/ai/role-fit.ts
@@ -1,10 +1,12 @@
 import Anthropic from '@anthropic-ai/sdk'
 import { resolveAnthropicKey } from './keys'
+import { formatManagerPriorities } from './priorities'
 
 type RoleInput = {
   roleId: string
   roleTitle: string
   roleRequirements: string
+  priorityKeywords?: readonly string[]
 }
 
 export type RoleFitResult = {
@@ -52,7 +54,7 @@ export async function analyseRoleFitForCandidate(
   const rolesBlock = roles
     .map(
       (r, i) =>
-        `${i + 1}. ${r.roleTitle} (id: ${r.roleId})\nRequirements: ${r.roleRequirements.slice(0, 500)}`
+        `${i + 1}. ${r.roleTitle} (id: ${r.roleId})\nRequirements: ${r.roleRequirements.slice(0, 500)}${formatManagerPriorities(r.priorityKeywords)}`
     )
     .join('\n\n')
 

--- a/src/lib/ai/scoring.ts
+++ b/src/lib/ai/scoring.ts
@@ -99,6 +99,7 @@ When scoring experience_level, assess specifically whether the candidate's senio
       candidateName: `${candidate.firstName} ${candidate.lastName}`,
       frameworkContext,
       budgetContext,
+      priorityKeywords: role.priorityKeywords,
     }
 
     const result = useGemini

--- a/src/lib/ai/shortlist-summary.ts
+++ b/src/lib/ai/shortlist-summary.ts
@@ -1,5 +1,6 @@
 import Anthropic from '@anthropic-ai/sdk'
 import { resolveAnthropicKey } from './keys'
+import { formatManagerPriorities } from './priorities'
 
 type CandidateSummaryInput = {
   name: string
@@ -15,7 +16,8 @@ export async function generateShortlistSummary(
   roleTitle: string,
   roleRequirements: string,
   candidates: CandidateSummaryInput[],
-  tenantId: string
+  tenantId: string,
+  priorityKeywords?: readonly string[]
 ): Promise<string> {
   const apiKey = await resolveAnthropicKey(tenantId)
   const client = new Anthropic({ apiKey })
@@ -36,7 +38,7 @@ ${i + 1}. ${c.name} — Overall: ${c.overallScore}/100
       content: `You are a senior recruitment advisor. Write a concise hiring recommendation for the following role and shortlisted candidates.
 
 ROLE: ${roleTitle}
-REQUIREMENTS: ${roleRequirements}
+REQUIREMENTS: ${roleRequirements}${formatManagerPriorities(priorityKeywords)}
 
 SHORTLISTED CANDIDATES:
 ${candidateDescriptions}

--- a/src/lib/ai/transcript-analysis.ts
+++ b/src/lib/ai/transcript-analysis.ts
@@ -17,6 +17,7 @@ import {
   TRANSCRIPT_ANALYSIS_TOOL,
   type TranscriptAnalysis,
 } from './transcript-schemas'
+import { formatManagerPriorities } from './priorities'
 
 const anthropic = new Anthropic({
   apiKey: process.env.ANTHROPIC_API_KEY,
@@ -46,6 +47,7 @@ type AnalysisInput = {
   roleDescription: string
   roleRequirements: string
   packQuestions?: PackQuestion[]
+  priorityKeywords?: readonly string[]
 }
 
 export async function analyzeTranscriptWithClaude(
@@ -69,7 +71,7 @@ REQUIREMENTS:
 ${input.roleRequirements}
 
 DESCRIPTION:
-${input.roleDescription}${questionsBlock}
+${input.roleDescription}${questionsBlock}${formatManagerPriorities(input.priorityKeywords)}
 
 Score 4 dimensions:
 - communication: clarity, fluency, confidence, listening
@@ -178,6 +180,7 @@ export async function triggerTranscriptAnalysis(
       roleDescription: role.description,
       roleRequirements: role.requirements,
       packQuestions,
+      priorityKeywords: role.priorityKeywords,
     })
 
     // Write analysis result (upsert to support re-analysis)

--- a/src/lib/scores/staleness.ts
+++ b/src/lib/scores/staleness.ts
@@ -1,0 +1,37 @@
+/**
+ * Score staleness — detects when a candidate's score is outdated relative to
+ * the current state of the role's manager priority keywords.
+ *
+ * Per Epic #42: when a recruiter edits role.priorityKeywords, the role's
+ * priorityKeywordsUpdatedAt timestamp is bumped. Any pre-existing score whose
+ * own updatedAt is earlier than that bump is "outdated" — it was scored
+ * against a different priority set.
+ *
+ * Per DEC-009 precedent, we DO NOT auto-rescore. Instead the UI surfaces a
+ * "Priorities updated" pill on outdated scores, and the recruiter clicks to
+ * trigger a rescore manually.
+ */
+
+interface ScoreLike {
+  updatedAt?: Date | string | null
+  createdAt?: Date | string | null
+}
+
+interface RoleLike {
+  priorityKeywordsUpdatedAt?: Date | string | null
+}
+
+export function isScoreOutdatedAgainstPriorities(
+  score: ScoreLike,
+  role: RoleLike,
+): boolean {
+  if (!role.priorityKeywordsUpdatedAt) return false
+  const scoreTime = score.updatedAt ?? score.createdAt
+  if (!scoreTime) return false
+  const scoreDate = scoreTime instanceof Date ? scoreTime : new Date(scoreTime)
+  const roleDate =
+    role.priorityKeywordsUpdatedAt instanceof Date
+      ? role.priorityKeywordsUpdatedAt
+      : new Date(role.priorityKeywordsUpdatedAt)
+  return scoreDate.getTime() < roleDate.getTime()
+}

--- a/tests/unit/ai/priorities.test.ts
+++ b/tests/unit/ai/priorities.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { formatManagerPriorities } from '@/lib/ai/priorities'
+
+describe('formatManagerPriorities', () => {
+  it('returns empty string for empty array (regression-safe)', () => {
+    expect(formatManagerPriorities([])).toBe('')
+  })
+
+  it('returns empty string for null', () => {
+    expect(formatManagerPriorities(null)).toBe('')
+  })
+
+  it('returns empty string for undefined', () => {
+    expect(formatManagerPriorities(undefined)).toBe('')
+  })
+
+  it('returns empty string when all entries are whitespace', () => {
+    expect(formatManagerPriorities(['  ', '\t', ''])).toBe('')
+  })
+
+  it('builds the priorities block for a single phrase', () => {
+    const out = formatManagerPriorities(['Self-starting'])
+    expect(out).toContain('MANAGER PRIORITIES (soft signals')
+    expect(out).toContain('- Self-starting')
+    expect(out).toContain('do NOT directly penalize or boost overall_score')
+  })
+
+  it('renders multiple phrases as bullets in input order', () => {
+    const out = formatManagerPriorities([
+      'Engineer who codes',
+      'Self-starting',
+      'Uses Claude Code',
+    ])
+    expect(out).toContain('- Engineer who codes')
+    expect(out).toContain('- Self-starting')
+    expect(out).toContain('- Uses Claude Code')
+    // Order preserved
+    expect(out.indexOf('Engineer who codes')).toBeLessThan(out.indexOf('Self-starting'))
+    expect(out.indexOf('Self-starting')).toBeLessThan(out.indexOf('Uses Claude Code'))
+  })
+
+  it('trims whitespace from each phrase', () => {
+    const out = formatManagerPriorities(['  Self-starting  ', '\tUses Claude Code\n'])
+    expect(out).toContain('- Self-starting')
+    expect(out).toContain('- Uses Claude Code')
+    expect(out).not.toContain('-   Self-starting')
+  })
+
+  it('drops whitespace-only entries from a mixed array', () => {
+    const out = formatManagerPriorities(['Self-starting', '   ', 'Uses Claude Code'])
+    expect(out).toContain('- Self-starting')
+    expect(out).toContain('- Uses Claude Code')
+    expect(out).not.toContain('-   ')
+    expect(out).not.toContain('- \n')
+  })
+
+  it('starts with a blank line for prompt separation', () => {
+    const out = formatManagerPriorities(['x'])
+    expect(out.startsWith('\n')).toBe(true)
+  })
+})

--- a/tests/unit/ui/chip-input.test.tsx
+++ b/tests/unit/ui/chip-input.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * Unit tests for the generic ChipInput component.
+ *
+ * Covers controlled-component behaviour: chip rendering, commit triggers
+ * (Enter / comma), trimming, case-insensitive dedupe, backspace removal,
+ * X-button removal, and the maxChips / maxLength constraints.
+ *
+ * Uses @testing-library/user-event for realistic keyboard interactions.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+import { ChipInput } from '@/components/ui/chip-input'
+
+/**
+ * Tiny harness that lets userEvent drive a controlled ChipInput.
+ * Tests assert against `onChange` *and* against rendered chips, so we
+ * thread a real state hook through the component.
+ */
+function Harness({
+  initial = [],
+  onChange,
+  maxChips,
+  maxLength,
+  placeholder,
+}: {
+  initial?: string[]
+  onChange?: (next: string[]) => void
+  maxChips?: number
+  maxLength?: number
+  placeholder?: string
+}) {
+  const [chips, setChips] = useState<string[]>(initial)
+  return (
+    <ChipInput
+      value={chips}
+      onChange={(next) => {
+        setChips(next)
+        onChange?.(next)
+      }}
+      maxChips={maxChips}
+      maxLength={maxLength}
+      placeholder={placeholder ?? 'Add keyword'}
+    />
+  )
+}
+
+describe('<ChipInput />', () => {
+  it('renders no chips when value is empty', () => {
+    render(<Harness />)
+
+    // The input is present, no remove buttons exist.
+    expect(screen.getByPlaceholderText('Add keyword')).toBeInTheDocument()
+    expect(screen.queryAllByRole('button')).toHaveLength(0)
+  })
+
+  it('renders existing chips passed via value', () => {
+    render(<Harness initial={['python', 'kubernetes', 'aws']} />)
+
+    expect(screen.getByText('python')).toBeInTheDocument()
+    expect(screen.getByText('kubernetes')).toBeInTheDocument()
+    expect(screen.getByText('aws')).toBeInTheDocument()
+    // One remove button per chip.
+    expect(screen.getAllByRole('button')).toHaveLength(3)
+  })
+
+  it('commits a new chip when Enter is pressed', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<Harness onChange={onChange} />)
+
+    const input = screen.getByPlaceholderText('Add keyword')
+    await user.type(input, 'python{Enter}')
+
+    expect(onChange).toHaveBeenLastCalledWith(['python'])
+    expect(screen.getByText('python')).toBeInTheDocument()
+    expect(input).toHaveValue('')
+  })
+
+  it('commits a new chip when comma is pressed', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<Harness onChange={onChange} />)
+
+    const input = screen.getByPlaceholderText('Add keyword')
+    await user.type(input, 'kubernetes,')
+
+    expect(onChange).toHaveBeenLastCalledWith(['kubernetes'])
+    expect(screen.getByText('kubernetes')).toBeInTheDocument()
+    expect(input).toHaveValue('')
+  })
+
+  it('does not commit a whitespace-only draft', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<Harness onChange={onChange} />)
+
+    const input = screen.getByPlaceholderText('Add keyword')
+    await user.type(input, '   {Enter}')
+
+    expect(onChange).not.toHaveBeenCalled()
+    expect(screen.queryAllByRole('button')).toHaveLength(0)
+  })
+
+  it('rejects duplicate chips case-insensitively', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<Harness initial={['Python']} onChange={onChange} />)
+
+    const input = screen.getByPlaceholderText('Add keyword')
+    await user.type(input, 'python{Enter}')
+
+    expect(onChange).not.toHaveBeenCalled()
+    // Only the original chip remains.
+    expect(screen.getAllByText(/python/i)).toHaveLength(1)
+  })
+
+  it('removes the last chip on Backspace when input is empty', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<Harness initial={['python', 'kubernetes']} onChange={onChange} />)
+
+    const input = screen.getByPlaceholderText('Add keyword')
+    input.focus()
+    await user.keyboard('{Backspace}')
+
+    expect(onChange).toHaveBeenLastCalledWith(['python'])
+    expect(screen.queryByText('kubernetes')).not.toBeInTheDocument()
+    expect(screen.getByText('python')).toBeInTheDocument()
+  })
+
+  it('does not remove a chip on Backspace when the input is non-empty', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<Harness initial={['python']} onChange={onChange} />)
+
+    const input = screen.getByPlaceholderText('Add keyword')
+    // Type then backspace one char — no chip removal should happen.
+    await user.type(input, 'a{Backspace}')
+
+    expect(onChange).not.toHaveBeenCalled()
+    expect(screen.getByText('python')).toBeInTheDocument()
+  })
+
+  it('removes a chip when its X button is clicked', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<Harness initial={['python', 'kubernetes']} onChange={onChange} />)
+
+    await user.click(screen.getByRole('button', { name: 'Remove python' }))
+
+    expect(onChange).toHaveBeenLastCalledWith(['kubernetes'])
+    expect(screen.queryByText('python')).not.toBeInTheDocument()
+    expect(screen.getByText('kubernetes')).toBeInTheDocument()
+  })
+
+  it('hides the input and shows "Max reached" when maxChips is hit', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<Harness initial={['a', 'b']} maxChips={2} onChange={onChange} />)
+
+    expect(screen.queryByPlaceholderText('Add keyword')).not.toBeInTheDocument()
+    expect(screen.getByText('Max reached')).toBeInTheDocument()
+
+    // No way to commit a new chip — but also assert defensively that
+    // user.click of the existing X still works (i.e. the limit doesn't lock the UI).
+    await user.click(screen.getByRole('button', { name: 'Remove b' }))
+    expect(onChange).toHaveBeenLastCalledWith(['a'])
+  })
+
+  it('passes the maxLength prop through to the underlying input', () => {
+    render(<Harness maxLength={50} />)
+
+    const input = screen.getByPlaceholderText('Add keyword') as HTMLInputElement
+    expect(input).toHaveAttribute('maxLength', '50')
+  })
+
+  it('trims surrounding whitespace before committing', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<Harness onChange={onChange} />)
+
+    const input = screen.getByPlaceholderText('Add keyword')
+    await user.type(input, '  python  {Enter}')
+
+    expect(onChange).toHaveBeenLastCalledWith(['python'])
+  })
+})


### PR DESCRIPTION
## Summary

Closes Epic #42 (sub-issues #43–#49).

Adds a `priorityKeywords` field to roles — a list of manager-supplied short phrases like "Engineer who codes, not a developer who knows infra", "Self-starting", "Uses Claude Code" — and threads it as a soft signal into all six AI helpers that consume role context.

## What's in this PR

| Commit | Item | Coverage |
|---|---|---|
| `584ce3f` | #43 schema + migration 0014 | `roles.priority_keywords text[]` + `roles.priority_keywords_updated_at timestamp` |
| `5dd13d2` | #45 priorities helper + 9 tests | `formatManagerPriorities(keywords)` — single source of truth for prompt template |
| `f17d404` | #44 ChipInput component + 12 tests | Generic `<ChipInput>` for any array-of-phrases input |
| `3ece264` | #46 server actions + role forms | Zod schema, audit-log diff metadata, `priorityKeywordsUpdatedAt` bump only on change |
| `2dc3f84` | #47 + #49 panel + stale pill | `<PriorityKeywordsPanel>` on role detail + `<StaleScorePill>` on role + candidate detail |
| `52136b1` | #48 AI plumbing | priorities block inserted in `claude.ts`, `transcript-analysis.ts`, `interview.ts`, `role-fit.ts`, `shortlist-summary.ts` |
| `91ded45` | #48 follow-up | wired through to `gemini.ts` + `matching.ts` + `shortlist-summary` action |

## Architectural pattern

Soft signal in the cached role-context block — mirrors DEC-009. **NOT a fifth scored dimension.** The four numeric dimensions (technical_skills, experience_level, cultural_fit, communication) stay exactly as they are. Priorities only influence the AI's reasoning text and summary, never the numeric score.

Empty `priorityKeywords` array → `formatManagerPriorities()` returns `''` → prompts are byte-identical to the pre-feature baseline (regression-safe).

## Stale-score signal

When a recruiter edits role priorities, `priorityKeywordsUpdatedAt` is bumped. Any score whose `updatedAt < priorityKeywordsUpdatedAt` is "outdated" → small "Priorities updated · rescore" pill appears next to it (yellow, click-through to existing rescore action). No auto-rescore (DEC-009 precedent).

## Test plan

- [x] **Migration**: applied to live dev DB after pg_dump backup → both columns visible
- [x] **Typecheck**: zero new errors. Same 6 pre-existing errors in `tests/integration/api/transcripts.test.ts` (out of scope)
- [x] **Vitest**: 146 pass / 12 pre-existing fail (unchanged from baseline). New: 9 priorities + 12 ChipInput tests added
- [x] **Smoke**: existing PDF export routes still return 401 (route registration intact, no regression)
- [ ] **Manual smoke** (after merge):
  1. Create role with priorities `["Engineer who codes", "Self-starting", "Uses Claude Code"]`
  2. Score a candidate → AI summary mentions one or more priorities
  3. Edit priorities (add "Mentors juniors", remove "Self-starting") → existing score shows "Priorities updated · rescore" pill
  4. Click pill → rescore happens → new summary reflects new priorities
  5. Run interview transcript analysis → priorities also surface
  6. Empty priorities → behaves identically to pre-PR (regression check)

## Coverage map

| Pipeline | Wired? |
|---|---|
| CV scoring (Claude) | ✅ via `claude.ts` + `scoring.ts` |
| CV scoring (Gemini fallback) | ✅ via `gemini.ts` |
| Interview transcript analysis | ✅ via `transcript-analysis.ts` |
| Interview pack generation | ✅ via `interview.ts` (full row passed) |
| Role-fit batch (per-CV across roles) | ✅ via `role-fit.ts` + `matching.ts` |
| Shortlist summary | ✅ via `shortlist-summary.ts` action |

## Backups

- `.backups/skillai-pre-priority-keywords-20260427-170122.sql` (9.2MB, NOT committed)
- Restore: `docker compose exec -T db psql -U skillai -d skillai < .backups/skillai-pre-priority-keywords-20260427-170122.sql`
- Migration rollback: `ALTER TABLE roles DROP COLUMN priority_keywords, DROP COLUMN priority_keywords_updated_at;`

## Future work (issues to open)

Per Epic #42 "Future work" section:
1. Customer-level default priorities (pre-populate from customer)
2. Tenant-level keyword library / autosuggest
3. Negative keywords / red flags
4. Per-keyword evidence in scoring output (`priorityMatches: { keyword, evidence, alignment }[]`)
5. Filter candidate list by priority keyword match (depends on 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)