### PR TITLE
fix(build): partial mitigation of Next 16 useContext-null prerender bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "file-type": "^22.0.1",
         "lucide-react": "^1.8.0",
         "mammoth": "^1.12.0",
-        "next": "16.2.3",
+        "next": "16.2.4",
         "next-auth": "^5.0.0-beta.30",
         "node-odt": "^1.0.1",
         "pdf-parse": "^2.4.5",
@@ -2525,9 +2525,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.3.tgz",
-      "integrity": "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
+      "integrity": "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2541,9 +2541,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.3.tgz",
-      "integrity": "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
+      "integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
       "cpu": [
         "arm64"
       ],
@@ -2557,9 +2557,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.3.tgz",
-      "integrity": "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
+      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
       "cpu": [
         "x64"
       ],
@@ -2573,9 +2573,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.3.tgz",
-      "integrity": "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
+      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
       "cpu": [
         "arm64"
       ],
@@ -2589,9 +2589,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.3.tgz",
-      "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
+      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
       "cpu": [
         "arm64"
       ],
@@ -2605,9 +2605,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.3.tgz",
-      "integrity": "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
+      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
       "cpu": [
         "x64"
       ],
@@ -2621,9 +2621,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.3.tgz",
-      "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
+      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
       "cpu": [
         "x64"
       ],
@@ -2637,9 +2637,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.3.tgz",
-      "integrity": "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
+      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
       "cpu": [
         "arm64"
       ],
@@ -2653,9 +2653,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.3.tgz",
-      "integrity": "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
+      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
       "cpu": [
         "x64"
       ],
@@ -10726,12 +10726,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.3.tgz",
-      "integrity": "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
+      "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.3",
+        "@next/env": "16.2.4",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -10745,14 +10745,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.3",
-        "@next/swc-darwin-x64": "16.2.3",
-        "@next/swc-linux-arm64-gnu": "16.2.3",
-        "@next/swc-linux-arm64-musl": "16.2.3",
-        "@next/swc-linux-x64-gnu": "16.2.3",
-        "@next/swc-linux-x64-musl": "16.2.3",
-        "@next/swc-win32-arm64-msvc": "16.2.3",
-        "@next/swc-win32-x64-msvc": "16.2.3",
+        "@next/swc-darwin-arm64": "16.2.4",
+        "@next/swc-darwin-x64": "16.2.4",
+        "@next/swc-linux-arm64-gnu": "16.2.4",
+        "@next/swc-linux-arm64-musl": "16.2.4",
+        "@next/swc-linux-x64-gnu": "16.2.4",
+        "@next/swc-linux-x64-musl": "16.2.4",
+        "@next/swc-win32-arm64-msvc": "16.2.4",
+        "@next/swc-win32-x64-msvc": "16.2.4",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "file-type": "^22.0.1",
     "lucide-react": "^1.8.0",
     "mammoth": "^1.12.0",
-    "next": "16.2.3",
+    "next": "16.2.4",
     "next-auth": "^5.0.0-beta.30",
     "node-odt": "^1.0.1",
     "pdf-parse": "^2.4.5",

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -3,6 +3,12 @@ import { redirect } from 'next/navigation'
 import { Sidebar } from '@/components/layout/sidebar'
 import { Providers } from '@/components/providers'
 
+// Dashboard pages all depend on the authenticated session, so they cannot be
+// statically prerendered. Marking the segment dynamic also avoids the
+// useContext null prerender error in Next 16 / React 19 caused by the
+// `next-auth/react` module-scope hook initialization (#41).
+export const dynamic = 'force-dynamic'
+
 export default async function DashboardLayout({
   children,
 }: {

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+// Custom global-error component — replaces Next 16's built-in /_global-error
+// page. The framework default page currently has a Next 16.2 / React 19 bug
+// that throws `Cannot read properties of null (reading 'useContext')` during
+// static prerender (#41). Even with this override the framework wrapper still
+// fails on prerender — but the runtime path uses our component, so users
+// see this UI when an actual error occurs at runtime.
+//
+// global-error.tsx must be a client component and must include its own
+// <html> and <body> because it replaces the root layout.
+
+export const dynamic = 'force-dynamic'
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen flex items-center justify-center bg-zinc-950 text-zinc-200 p-6">
+        <div className="max-w-md text-center">
+          <h1 className="text-2xl font-semibold mb-2">Something went wrong</h1>
+          <p className="text-sm text-zinc-400 mb-4">
+            An unexpected error has occurred. The team has been notified.
+          </p>
+          {error.digest && (
+            <p className="text-xs text-zinc-500 mb-4 font-mono">
+              Error ref: {error.digest}
+            </p>
+          )}
+          <button
+            onClick={reset}
+            className="rounded-md border border-zinc-600 bg-zinc-800 px-4 py-2 text-sm text-zinc-200 hover:bg-zinc-700"
+          >
+            Try again
+          </button>
+        </div>
+      </body>
+    </html>
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,6 +17,13 @@ export const metadata: Metadata = {
   description: "AI-powered candidate ranking and interview management",
 };
 
+// SkillAI is a session-gated internal tool. There are no public-facing pages
+// that benefit from static prerendering, and Next 16.2 / React 19 has a framework
+// bug that throws `Cannot read properties of null (reading 'useContext')` during
+// static prerender of any route under this layout (#41). Marking the segment
+// dynamic skips static prerender entirely; pages still render on request.
+export const dynamic = 'force-dynamic';
+
 export default function RootLayout({
   children,
 }: Readonly<{

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,10 @@
 import { redirect } from 'next/navigation'
 
+// Mark as dynamic so Next.js doesn't attempt a static prerender of a redirect-only
+// page. Static prerender of `/` triggers a useContext null in Next 16.2 / React 19
+// (#41). Since this page only redirects, dynamic rendering has zero downside.
+export const dynamic = 'force-dynamic'
+
 export default function RootPage() {
   redirect('/dashboard')
 }


### PR DESCRIPTION
Partial fix for #41. Real upstream Next.js bug — does NOT fully resolve the build, but reduces blast radius significantly and adds a properly-styled custom global-error.

## Investigation summary

The error is `TypeError: Cannot read properties of null (reading 'useContext')` during static prerender. Confirmed:

- Reproduces on **Next 16.2.3, 16.2.4, AND 16.3.0-canary.2** with React 19.2.4 — genuine upstream bug
- Failing page progression as fixes were applied:
  - Initial: `/` fails → no pages succeed
  - After force-dynamic on `/`: `/settings` (dashboard) fails
  - After force-dynamic on dashboard layout: `/_global-error` (framework page) fails
  - After force-dynamic on root layout AND custom global-error.tsx: still `/_global-error` fails
  - Cannot bypass — framework wraps user global-error in framework code that hits the bug
- Even minimal global-error (just `<html><body>Error</body></html>`) doesn't bypass

## What this PR fixes

| Change | Effect |
|---|---|
| `next` 16.2.3 → 16.2.4 | Latest stable patch (security/bugfix, even if specific bug not fixed) |
| `src/app/page.tsx` force-dynamic | `/` is a redirect, no SEO need — was the first failing page |
| `src/app/(dashboard)/layout.tsx` force-dynamic | Dashboard pages need auth, can't be statically rendered anyway |
| `src/app/layout.tsx` force-dynamic | Internal session-gated tool, no static-prerender benefit |
| `src/app/global-error.tsx` new | Properly-styled error UI for runtime — framework still has the prerender bug but the user-facing component is now ours |

**Page-prerender progress:** 0/30 (full crash) → 7/15 before hitting framework page.

## What this PR does NOT fix

`/_global-error` is Next.js framework-internal. User code can't reach the wrapper. Build still fails at this point. Tracking as upstream-blocked in #41.

## Effects

- ✅ `next dev` (Turbopack) — unaffected, still works
- ✅ Authenticated /dashboard returns 307 — correct behaviour
- ✅ All Epic #28 + #42 features still functional
- ❌ `next build` (production build) — still fails at the framework page

## Test plan

- [x] `next dev` works
- [x] /dashboard returns 307 (auth redirect, correct)
- [x] Existing tests still pass
- [ ] Visual smoke after merge: load /login, fail an auth, see error UI uses new global-error styling

## Next steps for #41

1. File a Next.js bug report with reproduction (this codebase as repro). Likely a React 19.2 + Next 16.2 framework regression.
2. Watch upstream for fix; bump version when released.
3. Until then: production builds (`docker compose build`) fail. Existing running container (4+ days old, built before bug surfaced) continues to work fine. Plan deploy strategy accordingly — either keep the running container OR resolve before next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)