### PR TITLE
feat: Multi-language interview + screening packs (Epic #85)

### DIFF
--- a/src/actions/interview.ts
+++ b/src/actions/interview.ts
@@ -13,12 +13,14 @@ import {
 import { requireRole } from '@/lib/auth/require-role'
 import { inferExperienceLevel } from '@/lib/ai/interview-helpers'
 import { getActionContext } from '@/lib/auth/action-context'
+import { SUPPORTED_LANGUAGES } from '@/lib/ai/language'
 
 const CreatePackSchema = z.object({
   candidateId: z.string().uuid(),
   roleId: z.string().uuid(),
   includeCodeChallenge: z.boolean().default(false),
   packType: z.enum(['full', 'pre_screening']).default('full'),
+  language: z.enum(SUPPORTED_LANGUAGES).default('en'),
 })
 
 export type CreatePackState =
@@ -42,10 +44,11 @@ export async function createInterviewPack(
     roleId: formData.get('roleId'),
     includeCodeChallenge: formData.get('includeCodeChallenge') === 'true',
     packType: formData.get('packType') || 'full',
+    language: formData.get('language') || 'en',
   })
   if (!parsed.success) return { success: false, error: 'Invalid input' }
 
-  const { candidateId, roleId, packType } = parsed.data
+  const { candidateId, roleId, packType, language } = parsed.data
   // Pre-screening never includes code challenge
   const includeCodeChallenge = packType === 'pre_screening' ? false : parsed.data.includeCodeChallenge
 
@@ -70,6 +73,7 @@ export async function createInterviewPack(
       experienceLevel,
       includesCodeChallenge: includeCodeChallenge,
       packType,
+      language,
       createdBy: userId,
     })
   })

--- a/src/actions/settings.ts
+++ b/src/actions/settings.ts
@@ -9,6 +9,7 @@ import { requireRole } from '@/lib/auth/require-role'
 import { encrypt } from '@/lib/crypto'
 import { getActionContext } from '@/lib/auth/action-context'
 import { writeAuditLog } from '@/lib/audit'
+import { isSupportedLanguage } from '@/lib/ai/language'
 
 const ALLOWED_KEYS = [
   'anthropic_api_key',
@@ -280,4 +281,70 @@ export async function getTrustedHosts(tenantId: string): Promise<string[]> {
   } catch {
     return []
   }
+}
+
+// ---------------------------------------------------------------------------
+// Default pack language (tenant-wide fallback for interview/screening pack
+// generation when the candidate has no language preference). Stored as plain
+// text under tenant_settings.key = 'default_pack_language' — a BCP 47 short
+// code from SUPPORTED_LANGUAGES (en, pl, de, ...).
+// ---------------------------------------------------------------------------
+
+const DEFAULT_PACK_LANGUAGE_KEY = 'default_pack_language'
+
+export async function saveDefaultPackLanguage(
+  language: string
+): Promise<TrustedHostsState> {
+  const ctx = await getActionContext()
+  if (!ctx) return { success: false, error: 'Unauthorized' }
+  const { tenantId, userId, userRole } = ctx
+
+  try { requireRole(userRole ?? undefined, 'admin') } catch {
+    return { success: false, error: 'Only admins can set the default pack language' }
+  }
+
+  if (!isSupportedLanguage(language)) {
+    return { success: false, error: 'Unsupported language code' }
+  }
+
+  // Read previous for audit diff
+  const previous = await getDefaultPackLanguage(tenantId)
+
+  await withTenant(tenantId, async (tx) => {
+    await tx
+      .insert(tenantSettings)
+      .values({ tenantId, key: DEFAULT_PACK_LANGUAGE_KEY, value: language, updatedBy: userId })
+      .onConflictDoUpdate({
+        target: [tenantSettings.tenantId, tenantSettings.key],
+        set: { value: language, updatedBy: userId, updatedAt: new Date() },
+      })
+  })
+
+  if (previous !== language) {
+    writeAuditLog(tenantId, {
+      action: 'settings.default_pack_language_updated',
+      entityType: 'settings',
+      metadata: { setting: DEFAULT_PACK_LANGUAGE_KEY, previous, current: language },
+    }).catch(() => {})
+  }
+
+  revalidatePath('/dashboard/settings')
+  return { success: true }
+}
+
+export async function getDefaultPackLanguage(tenantId: string): Promise<string> {
+  const rows = await withTenant(tenantId, async (tx) =>
+    tx
+      .select({ value: tenantSettings.value })
+      .from(tenantSettings)
+      .where(
+        and(
+          eq(tenantSettings.tenantId, tenantId),
+          eq(tenantSettings.key, DEFAULT_PACK_LANGUAGE_KEY)
+        )
+      )
+      .limit(1)
+  )
+  const value = rows[0]?.value
+  return isSupportedLanguage(value) ? value : 'en'
 }

--- a/src/app/(dashboard)/dashboard/candidates/[candidateId]/interview/[packId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/candidates/[candidateId]/interview/[packId]/page.tsx
@@ -95,6 +95,11 @@ export default async function InterviewPackPage({ params }: Props) {
                 Pre-screening · 30 min
               </span>
             )}
+            {pack.language && pack.language !== 'en' && (
+              <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-zinc-800 text-zinc-300 border border-zinc-700">
+                {pack.language.toUpperCase()}
+              </span>
+            )}
             {pack.experienceLevel && (
               <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-blue-950 text-blue-300 border border-blue-700 capitalize">
                 {pack.experienceLevel} level

--- a/src/app/(dashboard)/dashboard/candidates/[candidateId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/candidates/[candidateId]/page.tsx
@@ -26,6 +26,7 @@ import { CvFilePanel } from '@/components/candidates/cv-file-panel'
 import { TranscriptSection } from '@/components/transcripts/transcript-section'
 import { archiveCandidate } from '@/actions/candidates'
 import { rescoreCandidate } from '@/actions/scores'
+import { getDefaultPackLanguage } from '@/actions/settings'
 import { hasRole } from '@/lib/auth/require-role'
 import { StaleScorePill } from '@/components/roles/priority-keywords-panel'
 import { isScoreOutdatedAgainstPriorities } from '@/lib/scores/staleness'
@@ -71,6 +72,7 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
     calendarConns,
     [enrichmentRow],
     [cvProfileRow],
+    tenantDefaultLanguage,
   ] = await Promise.all([
     withTenant(tenantId, async (tx) =>
       tx
@@ -122,6 +124,8 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
         .where(eq(cvProfiles.candidateId, candidateId))
         .limit(1)
     ),
+    // Tenant-wide default pack language (3-tier fallback: candidate → tenant → 'en')
+    getDefaultPackLanguage(tenantId),
   ])
 
   const activeScore = roleId
@@ -419,6 +423,7 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
                   roleId={role.id}
                   roleName={role.title}
                   candidateLanguages={candidate.languagesSpoken ?? []}
+                  tenantDefaultLanguage={tenantDefaultLanguage}
                 />
               ))}
             </div>

--- a/src/app/(dashboard)/dashboard/candidates/[candidateId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/candidates/[candidateId]/page.tsx
@@ -418,6 +418,7 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
                   candidateId={candidateId}
                   roleId={role.id}
                   roleName={role.title}
+                  candidateLanguages={candidate.languagesSpoken ?? []}
                 />
               ))}
             </div>

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -8,6 +8,7 @@ import {
   getConfiguredKeys,
   getGeneralSettings,
   getTrustedHosts,
+  getDefaultPackLanguage,
 } from '@/actions/settings'
 import { listTenantUsers } from '@/actions/users'
 import { ApiKeyField } from '@/components/settings/api-key-field'
@@ -18,6 +19,7 @@ import { CalendarConnect } from '@/components/settings/calendar-connect'
 import { AccountSection } from '@/components/settings/account-section'
 import { CreateUserForm } from '@/components/settings/create-user-form'
 import { TrustedHostsForm } from '@/components/settings/trusted-hosts-form'
+import { DefaultLanguageForm } from '@/components/settings/default-language-form'
 import { AiUsagePanel } from '@/components/settings/ai-usage-panel'
 
 export default async function SettingsPage() {
@@ -30,6 +32,7 @@ export default async function SettingsPage() {
   const generalSettings = isAdmin ? await getGeneralSettings(tenantId) : {}
   const tenantUsers = isAdmin ? await listTenantUsers() : []
   const trustedHosts = isAdmin ? await getTrustedHosts(tenantId) : []
+  const defaultPackLanguage = isAdmin ? await getDefaultPackLanguage(tenantId) : 'en'
 
   // Calendar connections are per-user, not per-tenant — query directly
   const userId = session.user.id
@@ -150,6 +153,11 @@ export default async function SettingsPage() {
                 unit="MB"
               />
             </div>
+          </div>
+
+          {/* Default pack language */}
+          <div>
+            <DefaultLanguageForm initial={defaultPackLanguage} />
           </div>
 
           {/* Trusted Hosts */}

--- a/src/app/api/candidates/[candidateId]/interview-packs/route.ts
+++ b/src/app/api/candidates/[candidateId]/interview-packs/route.ts
@@ -26,6 +26,7 @@ export async function GET(
         recommendedDurationMinutes: interviewPacks.recommendedDurationMinutes,
         includesCodeChallenge: interviewPacks.includesCodeChallenge,
         packType: interviewPacks.packType,
+        language: interviewPacks.language,
         createdAt: interviewPacks.createdAt,
         updatedAt: interviewPacks.updatedAt,
         roleTitle: roles.title,

--- a/src/app/api/interview-packs/generate/route.ts
+++ b/src/app/api/interview-packs/generate/route.ts
@@ -15,6 +15,7 @@ import {
 import { generateQuestions } from '@/lib/ai/interview'
 import { getOrExtractCvProfile } from '@/lib/ai/cv-profile'
 import { inferLanguage } from '@/lib/ai/interview-helpers'
+import { SUPPORTED_LANGUAGES, isSupportedLanguage, type SupportedLanguage } from '@/lib/ai/language'
 import { writeAuditLog } from '@/lib/audit'
 
 export const maxDuration = 300
@@ -22,6 +23,7 @@ export const maxDuration = 300
 const GenerateSchema = z.object({
   packId: z.string().uuid(),
   includeCodeChallenge: z.boolean().default(false),
+  language: z.enum(SUPPORTED_LANGUAGES).optional(),
 })
 
 async function setStage(tenantId: string, packId: string, stage: string) {
@@ -63,7 +65,7 @@ export async function POST(request: Request) {
   if (!parsed.success) {
     return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
   }
-  const { packId, includeCodeChallenge } = parsed.data
+  const { packId, includeCodeChallenge, language: languageFromBody } = parsed.data
 
   const [pack] = await withTenant(tenantId, async (tx) =>
     tx.select().from(interviewPacks).where(eq(interviewPacks.id, packId)).limit(1)
@@ -82,7 +84,13 @@ export async function POST(request: Request) {
 
   await withTenant(tenantId, async (tx) =>
     tx.update(interviewPacks)
-      .set({ generationStatus: 'processing', generationStage: 'Loading candidate and role data…', updatedAt: new Date() })
+      .set({
+        generationStatus: 'processing',
+        generationStage: 'Loading candidate and role data…',
+        // Persist explicit body-supplied language override so retry uses the same value
+        ...(languageFromBody ? { language: languageFromBody } : {}),
+        updatedAt: new Date(),
+      })
       .where(eq(interviewPacks.id, packId))
   )
 
@@ -112,6 +120,10 @@ export async function POST(request: Request) {
       ? 'Generating 5 pre-screening questions…'
       : 'Generating personalised interview questions…')
     const language = inferLanguage(cvProfile.technical_skills)
+    // Resolve response language: explicit body override > stored pack column > 'en'
+    const responseLanguage: SupportedLanguage =
+      languageFromBody
+      ?? (isSupportedLanguage(pack.language) ? pack.language : 'en')
     const result = await generateQuestions(
       cvProfile,
       role,
@@ -119,6 +131,7 @@ export async function POST(request: Request) {
         includeCodeChallenge,
         language,
         packType: pack.packType,
+        responseLanguage,
       },
       tenantId,
       { candidateId: pack.candidateId, roleId: pack.roleId, packId }

--- a/src/components/interview/pack-generator.tsx
+++ b/src/components/interview/pack-generator.tsx
@@ -13,45 +13,64 @@ type Props = {
   roleId: string
   roleName: string
   candidateLanguages?: string[]
+  /**
+   * Tenant-wide default pack language (BCP 47 short code). Used when the
+   * candidate has no usable language preference. Falls through to 'en' if
+   * absent or unsupported.
+   */
+  tenantDefaultLanguage?: string
 }
 type PackType = 'full' | 'pre_screening'
 
 /**
- * Resolve the default pack language from the candidate's spoken languages.
- * Picks the first entry that maps to a SupportedLanguage; otherwise falls back
- * to English. Matches both BCP 47 codes ('pl') and full names ('Polish').
+ * Resolve the default pack language using the 3-tier fallback chain:
+ *   1. candidate.languagesSpoken[0..n] (first entry that maps to a SupportedLanguage)
+ *   2. tenant default (admin-configurable in /dashboard/settings)
+ *   3. 'en'
+ *
+ * Matches both BCP 47 codes ('pl') and full names ('Polish').
  */
-function resolveDefaultLanguage(candidateLanguages: string[] | undefined): SupportedLanguage {
-  if (!candidateLanguages?.length) return 'en'
-  for (const raw of candidateLanguages) {
-    const normalised = raw.trim().toLowerCase()
-    if (isSupportedLanguage(normalised)) return normalised
-    // Try mapping common display names back to a code
-    const codeFromName: Record<string, SupportedLanguage> = {
-      english: 'en',
-      polish: 'pl',
-      german: 'de',
-      french: 'fr',
-      spanish: 'es',
-      italian: 'it',
-      portuguese: 'pt',
-      dutch: 'nl',
-      czech: 'cs',
-      swedish: 'sv',
+function resolveDefaultLanguage(
+  candidateLanguages: string[] | undefined,
+  tenantDefaultLanguage: string | undefined
+): SupportedLanguage {
+  // Tier 1: candidate-spoken languages
+  if (candidateLanguages?.length) {
+    for (const raw of candidateLanguages) {
+      const normalised = raw.trim().toLowerCase()
+      if (isSupportedLanguage(normalised)) return normalised
+      // Try mapping common display names back to a code
+      const codeFromName: Record<string, SupportedLanguage> = {
+        english: 'en',
+        polish: 'pl',
+        german: 'de',
+        french: 'fr',
+        spanish: 'es',
+        italian: 'it',
+        portuguese: 'pt',
+        dutch: 'nl',
+        czech: 'cs',
+        swedish: 'sv',
+      }
+      const mapped = codeFromName[normalised]
+      if (mapped) return mapped
     }
-    const mapped = codeFromName[normalised]
-    if (mapped) return mapped
   }
+
+  // Tier 2: tenant default
+  if (isSupportedLanguage(tenantDefaultLanguage)) return tenantDefaultLanguage
+
+  // Tier 3: hard fallback
   return 'en'
 }
 
-export function PackGenerator({ candidateId, roleId, roleName, candidateLanguages }: Props) {
+export function PackGenerator({ candidateId, roleId, roleName, candidateLanguages, tenantDefaultLanguage }: Props) {
   const router = useRouter()
   const [open, setOpen] = useState(false)
   const [includeCode, setIncludeCode] = useState(false)
   const [packType, setPackType] = useState<PackType>('full')
   const [language, setLanguage] = useState<SupportedLanguage>(() =>
-    resolveDefaultLanguage(candidateLanguages)
+    resolveDefaultLanguage(candidateLanguages, tenantDefaultLanguage)
   )
 
   const isPreScreening = packType === 'pre_screening'

--- a/src/components/interview/pack-generator.tsx
+++ b/src/components/interview/pack-generator.tsx
@@ -5,15 +5,54 @@ import { useRouter } from 'next/navigation'
 import { SparklesIcon, Loader2Icon } from 'lucide-react'
 import { createInterviewPack } from '@/actions/interview'
 import type { CreatePackState } from '@/actions/interview'
+import { isSupportedLanguage, type SupportedLanguage } from '@/lib/ai/language'
+import { PackLanguagePicker } from './pack-language-picker'
 
-type Props = { candidateId: string; roleId: string; roleName: string }
+type Props = {
+  candidateId: string
+  roleId: string
+  roleName: string
+  candidateLanguages?: string[]
+}
 type PackType = 'full' | 'pre_screening'
 
-export function PackGenerator({ candidateId, roleId, roleName }: Props) {
+/**
+ * Resolve the default pack language from the candidate's spoken languages.
+ * Picks the first entry that maps to a SupportedLanguage; otherwise falls back
+ * to English. Matches both BCP 47 codes ('pl') and full names ('Polish').
+ */
+function resolveDefaultLanguage(candidateLanguages: string[] | undefined): SupportedLanguage {
+  if (!candidateLanguages?.length) return 'en'
+  for (const raw of candidateLanguages) {
+    const normalised = raw.trim().toLowerCase()
+    if (isSupportedLanguage(normalised)) return normalised
+    // Try mapping common display names back to a code
+    const codeFromName: Record<string, SupportedLanguage> = {
+      english: 'en',
+      polish: 'pl',
+      german: 'de',
+      french: 'fr',
+      spanish: 'es',
+      italian: 'it',
+      portuguese: 'pt',
+      dutch: 'nl',
+      czech: 'cs',
+      swedish: 'sv',
+    }
+    const mapped = codeFromName[normalised]
+    if (mapped) return mapped
+  }
+  return 'en'
+}
+
+export function PackGenerator({ candidateId, roleId, roleName, candidateLanguages }: Props) {
   const router = useRouter()
   const [open, setOpen] = useState(false)
   const [includeCode, setIncludeCode] = useState(false)
   const [packType, setPackType] = useState<PackType>('full')
+  const [language, setLanguage] = useState<SupportedLanguage>(() =>
+    resolveDefaultLanguage(candidateLanguages)
+  )
 
   const isPreScreening = packType === 'pre_screening'
   const effectiveIncludeCode = isPreScreening ? false : includeCode
@@ -33,6 +72,7 @@ export function PackGenerator({ candidateId, roleId, roleName }: Props) {
           packId: state.packId,
           includeCodeChallenge: effectiveIncludeCode,
           packType,
+          language,
         }),
       }).catch((err) => console.error('Failed to trigger generation:', err))
 
@@ -40,7 +80,7 @@ export function PackGenerator({ candidateId, roleId, roleName }: Props) {
       router.push(`/dashboard/candidates/${candidateId}/interview/${state.packId}`)
       router.refresh()
     }
-  }, [state, router, candidateId, effectiveIncludeCode, packType])
+  }, [state, router, candidateId, effectiveIncludeCode, packType, language])
 
   return (
     <>
@@ -82,6 +122,13 @@ export function PackGenerator({ candidateId, roleId, roleName }: Props) {
               <input type="hidden" name="roleId" value={roleId} />
               <input type="hidden" name="includeCodeChallenge" value={String(effectiveIncludeCode)} />
               <input type="hidden" name="packType" value={packType} />
+
+              {/* Language picker — defaults to candidate's primary spoken language if supported */}
+              <PackLanguagePicker
+                value={language}
+                onChange={setLanguage}
+                disabled={pending}
+              />
 
               {/* Pack type radio group */}
               <fieldset className="space-y-2">

--- a/src/components/interview/pack-language-picker.tsx
+++ b/src/components/interview/pack-language-picker.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { SUPPORTED_LANGUAGES, getDisplayName, type SupportedLanguage } from '@/lib/ai/language'
+
+interface PackLanguagePickerProps {
+  value: SupportedLanguage
+  onChange: (next: SupportedLanguage) => void
+  disabled?: boolean
+  id?: string
+}
+
+export function PackLanguagePicker({ value, onChange, disabled, id = 'pack-language' }: PackLanguagePickerProps) {
+  return (
+    <div>
+      <label htmlFor={id} className="block text-xs font-medium text-zinc-400 mb-1">
+        Pack language
+      </label>
+      <select
+        id={id}
+        name="language"
+        value={value}
+        onChange={(e) => onChange(e.target.value as SupportedLanguage)}
+        disabled={disabled}
+        className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
+                   focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+      >
+        {SUPPORTED_LANGUAGES.map((lang) => (
+          <option key={lang} value={lang}>
+            {getDisplayName(lang)} ({lang.toUpperCase()})
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}

--- a/src/components/interview/pack-list.tsx
+++ b/src/components/interview/pack-list.tsx
@@ -12,6 +12,7 @@ type Pack = {
   recommendedDurationMinutes: number | null
   includesCodeChallenge: boolean
   packType: 'full' | 'pre_screening'
+  language: string
   createdAt: string
   updatedAt: string
   roleTitle: string | null
@@ -100,6 +101,11 @@ export function PackList({ candidateId }: Props) {
                 {pack.packType === 'pre_screening' && (
                   <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-950 text-amber-300 border border-amber-800 flex-shrink-0">
                     Pre-screening
+                  </span>
+                )}
+                {pack.language && pack.language !== 'en' && (
+                  <span className="inline-flex items-center rounded-full border border-zinc-700 bg-zinc-800 px-1.5 py-0.5 text-[10px] font-medium text-zinc-300 flex-shrink-0">
+                    {pack.language.toUpperCase()}
                   </span>
                 )}
               </p>

--- a/src/components/settings/default-language-form.tsx
+++ b/src/components/settings/default-language-form.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { GlobeIcon } from 'lucide-react'
+import { saveDefaultPackLanguage } from '@/actions/settings'
+import { PackLanguagePicker } from '@/components/interview/pack-language-picker'
+import { isSupportedLanguage, type SupportedLanguage } from '@/lib/ai/language'
+
+interface DefaultLanguageFormProps {
+  /**
+   * Tenant's current default pack language. Falls back to 'en' if the stored
+   * value is not in SUPPORTED_LANGUAGES (defensive — getter already coerces).
+   */
+  initial: string
+}
+
+/**
+ * DefaultLanguageForm — admin-only editor for the per-tenant default language
+ * used by interview / pre-screening pack generation when a candidate has no
+ * explicit language preference set on their profile.
+ *
+ * Resolution chain (consumed in pack-generator.tsx):
+ *   1. candidate.languagesSpoken[0] (if it maps to a SupportedLanguage)
+ *   2. tenant default (this setting)
+ *   3. 'en'
+ */
+export function DefaultLanguageForm({ initial }: DefaultLanguageFormProps) {
+  const safe: SupportedLanguage = isSupportedLanguage(initial) ? initial : 'en'
+  const [value, setValue] = useState<SupportedLanguage>(safe)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+  const [pending, startTransition] = useTransition()
+
+  const handleSave = () => {
+    setError(null)
+    setSuccess(false)
+    startTransition(async () => {
+      const result = await saveDefaultPackLanguage(value)
+      if (result.success) {
+        setSuccess(true)
+      } else {
+        setError(result.error)
+      }
+    })
+  }
+
+  return (
+    <section className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-6">
+      <div className="flex items-center gap-2 mb-2">
+        <GlobeIcon className="h-4 w-4 text-zinc-400" aria-hidden="true" />
+        <h2 className="text-lg font-semibold text-zinc-100">Default pack language</h2>
+      </div>
+      <p className="text-xs text-zinc-500 mb-4">
+        New interview and screening packs default to this language when the
+        candidate has no language preference set.
+      </p>
+      <div className="max-w-xs">
+        <PackLanguagePicker
+          value={value}
+          onChange={(next) => {
+            setValue(next)
+            if (success) setSuccess(false)
+            if (error) setError(null)
+          }}
+          disabled={pending}
+          id="default-pack-language"
+        />
+      </div>
+      {error && <p className="mt-2 text-sm text-red-400">{error}</p>}
+      {success && (
+        <p className="mt-2 text-sm text-emerald-400">Default language updated.</p>
+      )}
+      <button
+        type="button"
+        onClick={handleSave}
+        disabled={pending}
+        className="mt-4 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-200 hover:bg-zinc-700 disabled:opacity-50"
+      >
+        {pending ? 'Saving…' : 'Save default language'}
+      </button>
+    </section>
+  )
+}

--- a/src/components/transcripts/transcript-section.tsx
+++ b/src/components/transcripts/transcript-section.tsx
@@ -7,6 +7,7 @@ import { TranscriptUploadForm } from './transcript-upload-form'
 import { TranscriptAnalysisView } from './transcript-analysis-view'
 import { FileTextIcon, ClockIcon } from 'lucide-react'
 import type { QuestionResponse } from '@/db/schema/transcript-analyses'
+import { getDisplayName, isSupportedLanguage } from '@/lib/ai/language'
 
 type Props = {
   candidateId: string
@@ -64,6 +65,7 @@ export async function TranscriptSection({ candidateId, defaultRoleId }: Props) {
           redFlags: transcriptAnalyses.redFlags,
           recommendedDecision: transcriptAnalyses.recommendedDecision,
           questionResponses: transcriptAnalyses.questionResponses,
+          detectedLanguage: transcriptAnalyses.detectedLanguage,
         })
         .from(interviewTranscripts)
         .leftJoin(transcriptAnalyses, eq(transcriptAnalyses.transcriptId, interviewTranscripts.id))
@@ -134,6 +136,13 @@ export async function TranscriptSection({ candidateId, defaultRoleId }: Props) {
                 })
               : null
 
+            // Only show the language badge for non-English analyses — keeps
+            // the UI quiet for the common English case. `detectedLanguage`
+            // may be null on rows where analysis is still pending.
+            const langCode = t.detectedLanguage
+            const showLanguageBadge =
+              isComplete && langCode && langCode !== 'en' && isSupportedLanguage(langCode)
+
             return (
               <div key={t.id} className="rounded-lg border border-zinc-700 overflow-hidden">
                 {/* Transcript header */}
@@ -144,6 +153,11 @@ export async function TranscriptSection({ candidateId, defaultRoleId }: Props) {
                       <span className="text-sm font-medium text-zinc-200">{platform}</span>
                       {interviewDateStr && (
                         <span className="ml-2 text-xs text-zinc-500">{interviewDateStr}</span>
+                      )}
+                      {showLanguageBadge && (
+                        <span className="ml-2 inline-flex items-center rounded-full border border-zinc-700 bg-zinc-800 px-1.5 py-0.5 text-[10px] font-medium text-zinc-300">
+                          Analysis in {getDisplayName(langCode)}
+                        </span>
                       )}
                     </div>
                   </div>

--- a/src/db/migrations/0018_interview_pack_language.sql
+++ b/src/db/migrations/0018_interview_pack_language.sql
@@ -1,0 +1,7 @@
+-- Migration: Multi-language interview + screening packs (Epic #85 / #86)
+-- Adds a language column to interview_packs storing the BCP 47 short code
+-- of the language the pack was generated in. Defaults to 'en' for backward
+-- compatibility — all existing packs are English.
+
+ALTER TABLE "interview_packs"
+  ADD COLUMN IF NOT EXISTS "language" varchar(10) NOT NULL DEFAULT 'en';

--- a/src/db/migrations/0019_transcript_analysis_language.sql
+++ b/src/db/migrations/0019_transcript_analysis_language.sql
@@ -1,0 +1,9 @@
+-- Migration: Multi-language transcript analysis (Epic #85 / #90)
+-- Adds a detected_language column to transcript_analyses storing the BCP 47
+-- short code of the language detected for the source transcript. The AI
+-- analysis (summary + dimension reasoning) is generated in the same language
+-- so the recruiter can read the assessment without translating. Defaults to
+-- 'en' for backward compatibility — all existing analyses are English.
+
+ALTER TABLE "transcript_analyses"
+  ADD COLUMN IF NOT EXISTS "detected_language" varchar(10) NOT NULL DEFAULT 'en';

--- a/src/db/schema/interview-packs.ts
+++ b/src/db/schema/interview-packs.ts
@@ -6,6 +6,7 @@ import {
   integer,
   boolean,
   text,
+  varchar,
   timestamp,
   index,
 } from 'drizzle-orm/pg-core'
@@ -50,6 +51,7 @@ export const interviewPacks = pgTable(
     recommendedDurationMinutes: integer('recommended_duration_minutes'),
     includesCodeChallenge: boolean('includes_code_challenge').notNull().default(false),
     packType: packTypeEnum('pack_type').notNull().default('full'),
+    language: varchar('language', { length: 10 }).notNull().default('en'),
     errorMessage: text('error_message'),
     createdBy: uuid('created_by')
       .notNull()

--- a/src/db/schema/transcript-analyses.ts
+++ b/src/db/schema/transcript-analyses.ts
@@ -9,6 +9,7 @@ import {
   timestamp,
   index,
   unique,
+  varchar,
 } from 'drizzle-orm/pg-core'
 import { sql } from 'drizzle-orm'
 import { tenants } from './tenants'
@@ -59,6 +60,12 @@ export const transcriptAnalyses = pgTable(
 
     // Per-question breakdown (populated when transcript is linked to a pack)
     questionResponses: jsonb('question_responses').$type<QuestionResponse[]>(),
+
+    // BCP 47 short code of the language the transcript was analysed in.
+    // Detected via a quick Claude Haiku probe on the raw transcript text;
+    // the analysis (summary + reasoning) is then generated in the same
+    // language. Defaults to 'en' for backward compatibility.
+    detectedLanguage: varchar('detected_language', { length: 10 }).notNull().default('en'),
 
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },

--- a/src/lib/ai/interview.ts
+++ b/src/lib/ai/interview.ts
@@ -15,6 +15,7 @@ import {
 } from './interview-schemas'
 import { inferExperienceLevel, inferLanguage } from './interview-helpers'
 import { formatManagerPriorities } from './priorities'
+import { formatLanguageDirective, TOOL_LANGUAGE_REINFORCEMENT, type SupportedLanguage } from './language'
 import { logAiUsage, anthropicUsageToInput } from './usage-logger'
 
 export { inferExperienceLevel, inferLanguage }
@@ -123,11 +124,12 @@ ${cvText.slice(0, 6000)}`,
 export async function generateQuestions(
   cvProfile: CvProfile,
   role: { title: string; description: string; requirements: string; priorityKeywords?: readonly string[] },
-  options: { includeCodeChallenge: boolean; language?: string; packType?: 'full' | 'pre_screening' },
+  options: { includeCodeChallenge: boolean; language?: string; packType?: 'full' | 'pre_screening'; responseLanguage?: SupportedLanguage },
   tenantId?: string,
   metadata?: { candidateId?: string; roleId?: string; packId?: string }
 ): Promise<InterviewPackOutput> {
   const language = options.language ?? inferLanguage(cvProfile.technical_skills)
+  const responseLanguage: SupportedLanguage = options.responseLanguage ?? 'en'
   const experienceLevel = cvProfile.experience_level ?? 'mid'
   const packType = options.packType ?? 'full'
   const isPreScreening = packType === 'pre_screening'
@@ -136,7 +138,9 @@ export async function generateQuestions(
 
   const QUESTION_TOOL: Anthropic.Tool = {
     name: 'submit_interview_pack',
-    description: 'Submit a complete interview pack',
+    description: responseLanguage === 'en'
+      ? 'Submit a complete interview pack'
+      : `Submit a complete interview pack. ${TOOL_LANGUAGE_REINFORCEMENT}`,
     input_schema: {
       type: 'object' as const,
       properties: {
@@ -207,7 +211,7 @@ ${role.requirements}${formatManagerPriorities(role.priorityKeywords)}`,
           },
           {
             type: 'text',
-            text: isPreScreening
+            text: (isPreScreening
               ? `Create a SHORT pre-screening interview pack for this ${experienceLevel}-level candidate.
 
 CANDIDATE PROFILE:
@@ -240,14 +244,14 @@ Requirements:
 - Include scoring rubric: strong/acceptable/weak answer signals
 - Include up to 2 follow-up questions per question
 ${includeCodeChallenge ? `- Include a ${language} code challenge appropriate for ${experienceLevel} level` : '- Do NOT include a code challenge'}
-- Calibrate difficulty to ${experienceLevel} level`,
+- Calibrate difficulty to ${experienceLevel} level`) + formatLanguageDirective(responseLanguage),
           },
         ],
       },
     ],
   })
 
-  console.log(`Stage 2 response: stop_reason=${response.stop_reason}, usage=${JSON.stringify(response.usage)}`)
+  console.log(`Stage 2 response: stop_reason=${response.stop_reason}, language=${responseLanguage}, usage=${JSON.stringify(response.usage)}`)
 
   if (tenantId) {
     logAiUsage({
@@ -257,7 +261,7 @@ ${includeCodeChallenge ? `- Include a ${language} code challenge appropriate for
       model: response.model,
       usage: anthropicUsageToInput(response.usage),
       durationMs: Date.now() - startedAt,
-      metadata: { ...metadata, packType, includeCodeChallenge },
+      metadata: { ...metadata, packType, includeCodeChallenge, language: responseLanguage },
     }).catch(() => {})
   }
 

--- a/src/lib/ai/language.ts
+++ b/src/lib/ai/language.ts
@@ -1,0 +1,108 @@
+/**
+ * Language directive helper — single source of truth for the
+ * "RESPONSE LANGUAGE: ..." prompt block injected into AI helpers
+ * (interview pack generation, transcript analysis, etc.)
+ *
+ * Pattern mirrors src/lib/ai/priorities.ts: helper returns '' for the
+ * default/no-op case so prompts on default-language work are byte-identical
+ * to the pre-feature baseline (regression-safe).
+ *
+ * Architectural note (per Epic #85 plan): the directive returned by this
+ * helper goes in the UNCACHED per-candidate block of AI prompts. Putting
+ * it in the cached system prompt or role block would fragment the prompt
+ * cache per language. Keep it where it is.
+ */
+
+export const SUPPORTED_LANGUAGES = [
+  'en',  // English
+  'pl',  // Polish
+  'de',  // German
+  'fr',  // French
+  'es',  // Spanish
+  'it',  // Italian
+  'pt',  // Portuguese
+  'nl',  // Dutch
+  'cs',  // Czech
+  'sv',  // Swedish
+] as const
+
+export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number]
+
+export function isSupportedLanguage(value: unknown): value is SupportedLanguage {
+  return typeof value === 'string' && (SUPPORTED_LANGUAGES as readonly string[]).includes(value)
+}
+
+/**
+ * Resolve a human-readable display name for a language code, in the
+ * given UI locale.
+ *
+ * @param language    BCP 47 short code (e.g. 'pl')
+ * @param displayIn   The locale to resolve the name in (default 'en')
+ * @returns           Display name (e.g. 'Polish' or 'polski')
+ */
+export function getDisplayName(language: SupportedLanguage, displayIn = 'en'): string {
+  try {
+    const dn = new Intl.DisplayNames([displayIn], { type: 'language' })
+    return dn.of(language) ?? language
+  } catch {
+    return language
+  }
+}
+
+/**
+ * Build the language directive prompt block for a given language.
+ *
+ * Returns '' for English — prompts on English packs are byte-identical
+ * to the pre-feature baseline (regression-safe; preserves existing
+ * prompt-cache hits).
+ *
+ * For other languages, returns a leading-newline-separated block that
+ * tells Claude/Gemini to emit values in the target language while
+ * preserving English JSON field names. Polish gets an additional
+ * formal-register clause (Pan/Pani) — Claude defaults to neutral
+ * register and drifts informal otherwise. German gets a similar Sie
+ * clause; other Tier-1 languages don't need it (English-equivalent
+ * formal register defaults are already correct).
+ */
+export function formatLanguageDirective(language: SupportedLanguage): string {
+  if (language === 'en') return ''
+
+  const displayName = getDisplayName(language, 'en')
+
+  // Per-language formal-register clause for languages with a strong
+  // formal/informal distinction. Empty string for languages where the
+  // default register is already correct.
+  const formalClause = (() => {
+    switch (language) {
+      case 'pl':
+        return '- Use formal register throughout (Pan/Pani forms, formal verb conjugations). Never use informal "ty".\n'
+      case 'de':
+        return '- Use formal register throughout (Sie / Ihr forms). Never use informal "du".\n'
+      case 'fr':
+        return '- Use formal register throughout (vous). Never use informal "tu".\n'
+      case 'it':
+        return '- Use formal register throughout (Lei). Never use informal "tu".\n'
+      case 'es':
+      case 'pt':
+        return '- Use formal register throughout (usted / o senhor / a senhora). Avoid informal "tú/tu".\n'
+      default:
+        return ''
+    }
+  })()
+
+  return `
+
+RESPONSE LANGUAGE: Generate ALL output in ${displayName} (${language}).
+- Field names stay in English (the JSON schema field names you submit).
+- All field VALUES — question text, rationale, follow-ups, scoring rubric signals, summary — must be in ${displayName}.
+${formalClause}- Keep proper nouns and established technical terms in English (Kubernetes, GraphQL, REST, CI/CD, AWS, Postgres).
+- Translate generic concepts (e.g. scalability → the equivalent term in ${displayName}; deployment → equivalent).`
+}
+
+/**
+ * Reinforcement clause for Anthropic tool descriptions. Append to the
+ * existing tool description so the model has TWO signals: one in the
+ * user message (formatLanguageDirective) and one in the tool spec.
+ */
+export const TOOL_LANGUAGE_REINFORCEMENT =
+  'Field NAMES are in English (do not translate). Field VALUES must match the language directive in the user message.'

--- a/src/lib/ai/transcript-analysis.ts
+++ b/src/lib/ai/transcript-analysis.ts
@@ -18,6 +18,12 @@ import {
   type TranscriptAnalysis,
 } from './transcript-schemas'
 import { formatManagerPriorities } from './priorities'
+import {
+  SUPPORTED_LANGUAGES,
+  formatLanguageDirective,
+  isSupportedLanguage,
+  type SupportedLanguage,
+} from './language'
 import { logAiUsage, anthropicUsageToInput } from './usage-logger'
 
 const anthropic = new Anthropic({
@@ -53,9 +59,49 @@ type AnalysisInput = {
   transcriptId?: string
 }
 
+export type AnalyzeTranscriptResult = {
+  analysis: TranscriptAnalysis
+  detectedLanguage: SupportedLanguage
+}
+
+/**
+ * Detect the primary language of a transcript using Claude Haiku.
+ * Cheap and fast (~50 tokens, sub-second). Falls back to 'en' on any
+ * uncertainty or error — analysis works either way, only the language
+ * directive injection differs.
+ */
+async function detectTranscriptLanguage(
+  transcriptText: string
+): Promise<SupportedLanguage> {
+  const sample = transcriptText.slice(0, 500)
+  try {
+    const response = await anthropic.messages.create({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 50,
+      messages: [
+        {
+          role: 'user',
+          content: `What language is this text written in? Reply ONLY with a BCP 47 short code from this list: ${SUPPORTED_LANGUAGES.join(', ')}. If uncertain or not in the list, reply "en".\n\nText:\n${sample}`,
+        },
+      ],
+    })
+    const block = response.content.find(
+      (b): b is Anthropic.TextBlock => b.type === 'text'
+    )
+    const code = block?.text.trim().toLowerCase().slice(0, 2)
+    return isSupportedLanguage(code) ? code : 'en'
+  } catch (err) {
+    console.warn(
+      `[transcript-analysis] language detection failed, defaulting to 'en':`,
+      err instanceof Error ? err.message : err
+    )
+    return 'en'
+  }
+}
+
 export async function analyzeTranscriptWithClaude(
   input: AnalysisInput
-): Promise<TranscriptAnalysis> {
+): Promise<AnalyzeTranscriptResult> {
   const questionsBlock =
     input.packQuestions && input.packQuestions.length > 0
       ? `\n\nINTERVIEW QUESTIONS (score responses against these):\n${input.packQuestions
@@ -82,7 +128,19 @@ Score 4 dimensions:
 - problem_solving: structure, approach, adaptability
 - social_fit: collaboration language, humility, team-first framing
 
-${input.packQuestions?.length ? 'Map transcript excerpts to each interview question and score quality (strong/acceptable/weak).' : 'Provide overall assessment without per-question breakdown.'}`
+${input.packQuestions?.length ? 'Map transcript excerpts to each interview question and score quality (strong/acceptable/weak).' : 'Provide overall assessment without per-question breakdown.'}
+
+Numeric scores are language-agnostic. Reasoning text and the summary must be in the response language indicated below.`
+
+  // Detect language BEFORE the main analysis call so we can inject the
+  // language directive into the uncached per-transcript block. Putting
+  // it in the cached system block would fragment the prompt cache per
+  // language. Falls back to 'en' on any failure (analysis still works).
+  const detectedLanguage = await detectTranscriptLanguage(input.transcriptText)
+  console.log(
+    `[transcript-analysis] detected language=${detectedLanguage} for transcript=${input.transcriptId ?? '<unknown>'}`
+  )
+  const languageDirective = formatLanguageDirective(detectedLanguage)
 
   const startedAt = Date.now()
   const response = await anthropic.messages.create({
@@ -107,7 +165,7 @@ ${input.packQuestions?.length ? 'Map transcript excerpts to each interview quest
                 ? input.transcriptText.slice(0, MAX_TRANSCRIPT_CHARS) +
                   '\n\n[...transcript truncated to fit AI context window...]'
                 : input.transcriptText
-            }\n\nUse the submit_transcript_analysis tool to return your structured assessment.`,
+            }\n\nUse the submit_transcript_analysis tool to return your structured assessment.${languageDirective}`,
           },
         ],
       },
@@ -138,7 +196,7 @@ ${input.packQuestions?.length ? 'Map transcript excerpts to each interview quest
     throw new Error(`Claude response failed schema validation: ${parsed.error.message}`)
   }
 
-  return parsed.data
+  return { analysis: parsed.data, detectedLanguage }
 }
 
 export async function triggerTranscriptAnalysis(
@@ -190,7 +248,7 @@ export async function triggerTranscriptAnalysis(
       }
     }
 
-    const result = await analyzeTranscriptWithClaude({
+    const { analysis: result, detectedLanguage } = await analyzeTranscriptWithClaude({
       transcriptText: transcript.rawTranscriptText,
       roleTitle: role.title,
       roleDescription: role.description,
@@ -218,6 +276,7 @@ export async function triggerTranscriptAnalysis(
       strengths: result.strengths,
       redFlags: result.red_flags,
       recommendedDecision: result.recommended_decision,
+      detectedLanguage,
       questionResponses: result.question_responses.map((qr) => ({
         questionText: qr.question_text,
         transcriptExcerpt: qr.transcript_excerpt,

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -16,6 +16,7 @@ export type AuditAction =
   | 'score.completed' | 'score.failed' | 'score.removed'
   | 'interview_pack.created' | 'interview_pack.completed' | 'interview_pack.failed'
   | 'interview_pack.deleted' | 'interview_pack.retried'
+  | 'interview_pack.generated_in_language'
   | 'interview_slot.created' | 'interview_slot.updated' | 'interview_slot.cancelled'
   | 'note.created' | 'note.deleted'
   | 'user.invited' | 'user.role_changed' | 'user.deactivated'

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -24,6 +24,7 @@ export type AuditAction =
   | 'user.password_changed'
   | 'user.email_changed'
   | 'settings.trusted_hosts_updated'
+  | 'settings.default_pack_language_updated'
   | 'auth.untrusted_host_blocked'
   | 'agency.created' | 'agency.archived'
 

--- a/src/lib/pdf/interview-pack-pdf.tsx
+++ b/src/lib/pdf/interview-pack-pdf.tsx
@@ -6,21 +6,42 @@ import {
   View,
   StyleSheet,
 } from '@react-pdf/renderer'
+import '@/lib/pdf/fonts' // side-effect: registers Inter font family (Polish + Latin Extended-A glyph support)
 import { base, colors } from './styles'
 import type { InterviewPack, InterviewQuestion, CodeChallenge } from '@/db/schema'
 
+// Local overrides of shared `base` styles. The shared `base` uses the built-in
+// PDF core font (no Latin Extended-A glyphs — Polish diacritics fail), so we
+// override per-style to use Inter, which is registered in `./fonts` with
+// numeric weights 400/500/600/700 and covers all v1 supported languages.
+// Other PDFs continue using `base` directly until they need similar coverage.
+const t = StyleSheet.create({
+  page: { ...base.page, fontFamily: 'Inter' },
+  h1: { ...base.h1, fontFamily: 'Inter', fontWeight: 700 },
+  h2: { ...base.h2, fontFamily: 'Inter', fontWeight: 700 },
+  h3: { ...base.h3, fontFamily: 'Inter', fontWeight: 700 },
+  label: { ...base.label, fontFamily: 'Inter', fontWeight: 700 },
+  text: { ...base.text, fontFamily: 'Inter' },
+  small: { ...base.small, fontFamily: 'Inter' },
+  divider: base.divider,
+  badge: { ...base.badge, fontFamily: 'Inter', fontWeight: 700 },
+  card: base.card,
+  row: base.row,
+  footer: base.footer,
+})
+
 const s = StyleSheet.create({
   statusBadge: {
-    ...base.badge,
+    ...t.badge,
     backgroundColor: colors.violet50,
     color: colors.violet700,
   },
   diffBadge: {
-    ...base.badge,
+    ...t.badge,
     marginRight: 4,
   },
   questionBox: {
-    ...base.card,
+    ...t.card,
     marginBottom: 10,
   },
   signalBox: {
@@ -59,11 +80,11 @@ type Props = {
 export function InterviewPackPDF({ pack, questions, codeChallenge, candidateName, roleTitle }: Props) {
   return (
     <Document title={`Interview Pack — ${candidateName}`}>
-      <Page size="A4" style={base.page}>
+      <Page size="A4" style={t.page}>
         {/* Header */}
         <View style={{ marginBottom: 20 }}>
-          <Text style={base.h1}>Interview Pack</Text>
-          <Text style={{ ...base.text, marginTop: 2 }}>
+          <Text style={t.h1}>Interview Pack</Text>
+          <Text style={{ ...t.text, marginTop: 2 }}>
             {candidateName} · {roleTitle}
           </Text>
           <View style={{ flexDirection: 'row', gap: 8, marginTop: 8 }}>
@@ -71,24 +92,24 @@ export function InterviewPackPDF({ pack, questions, codeChallenge, candidateName
               <Text style={{ ...s.statusBadge }}>{pack.experienceLevel} level</Text>
             )}
             {pack.recommendedDurationMinutes && (
-              <Text style={{ ...base.small }}>{pack.recommendedDurationMinutes} min recommended</Text>
+              <Text style={{ ...t.small }}>{pack.recommendedDurationMinutes} min recommended</Text>
             )}
-            <Text style={base.small}>{questions.length} questions</Text>
+            <Text style={t.small}>{questions.length} questions</Text>
           </View>
         </View>
 
-        <View style={base.divider} />
+        <View style={t.divider} />
 
         {/* Questions */}
-        <Text style={base.h2}>Interview Questions</Text>
+        <Text style={t.h2}>Interview Questions</Text>
         {questions.map((q, i) => {
           const followUps = (q.followUps as Array<{ question: string }>) ?? []
           return (
             <View key={q.id} style={s.questionBox} wrap={false}>
-              <View style={{ ...base.row, marginBottom: 6 }}>
-                <Text style={{ ...base.small, marginRight: 8, marginTop: 1 }}>{i + 1}.</Text>
+              <View style={{ ...t.row, marginBottom: 6 }}>
+                <Text style={{ ...t.small, marginRight: 8, marginTop: 1 }}>{i + 1}.</Text>
                 <View style={{ flex: 1 }}>
-                  <Text style={{ ...base.text, fontFamily: 'Helvetica-Bold' }}>
+                  <Text style={{ ...t.text, fontFamily: 'Inter', fontWeight: 700 }}>
                     {q.questionText}
                   </Text>
                   <View style={{ flexDirection: 'row', marginTop: 4, gap: 4 }}>
@@ -121,16 +142,16 @@ export function InterviewPackPDF({ pack, questions, codeChallenge, candidateName
 
               {q.rationale && (
                 <View style={{ marginBottom: 6 }}>
-                  <Text style={base.label}>Why ask this</Text>
-                  <Text style={base.text}>{q.rationale}</Text>
+                  <Text style={t.label}>Why ask this</Text>
+                  <Text style={t.text}>{q.rationale}</Text>
                 </View>
               )}
 
               {followUps.length > 0 && (
                 <View style={{ marginBottom: 6 }}>
-                  <Text style={base.label}>Follow-ups</Text>
+                  <Text style={t.label}>Follow-ups</Text>
                   {followUps.map((f, fi) => (
-                    <Text key={fi} style={{ ...base.text, marginBottom: 2 }}>
+                    <Text key={fi} style={{ ...t.text, marginBottom: 2 }}>
                       → {f.question}
                     </Text>
                   ))}
@@ -139,9 +160,9 @@ export function InterviewPackPDF({ pack, questions, codeChallenge, candidateName
 
               {q.strongAnswerSignals?.length ? (
                 <View style={{ ...s.signalBox, backgroundColor: colors.green50 }}>
-                  <Text style={{ ...base.label, color: colors.green700 }}>Strong signals</Text>
+                  <Text style={{ ...t.label, color: colors.green700 }}>Strong signals</Text>
                   {q.strongAnswerSignals.map((sig, si) => (
-                    <Text key={si} style={{ ...base.text, color: colors.green700, marginBottom: 1 }}>
+                    <Text key={si} style={{ ...t.text, color: colors.green700, marginBottom: 1 }}>
                       • {sig}
                     </Text>
                   ))}
@@ -150,11 +171,11 @@ export function InterviewPackPDF({ pack, questions, codeChallenge, candidateName
 
               {/* Notes line for interviewer */}
               <View style={{ marginTop: 6, borderTop: `1pt dashed ${colors.slate200}`, paddingTop: 4 }}>
-                <Text style={base.label}>Interviewer notes</Text>
+                <Text style={t.label}>Interviewer notes</Text>
                 {q.notes ? (
-                  <Text style={base.text}>{q.notes}</Text>
+                  <Text style={t.text}>{q.notes}</Text>
                 ) : (
-                  <Text style={{ ...base.small, color: colors.slate400 }}>
+                  <Text style={{ ...t.small, color: colors.slate400 }}>
                     ________________________________________
                   </Text>
                 )}
@@ -166,28 +187,28 @@ export function InterviewPackPDF({ pack, questions, codeChallenge, candidateName
         {/* Code challenge */}
         {codeChallenge && (
           <View>
-            <Text style={base.h2}>Code Challenge</Text>
-            <View style={base.card}>
-              <Text style={{ ...base.h3, marginBottom: 2 }}>{codeChallenge.title}</Text>
+            <Text style={t.h2}>Code Challenge</Text>
+            <View style={t.card}>
+              <Text style={{ ...t.h3, marginBottom: 2 }}>{codeChallenge.title}</Text>
               <View style={{ flexDirection: 'row', gap: 8, marginBottom: 8 }}>
                 <Text style={{ ...s.statusBadge }}>{codeChallenge.language}</Text>
                 {codeChallenge.estimatedMinutes && (
-                  <Text style={base.small}>{codeChallenge.estimatedMinutes} min</Text>
+                  <Text style={t.small}>{codeChallenge.estimatedMinutes} min</Text>
                 )}
               </View>
 
-              <Text style={base.label}>Problem</Text>
-              <Text style={{ ...base.text, marginBottom: 8 }}>{codeChallenge.problemDescription}</Text>
+              <Text style={t.label}>Problem</Text>
+              <Text style={{ ...t.text, marginBottom: 8 }}>{codeChallenge.problemDescription}</Text>
 
-              <Text style={base.label}>Starter Code</Text>
+              <Text style={t.label}>Starter Code</Text>
               <View style={s.codeBlock}>
                 <Text style={s.codeText}>{codeChallenge.starterCode}</Text>
               </View>
 
               {codeChallenge.evaluationCriteria && (
                 <View style={{ marginTop: 8 }}>
-                  <Text style={base.label}>Evaluation Criteria</Text>
-                  <Text style={base.text}>{codeChallenge.evaluationCriteria}</Text>
+                  <Text style={t.label}>Evaluation Criteria</Text>
+                  <Text style={t.text}>{codeChallenge.evaluationCriteria}</Text>
                 </View>
               )}
             </View>
@@ -195,9 +216,9 @@ export function InterviewPackPDF({ pack, questions, codeChallenge, candidateName
         )}
 
         {/* Footer */}
-        <View style={base.footer} fixed>
-          <Text style={base.small}>SkillAI — Confidential</Text>
-          <Text style={base.small} render={({ pageNumber, totalPages }) => `${pageNumber} / ${totalPages}`} />
+        <View style={t.footer} fixed>
+          <Text style={t.small}>SkillAI — Confidential</Text>
+          <Text style={t.small} render={({ pageNumber, totalPages }) => `${pageNumber} / ${totalPages}`} />
         </View>
       </Page>
     </Document>

--- a/tests/unit/ai/language.test.ts
+++ b/tests/unit/ai/language.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import {
+  SUPPORTED_LANGUAGES,
+  isSupportedLanguage,
+  getDisplayName,
+  formatLanguageDirective,
+  TOOL_LANGUAGE_REINFORCEMENT,
+} from '@/lib/ai/language'
+
+describe('SUPPORTED_LANGUAGES', () => {
+  it('contains all 10 v1 supported languages', () => {
+    expect(SUPPORTED_LANGUAGES).toEqual([
+      'en', 'pl', 'de', 'fr', 'es', 'it', 'pt', 'nl', 'cs', 'sv',
+    ])
+  })
+})
+
+describe('isSupportedLanguage', () => {
+  it('returns true for supported codes', () => {
+    expect(isSupportedLanguage('pl')).toBe(true)
+    expect(isSupportedLanguage('en')).toBe(true)
+  })
+  it('returns false for non-string', () => {
+    expect(isSupportedLanguage(123)).toBe(false)
+    expect(isSupportedLanguage(null)).toBe(false)
+    expect(isSupportedLanguage(undefined)).toBe(false)
+  })
+  it('returns false for unsupported codes', () => {
+    expect(isSupportedLanguage('zh')).toBe(false)
+    expect(isSupportedLanguage('en-US')).toBe(false)
+    expect(isSupportedLanguage('made-up')).toBe(false)
+  })
+})
+
+describe('getDisplayName', () => {
+  it('resolves Polish name in English', () => {
+    expect(getDisplayName('pl')).toBe('Polish')
+  })
+  it('resolves German name in English', () => {
+    expect(getDisplayName('de')).toBe('German')
+  })
+  it('resolves Polish name in Polish (native)', () => {
+    expect(getDisplayName('pl', 'pl').toLowerCase()).toContain('polsk')
+  })
+})
+
+describe('formatLanguageDirective', () => {
+  it('returns empty string for English (regression-safe)', () => {
+    expect(formatLanguageDirective('en')).toBe('')
+  })
+
+  it('returns a directive block for Polish that includes the Pan/Pani clause', () => {
+    const out = formatLanguageDirective('pl')
+    expect(out).toContain('RESPONSE LANGUAGE: Generate ALL output in Polish (pl)')
+    expect(out).toContain('Pan/Pani')
+    expect(out).toContain('Field names stay in English')
+    expect(out).toContain('Keep proper nouns and established technical terms in English')
+  })
+
+  it('returns a directive block for German that includes the Sie clause', () => {
+    const out = formatLanguageDirective('de')
+    expect(out).toContain('Generate ALL output in German (de)')
+    expect(out).toContain('Sie')
+  })
+
+  it('returns a directive block for French that includes the vous clause', () => {
+    const out = formatLanguageDirective('fr')
+    expect(out).toContain('vous')
+  })
+
+  it('returns a directive without formal-register clause for Dutch (no strong distinction needed)', () => {
+    const out = formatLanguageDirective('nl')
+    expect(out).toContain('RESPONSE LANGUAGE')
+    expect(out).not.toContain('Pan/Pani')
+    expect(out).not.toContain('Sie / Ihr')
+  })
+
+  it('starts with a leading blank line for prompt separation', () => {
+    expect(formatLanguageDirective('pl').startsWith('\n')).toBe(true)
+  })
+
+  it('mentions Kubernetes/GraphQL etc. as proper-noun examples', () => {
+    const out = formatLanguageDirective('pl')
+    expect(out).toContain('Kubernetes')
+    expect(out).toContain('GraphQL')
+  })
+})
+
+describe('TOOL_LANGUAGE_REINFORCEMENT', () => {
+  it('reinforces field-name-vs-value rule', () => {
+    expect(TOOL_LANGUAGE_REINFORCEMENT).toContain('Field NAMES')
+    expect(TOOL_LANGUAGE_REINFORCEMENT).toContain('English')
+  })
+})

--- a/tests/unit/ai/transcript-schemas.test.ts
+++ b/tests/unit/ai/transcript-schemas.test.ts
@@ -130,6 +130,16 @@ vi.mock('@anthropic-ai/sdk', () => ({
 describe('analyzeTranscriptWithClaude()', () => {
   let analyzeTranscriptWithClaude: typeof import('@/lib/ai/transcript-analysis').analyzeTranscriptWithClaude
 
+  // The implementation now makes TWO Anthropic calls per analysis:
+  //   1. A cheap Haiku call to detect transcript language
+  //   2. The main Sonnet analysis call
+  // Tests must mock the detection call first. We default detection to 'en'
+  // (a text block with the BCP 47 code) so the language directive is empty
+  // and the analysis prompt remains byte-identical to the pre-feature path.
+  const mockDetectionResponse = (lang = 'en') => ({
+    content: [{ type: 'text', text: lang }],
+  })
+
   beforeEach(async () => {
     mockCreate.mockReset()
     const mod = await import('@/lib/ai/transcript-analysis')
@@ -137,15 +147,17 @@ describe('analyzeTranscriptWithClaude()', () => {
   })
 
   it('returns parsed TranscriptAnalysis on valid tool_use response', async () => {
-    mockCreate.mockResolvedValueOnce({
-      content: [
-        {
-          type: 'tool_use',
-          name: 'submit_transcript_analysis',
-          input: VALID_ANALYSIS,
-        },
-      ],
-    })
+    mockCreate
+      .mockResolvedValueOnce(mockDetectionResponse('en'))
+      .mockResolvedValueOnce({
+        content: [
+          {
+            type: 'tool_use',
+            name: 'submit_transcript_analysis',
+            input: VALID_ANALYSIS,
+          },
+        ],
+      })
 
     const result = await analyzeTranscriptWithClaude({
       transcriptText: '[Alice]: I have used TypeScript for three years.',
@@ -154,15 +166,41 @@ describe('analyzeTranscriptWithClaude()', () => {
       roleRequirements: 'TypeScript, Node.js',
     })
 
-    expect(result.overall_score).toBe(78)
-    expect(result.recommended_decision).toBe('proceed')
-    expect(result.dimensions.communication.score).toBe(82)
+    expect(result.analysis.overall_score).toBe(78)
+    expect(result.analysis.recommended_decision).toBe('proceed')
+    expect(result.analysis.dimensions.communication.score).toBe(82)
+    expect(result.detectedLanguage).toBe('en')
+  })
+
+  it('returns the detected language for non-English transcripts', async () => {
+    mockCreate
+      .mockResolvedValueOnce(mockDetectionResponse('pl'))
+      .mockResolvedValueOnce({
+        content: [
+          {
+            type: 'tool_use',
+            name: 'submit_transcript_analysis',
+            input: VALID_ANALYSIS,
+          },
+        ],
+      })
+
+    const result = await analyzeTranscriptWithClaude({
+      transcriptText: 'Dzień dobry, opowiem o swoim doświadczeniu z TypeScriptem.',
+      roleTitle: 'Senior Engineer',
+      roleDescription: 'Build scalable systems.',
+      roleRequirements: 'TypeScript',
+    })
+
+    expect(result.detectedLanguage).toBe('pl')
   })
 
   it('throws when Claude returns no tool_use block', async () => {
-    mockCreate.mockResolvedValueOnce({
-      content: [{ type: 'text', text: 'Here is my analysis...' }],
-    })
+    mockCreate
+      .mockResolvedValueOnce(mockDetectionResponse('en'))
+      .mockResolvedValueOnce({
+        content: [{ type: 'text', text: 'Here is my analysis...' }],
+      })
 
     await expect(
       analyzeTranscriptWithClaude({
@@ -175,15 +213,17 @@ describe('analyzeTranscriptWithClaude()', () => {
   })
 
   it('throws when tool_use input fails schema validation', async () => {
-    mockCreate.mockResolvedValueOnce({
-      content: [
-        {
-          type: 'tool_use',
-          name: 'submit_transcript_analysis',
-          input: { overall_score: 999, dimensions: {} },
-        },
-      ],
-    })
+    mockCreate
+      .mockResolvedValueOnce(mockDetectionResponse('en'))
+      .mockResolvedValueOnce({
+        content: [
+          {
+            type: 'tool_use',
+            name: 'submit_transcript_analysis',
+            input: { overall_score: 999, dimensions: {} },
+          },
+        ],
+      })
 
     await expect(
       analyzeTranscriptWithClaude({
@@ -196,9 +236,11 @@ describe('analyzeTranscriptWithClaude()', () => {
   })
 
   it('includes optional pack questions in the prompt when provided', async () => {
-    mockCreate.mockResolvedValueOnce({
-      content: [{ type: 'tool_use', name: 'submit_transcript_analysis', input: VALID_ANALYSIS }],
-    })
+    mockCreate
+      .mockResolvedValueOnce(mockDetectionResponse('en'))
+      .mockResolvedValueOnce({
+        content: [{ type: 'tool_use', name: 'submit_transcript_analysis', input: VALID_ANALYSIS }],
+      })
 
     await analyzeTranscriptWithClaude({
       transcriptText: '[Alice]: TypeScript is great.',
@@ -213,7 +255,8 @@ describe('analyzeTranscriptWithClaude()', () => {
       ],
     })
 
-    const callArg = mockCreate.mock.calls[0][0]
+    // The second call is the main analysis call; detection is the first.
+    const callArg = mockCreate.mock.calls[1][0]
     const userText = JSON.stringify(callArg.messages[0].content)
     expect(userText).toContain('Tell me about TypeScript.')
     expect(userText).toContain('Concrete examples')


### PR DESCRIPTION
Closes Epic #85 (sub-issues #86–#91). Recruiters can now generate interview + screening packs in any of 10 supported languages (en, pl, de, fr, es, it, pt, nl, cs, sv) — Polish was the named test case but the architecture is language-agnostic.

## Summary

Today every interview pack and screening pack is generated in English. Recruiters interviewing Polish candidates either translate questions on the fly or write Polish prompts manually outside SkillAi. This PR adds a per-pack language picker with sensible fallback chain (candidate language → tenant default → 'en') and threads the language through the full stack: schema → AI prompt → server action → UI → PDF.

## Architecture

**Soft signal in the uncached per-candidate block** — language directive lives where it doesn't fragment the prompt cache (preserves Anthropic cache hits across candidates speaking different languages). English path returns `''` from the helper → byte-identical prompts vs today (regression-safe).

**No new dependencies** — Inter font already vendored from Epic #28, recharts not needed, no new SDKs.

## What's in this PR

| Commit | Item |
|---|---|
| `fb39ba5` | #86 schema: \`interview_packs.language\` column + migration 0018 + audit action |
| `ce1f909` | #87 \`formatLanguageDirective\` helper + \`SUPPORTED_LANGUAGES\` enum + 15 tests |
| `1b23356` | #88 PDF font swap Helvetica → Inter for Polish glyph support |
| `7244f3d` | #87 wire \`formatLanguageDirective\` into interview.ts (param: \`responseLanguage\`) |
| `512314f` | #89 pack language picker + listing badges + action+API wiring |
| `604707b` | #90 transcript analysis multilingual + migration 0019 |
| `ef46ae0` | #91 tenant default pack language setting + 3-tier fallback |

## User-confirmed decisions baked in

| Decision | Choice |
|---|---|
| Where language directive goes | Per-candidate (uncached) block + tool description reinforcement (preserves cache) |
| Storage | \`interview_packs.language\` + \`tenant_settings.default_pack_language\` |
| Language ID format | BCP 47 short codes as \`SUPPORTED_LANGUAGES\` const |
| v1 supported languages | 10 Tier-1 (Inter font covers Latin Extended-A) |
| Polish-specific clause | Force formal register (Pan/Pani) — Claude default register drifts informal |
| PDF font | Inter (already vendored from Epic #28) |
| Default selection | candidate.languagesSpoken[0] → tenant default → 'en' |
| Tenant default scope | Admin-only setting in /settings page |
| Transcript analysis | Detect language via Claude Haiku call, output analysis in same language |

## Test plan

- [x] Migrations 0018 + 0019 applied to live dev DB after pg_dump backup
- [x] Both columns verified via \`\\d interview_packs\` and \`\\d transcript_analyses\`
- [x] Typecheck: 6 pre-existing errors only (all in transcripts.test.ts, out of scope)
- [x] Vitest: language helper 15/15 pass
- [x] App smoke: /login=200, /dashboard=200 after restart
- [ ] Manual smoke (after merge):
  1. Create candidate Łukasz Wójcik with \`languagesSpoken: ['pl']\`
  2. Generate interview pack — picker preselects Polish
  3. Verify questions in Polish, formal register (Pan/Pani), technical terms in English
  4. Download PDF — confirm \`ąćęłńóśźż\` render correctly (no mojibake)
  5. Generate English pack on same candidate — confirm both packs coexist with EN/PL badges
  6. Upload Polish transcript — confirm scores generated, reasoning text in Polish, 'Analysis in Polish' badge appears
  7. Set tenant default to Polish in /settings — confirm new packs default to Polish

## Backups

- \`.backups/skillai-pre-multilang-20260428-083756.sql\` (NOT committed)
- Migration rollback: \`ALTER TABLE interview_packs DROP COLUMN language; ALTER TABLE transcript_analyses DROP COLUMN detected_language;\`

## Effort

7 commits, 7 working days planned → completed in single session via parallel agents.

## Out of scope (v2)

- Customer-level / role-level default columns
- Sticky user preference
- Manual transcript-language override
- Tier-2 (Japanese, Korean, Mandarin) — need CJK fonts
- RTL languages (Arabic, Hebrew)
- Polish prompt native-speaker tuning (recommend after first 5-10 Polish packs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)