### PR TITLE
fix(cv): persistCvFile path symmetry (closes loop on #98)

### DIFF
--- a/src/lib/cv/store.ts
+++ b/src/lib/cv/store.ts
@@ -140,7 +140,7 @@ export async function parseCvBuffer(
 // ---------------------------------------------------------------------------
 
 /**
- * Writes the CV buffer to `{UPLOAD_DIR}/{tenantId}/{uuid}.{ext}` on disk.
+ * Writes the CV buffer to `/uploads/{tenantId}/{uuid}.{ext}` on disk.
  *
  * Returns:
  * - `fileId`   — the UUID used as the filename stem (useful for linking back)
@@ -152,17 +152,18 @@ export async function persistCvFile(
   buffer: Buffer,
   fileType: CvFileType
 ): Promise<{ filePath: string; fileId: string }> {
-  const uploadBase = join(process.cwd(), process.env.UPLOAD_DIR ?? 'uploads')
-  const uploadDir = join(uploadBase, tenantId)
-  await mkdir(uploadDir, { recursive: true })
-
   const fileId = randomUUID()
   const fileName = `${fileId}.${fileType}`
-  const absolutePath = join(uploadDir, fileName)
-  await writeFile(absolutePath, buffer)
 
-  // DB-stored path uses a leading slash to match existing conventions.
+  // Compute the DB path first, then derive the absolute path from it — the same
+  // resolution rule used by deleteCvFile — so write and read sides are always
+  // symmetric. Using UPLOAD_DIR directly on the write side caused double-prefix
+  // bugs when the env var is an absolute path (e.g. /app/app/uploads). See #98.
   const filePath = `/uploads/${tenantId}/${fileName}`
+  const absolutePath = join(process.cwd(), filePath.slice(1))
+
+  await mkdir(join(absolutePath, '..'), { recursive: true })
+  await writeFile(absolutePath, buffer)
 
   return { filePath, fileId }
 }


### PR DESCRIPTION
## Summary

- **Parallel bug to `branding/store.ts`** (fixed in commit 6f9fdb8): `persistCvFile` computed the write-side absolute path using `join(process.cwd(), process.env.UPLOAD_DIR ?? 'uploads', tenantId)`. With `UPLOAD_DIR=/app/uploads` and `cwd=/app`, this resolves to `/app/app/uploads/...` — the double-prefix bug from #98.
- **Why CVs work today:** The Docker dev environment does not set `UPLOAD_DIR` as an env var (falls back to the bare string `'uploads'`), so the path coincidentally resolves correctly. If `UPLOAD_DIR` is set to an absolute path in any deployment, uploads land in the wrong directory and subsequent reads return 404 / ENOENT.
- **What changes:** `persistCvFile` now computes `filePath` (the DB-stored value) first, then derives `absolutePath` via `join(process.cwd(), filePath.slice(1))` — exactly the same resolution rule already used by `deleteCvFile`. Single source of truth, zero asymmetry.
- **No behavioral change for callers:** Function signature and return shape (`{ filePath, fileId }`) are unchanged. The DB-stored path format (`/uploads/{tenantId}/{uuid}.{ext}`) is unchanged.

## Test plan

- [x] `tsc --noEmit` inside container: 0 errors
- [x] Node REPL path symmetry check inside container: `write === read: true` (`/app/uploads/{tenantId}/foo.pdf`)
- [x] HTTP smoke: `/login` → 200, `/dashboard/candidates` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)