### PR TITLE
feat(health): /api/health endpoint (#35)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,12 @@ services:
       ENCRYPTION_KEY: ${ENCRYPTION_KEY}
       BRAVE_SEARCH_API_KEY: ${BRAVE_SEARCH_API_KEY}
       GITHUB_TOKEN: ${GITHUB_TOKEN}
+    healthcheck:
+      test: ['CMD-SHELL', 'curl -sf http://localhost:3000/api/health || exit 1']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
     volumes:
       - uploads_data:/app/uploads
     depends_on:

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server'
+import { sql } from 'drizzle-orm'
+import { db } from '@/db'
+
+/**
+ * GET /api/health
+ *
+ * Unauthenticated health probe for Docker healthchecks and external monitors.
+ * Issues a trivial DB query to confirm the database connection is alive.
+ *
+ * Returns:
+ *   200 { status: 'ok',        db: 'ok',    uptime, timestamp } — healthy
+ *   503 { status: 'unhealthy', db: 'error',          timestamp } — DB unreachable
+ *
+ * Never cached — monitors must always get a live result.
+ */
+export async function GET(): Promise<NextResponse> {
+  const timestamp = new Date().toISOString()
+
+  try {
+    await db.execute(sql`SELECT 1`)
+
+    return NextResponse.json(
+      {
+        status: 'ok',
+        db: 'ok',
+        uptime: process.uptime(),
+        timestamp,
+      },
+      {
+        status: 200,
+        headers: { 'Cache-Control': 'no-store' },
+      }
+    )
+  } catch {
+    return NextResponse.json(
+      {
+        status: 'unhealthy',
+        db: 'error',
+        timestamp,
+      },
+      {
+        status: 503,
+        headers: { 'Cache-Control': 'no-store' },
+      }
+    )
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `GET /api/health` at `src/app/api/health/route.ts`
- Issues `SELECT 1` via the raw `db` connection — no tenant context, no `withTenant` wrapper
- Returns `200 { status, db, uptime, timestamp }` when healthy; `503 { status, db, timestamp }` on DB failure
- Sets `Cache-Control: no-store` on all responses
- Not listed in the middleware matcher (`src/proxy.ts`) — bypasses auth automatically
- Wires `healthcheck` block to the `app` service in `docker-compose.yml` (`curl -sf http://localhost:3000/api/health`)

## Test plan

- [ ] `tsc --noEmit` — zero errors (confirmed)
- [ ] `curl http://localhost:3000/api/health` returns `200` with correct JSON body (confirmed)
- [ ] `/login` still returns `200` — no regressions (confirmed)
- [ ] Docker `app` service reports healthy after `docker compose up`

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)