### PR TITLE
docs: post-merge updates for #95 / #96 / #97

### DIFF
--- a/.agent-os/product/roadmap.md
+++ b/.agent-os/product/roadmap.md
@@ -1,8 +1,8 @@
 # Product Roadmap
 
 > Last Updated: 2026-04-28
-> Version: 2.1.0
-> Status: Phases 1–4 shipped; Phase 5 partial; Hiring Manager persona shipped (Epic #73); further integrations tracked on GitHub
+> Version: 2.2.0
+> Status: Phases 1–4 shipped; Phase 5 partial; Hiring Manager persona shipped (Epic #73); in-app help, branding logos, and candidate-list cleanup shipped; further integrations tracked on GitHub
 
 ## Phase 1: Foundation & Core MVP ✅ SHIPPED
 
@@ -157,6 +157,18 @@ Features delivered mid-flight, not in the original v1.0.0 plan.
 - [x] **Recruiter-side controls** — `ManagerAssignmentDialog` to assign managers, `SendForApprovalButton` to dispatch the shortlist, `ShortlistStatusPill` showing "Sent Nd ago — A/T approved, R rejected, P pending"
 - [x] **Audit trail** — four new actions: `shortlist.sent`, `candidate.approved_by_manager`, `candidate.rejected_by_manager`, `role.manager_assigned`
 - [x] **`notes.is_shareable`** — recruiters opt-in per note; default-private to avoid leaking internal language to managers
+
+### Help & In-App Documentation (PR #96)
+
+- [x] **`/dashboard/help` route** — searchable in-app documentation hub with category navigation
+- [x] **20 articles across 8 categories** — Getting Started, Roles & Candidates, AI Scoring & Interviews, Hiring Manager Workflow, Agencies & Customers, Settings & Admin, Tips & Best Practice, Troubleshooting
+- [x] **Audience-tagged front-matter** — each article declares its target persona (recruiter / manager / admin / all); loader filters articles to the current user's role so each persona only sees relevant content
+- [x] **Static markdown loader** — `gray-matter` + Zod-validated front-matter; articles live in `src/content/help/*.md` so authoring is a flat-file drop-in with no code change
+
+### Branding & UI Polish (PR #97)
+
+- [x] **Agency + customer logos** — upload via existing entity edit forms; PNG / JPEG / WebP only with a 2 MB cap; rendered at 32 px in lists and 64 px on detail headers; initials avatar fallback when no logo is set
+- [x] **Single checkbox column on candidate list** — consolidated bulk-select into one left-edge column; comparison icon button moved adjacent to the CV download action for a cleaner row
 
 ### Exports & PDFs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,14 @@ When asked to work on this codebase:
 - **ORM:** Drizzle only. No raw SQL except for RLS session variable setting. Schema in `src/db/schema/`.
 - **pgvector:** Embeddings stored in `candidates.embedding` (vector(1536)). Use HNSW index. Cosine similarity for search.
 
+## Patterns introduced recently
+
+These patterns are load-bearing across multiple pages — follow them when extending the same surfaces.
+
+- **Audience-based view sanitisation** — pages and shared components accept an `audience: 'recruiter' | 'customer' | 'manager'` prop and strip fields accordingly. Recruiters see everything; customers see no internal notes / rates / margin / agency; managers see score breakdown + reasoning + interview pack but no rates / margin / agency, and edit controls become read-only. Threaded through the role detail and candidate detail pages, plus `RoleCandidateCard`, `EditDetailsForm`, `NotesPanel`, `RoleTagsPanel`, `PriorityKeywordsPanel`. Notes additionally honour `is_shareable=true` for the manager audience. When adding new fields with commercial / internal data, gate them on `audience === 'recruiter'` explicitly — do not default to visible. (PR #95)
+- **Logo upload pattern** — agency and customer logos stored at DB path `/uploads/{tenantId}/logos/{uuid}.{ext}` (web-relative, leading slash). The filesystem write path MUST be derived from that same DB path via the storage helper so write and read stay symmetric (regression risk: see issue #98). Allowed MIME types: PNG / JPEG / WebP only. Hard cap 2 MB. Lists render at 32 px, detail headers at 64 px, with an initials avatar fallback when absent. (PR #97)
+- **Help-tab content pattern** — in-app docs live as markdown files in `src/content/help/*.md` with YAML front-matter (`title`, `category`, `audience`, `order`, `summary`). `gray-matter` parses; a Zod schema validates each file at load time so a malformed doc fails loudly rather than silently. The loader filters by the current user's role so each persona sees only their relevant articles. To add a new article, drop a file in `src/content/help/` — no code change needed. (PR #96)
+
 ## Important Notes
 
 - Product-specific files in `.agent-os/product/` override any global standards


### PR DESCRIPTION
## Summary

Documentation-only sweep after PRs #95 (hiring manager persona), #96 (help tab), and #97 (branding logos + checkbox cleanup) merged onto `core-mvp-foundation`.

### `CLAUDE.md`
Adds a new "Patterns introduced recently" section so future agents working in the codebase do not have to rediscover the load-bearing conventions these PRs introduced:

- **Audience-based view sanitisation** — the `audience: 'recruiter' | 'customer' | 'manager'` prop pattern threading through detail pages and shared components, including which fields each persona is allowed to see.
- **Logo upload path-symmetry rule** — DB stores `/uploads/{tenantId}/logos/{uuid}.{ext}` and the filesystem write path must be derived from that same DB path via the storage helper (regression risk per issue #98). PNG / JPEG / WebP only, 2 MB cap.
- **Help-tab content pattern** — markdown files in `src/content/help/*.md` with YAML front-matter, parsed by `gray-matter` and Zod-validated, filtered by audience at load time.

### `.agent-os/product/roadmap.md`

- Bumps Last Updated → 2026-04-28 and version → 2.2.0.
- New Phase 6 subsection **"Help & In-App Documentation (PR #96)"** — `/dashboard/help` route, 20 articles across 8 categories, audience-tagged front-matter, static markdown loader.
- New Phase 6 subsection **"Branding & UI Polish (PR #97)"** — agency + customer logos (32 px lists / 64 px detail headers, initials avatar fallback), single-checkbox candidate list with comparison icon next to CV download.
- Hiring Manager persona section from #95 was already present and is left as-is.

## Test plan

- [ ] Render `CLAUDE.md` on GitHub — section headings and bullets read cleanly
- [ ] Render `roadmap.md` on GitHub — new Phase 6 subsections appear above "Exports & PDFs"
- [ ] Confirm version + date in roadmap header are updated to 2.2.0 / 2026-04-28
- [ ] No code paths touched, no migrations, no build impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)