### PR TITLE
feat(mcp): Wave 3 — MCP server adapter for claude-desktop (#110)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@anthropic-ai/sdk": "^0.86.1",
         "@auth/drizzle-adapter": "^1.11.1",
         "@google/generative-ai": "^0.24.1",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@node-rs/argon2": "^2.0.2",
         "@react-pdf/renderer": "^4.4.0",
         "@tanstack/react-query": "^5.97.0",
@@ -1729,6 +1730,18 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -2327,6 +2340,68 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/canvas": {
       "version": "0.1.80",
@@ -5173,6 +5248,19 @@
       "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==",
       "license": "MIT"
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -5212,6 +5300,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -5724,6 +5851,46 @@
       "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
       "license": "MIT"
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -5840,6 +6007,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
@@ -5863,7 +6039,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5877,7 +6052,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -6093,6 +6267,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -6100,11 +6296,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/crc-32": {
       "version": "1.2.2",
@@ -6452,6 +6683,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/dequal": {
@@ -7169,7 +7409,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -7231,6 +7470,12 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.344",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
@@ -7249,6 +7494,15 @@
       "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
       "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.21.0",
@@ -7350,7 +7604,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7360,7 +7613,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7405,7 +7657,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -7524,6 +7775,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -7987,6 +8244,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -8020,6 +8286,27 @@
         "bare-events": "^2.7.0"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -8028,6 +8315,67 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/extend": {
@@ -8104,6 +8452,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -8174,6 +8538,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -8263,6 +8648,24 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -8282,7 +8685,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8343,7 +8745,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -8368,7 +8769,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -8501,7 +8901,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8609,7 +9008,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8638,7 +9036,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
       "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -8727,6 +9124,15 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/hsl-to-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/hsl-to-hex/-/hsl-to-hex-1.0.0.tgz",
@@ -8780,6 +9186,26 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/hyphen": {
@@ -8917,6 +9343,24 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-alphabetical": {
@@ -9268,6 +9712,12 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
     "node_modules/is-regex": {
@@ -9661,6 +10111,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -10316,7 +10772,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10487,6 +10942,27 @@
       "resolved": "https://registry.npmjs.org/media-engine/-/media-engine-1.0.3.tgz",
       "integrity": "sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg==",
       "license": "MIT"
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -10954,6 +11430,31 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -11052,6 +11553,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/next": {
       "version": "16.2.4",
@@ -11262,7 +11772,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11381,6 +11890,27 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/oniguruma-parser": {
       "version": "0.12.2",
@@ -11542,6 +12072,15 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -11598,6 +12137,16 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -11664,6 +12213,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/playwright": {
@@ -11873,6 +12431,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -11881,6 +12452,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue": {
@@ -11912,6 +12498,46 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/react": {
       "version": "19.2.4",
@@ -12337,6 +12963,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/rtf-parser": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rtf-parser/-/rtf-parser-1.3.3.tgz",
@@ -12530,6 +13172,51 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -12584,6 +13271,12 @@
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -12687,7 +13380,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -12707,7 +13399,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -12724,7 +13415,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -12743,7 +13433,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -12860,6 +13549,15 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "4.1.0",
@@ -13443,6 +14141,15 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/token-types": {
@@ -14102,6 +14809,20 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -14398,6 +15119,15 @@
         }
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -14488,6 +15218,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/vfile": {
       "version": "6.0.3",
@@ -15020,6 +15759,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -15093,6 +15838,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zod-validation-error": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@anthropic-ai/sdk": "^0.86.1",
     "@auth/drizzle-adapter": "^1.11.1",
     "@google/generative-ai": "^0.24.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@node-rs/argon2": "^2.0.2",
     "@react-pdf/renderer": "^4.4.0",
     "@tanstack/react-query": "^5.97.0",

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1,0 +1,172 @@
+/**
+ * MCP HTTP endpoint — `/api/mcp`.
+ *
+ * Exposes SkillAi tools/resources/prompts to claude-desktop (and any other
+ * MCP-aware client) over the streamable-HTTP transport. Stateless mode:
+ * each request validates its own bearer token, runs the corresponding
+ * tool, and closes. No session continuity is kept across requests.
+ *
+ * Auth flow on every request:
+ *   1. Extract `Authorization: Bearer <token>` (return 401 if missing).
+ *   2. Validate the token via `validateApiToken` (return 401 if bad).
+ *   3. Look up the user's product-role (admin/recruiter/...) so that
+ *      delegated server actions can enforce role-based gating.
+ *   4. Rate-limit via `checkRateLimit` (return 429 if exceeded).
+ *   5. Build a per-request `McpServer`, connect it to a fresh
+ *      `WebStandardStreamableHTTPServerTransport`, and let the SDK
+ *      dispatch the JSON-RPC body to the matching tool/resource/prompt.
+ */
+
+import { eq } from 'drizzle-orm'
+import { db } from '@/db'
+import { users } from '@/db/schema'
+import { validateApiToken } from '@/lib/api-tokens/validate'
+import { checkRateLimit } from '@/lib/api/rate-limit'
+import { writeAuditLog } from '@/lib/audit'
+import { buildMcpServer } from '@/lib/mcp/server'
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
+import type { ApiTokenScope } from '@/db/schema/api-tokens'
+import type { UserRole } from '@/lib/auth/types'
+
+export const runtime = 'nodejs'
+// Disable static optimisation — this route always runs per-request.
+export const dynamic = 'force-dynamic'
+
+function jsonError(status: number, code: string, message: string): Response {
+  return Response.json(
+    {
+      jsonrpc: '2.0',
+      error: { code: status === 401 ? -32001 : status === 403 ? -32002 : -32000, message },
+      id: null,
+      _http: { status, code },
+    },
+    { status }
+  )
+}
+
+/**
+ * Heuristic that looks at a parsed JSON-RPC body to decide whether the
+ * call is a "write" for rate-limiting purposes. Tool calls that modify
+ * state are usually `tools/call` with a method name we recognise;
+ * everything else (tools/list, resources/read, prompts/get) is a read.
+ *
+ * We err on the side of `false` — false negatives just give a slightly
+ * higher per-tenant ceiling on writes than intended; false positives
+ * would unfairly throttle reads.
+ */
+function isLikelyWrite(parsed: unknown): boolean {
+  const body = parsed as { method?: string; params?: { name?: string; arguments?: unknown } } | null
+  if (!body) return false
+  if (body.method !== 'tools/call') return false
+  const toolName = body.params?.name ?? ''
+  // Match the write tool names registered in src/lib/mcp/tools/*.
+  return /^(update_|archive_|create_|delete_|deactivate_|approve_|reject_|rescore_|bulk_)/.test(toolName)
+}
+
+async function handle(req: Request): Promise<Response> {
+  // -- 1. Bearer token ---------------------------------------------------------
+  const authHeader = req.headers.get('authorization')
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return jsonError(401, 'no_token', 'Missing Authorization: Bearer header')
+  }
+  const rawToken = authHeader.slice(7).trim()
+  if (!rawToken) {
+    return jsonError(401, 'no_token', 'Empty bearer token')
+  }
+
+  // -- 2. Validate token -------------------------------------------------------
+  const validated = await validateApiToken(rawToken)
+  if (!validated) {
+    return jsonError(401, 'invalid_token', 'Token is invalid, expired, or revoked')
+  }
+  const { tenantId, userId, scopes, tokenId } = validated
+  const scopeList = scopes as ApiTokenScope[]
+
+  // -- 3. Resolve user role for action-context delegation ----------------------
+  // Server actions read userRole from the ActionContext to gate writes.
+  // We look it up once per MCP request rather than embedding it in the token.
+  let userRole: UserRole = 'viewer'
+  try {
+    const [row] = await db
+      .select({ role: users.role })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1)
+    if (row?.role) userRole = row.role as UserRole
+  } catch (err) {
+    console.error('[mcp] failed to resolve user role; defaulting to viewer:', err)
+  }
+
+  // -- 4. Body parse + rate limit ---------------------------------------------
+  // We have to read the body once (rate-limit decision) and replay it to the
+  // SDK transport — the request stream is one-shot, so the transport receives
+  // a parsedBody hint instead of the original Request.
+  let parsedBody: unknown = null
+  if (req.method === 'POST') {
+    try {
+      parsedBody = await req.clone().json()
+    } catch {
+      // Non-JSON POST; SDK will reject. Treat as read for rate-limit purposes.
+      parsedBody = null
+    }
+  }
+
+  const isWrite = isLikelyWrite(parsedBody)
+  const rateLimit = await checkRateLimit(tenantId, tokenId, isWrite)
+  if (!rateLimit.ok) {
+    void writeAuditLog(tenantId, {
+      action: 'api.rate_limit_exceeded',
+      entityType: 'api_token',
+      entityId: tokenId,
+      metadata: { limit: rateLimit.limit, retryAfter: rateLimit.retryAfter, via: 'mcp' },
+    })
+    return new Response(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        error: { code: -32003, message: 'rate_limit_exceeded' },
+        id: null,
+      }),
+      {
+        status: 429,
+        headers: {
+          'Content-Type': 'application/json',
+          'Retry-After': String(rateLimit.retryAfter),
+          'X-RateLimit-Remaining': '0',
+          'X-RateLimit-Reset': String(Math.floor(Date.now() / 1000) + rateLimit.retryAfter),
+        },
+      }
+    )
+  }
+
+  // -- 5. Build MCP server + dispatch ------------------------------------------
+  try {
+    const ctx = { tenantId, userId, tokenId, scopes: scopeList, userRole }
+    const server = buildMcpServer(ctx)
+
+    // Stateless mode — sessionIdGenerator omitted. JSON response mode is on
+    // for simplicity: claude-desktop handles both, and JSON is much easier
+    // to debug in the early iterations of this adapter.
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true,
+    })
+
+    await server.connect(transport)
+
+    // Pass the parsed body so the SDK doesn't try to re-read the consumed stream.
+    return await transport.handleRequest(req, {
+      parsedBody: parsedBody ?? undefined,
+    })
+  } catch (err) {
+    console.error('[mcp] handler error:', err)
+    return jsonError(
+      500,
+      'internal_error',
+      err instanceof Error ? err.message : 'Unexpected MCP handler error'
+    )
+  }
+}
+
+export const POST = handle
+export const GET = handle
+export const DELETE = handle

--- a/src/content/help/mcp-server-claude-desktop.md
+++ b/src/content/help/mcp-server-claude-desktop.md
@@ -1,0 +1,106 @@
+---
+title: "Connecting SkillAi to claude-desktop (MCP server)"
+category: "Integrations"
+audience: ["admin", "recruiter"]
+order: 60
+lastUpdated: "2026-04-28"
+tags: ["integrations", "mcp", "claude-desktop", "ai", "api"]
+---
+
+# Connecting SkillAi to claude-desktop (MCP server)
+
+SkillAi exposes a built-in MCP (Model Context Protocol) server at `/api/mcp`. Once connected, you can ask claude-desktop things like "show me my top candidates for the Acme platform-engineer role" and it will read SkillAi data — and, with explicit confirmation, change candidate statuses, add notes, or trigger a rescore — all without leaving the chat.
+
+This article assumes claude-desktop 0.10 or newer.
+
+## What MCP is, in one paragraph
+
+MCP is the open protocol that lets a chat client (claude-desktop, Cursor, etc.) talk to external tools. SkillAi advertises a catalogue of read-only **tools** (e.g. `list_candidates`, `get_role_with_candidates`), write **tools** that require explicit confirmation (`update_candidate_status`, `create_note`, `rescore_candidate`), URL-style **resources** (`skillai://candidates/<id>`), and prebuilt **prompts** for common workflows. The chat client picks which to call based on your message.
+
+## 1. Generate an API token
+
+1. Sign in to SkillAi as an admin (or as a recruiter for read+write tokens — admin scope is required for user/settings tools).
+2. Go to **Settings → API tokens** and click **New token**.
+3. Give it a name like `claude-desktop-laptop` and pick a scope:
+   - **read** — listings and lookups only. Good for "what does my pipeline look like?" questions.
+   - **write** — read + state-changing tools (status, notes, rescore, approvals).
+   - **admin** — write + user management and settings tools.
+4. Click **Create**. Copy the token starting with `skl_prod_...` immediately. **You will not be able to see it again.** Store it in your password manager or system keychain.
+
+Tokens are scoped to your tenant; they cannot read data from other tenants.
+
+## 2. Edit the claude-desktop config
+
+On macOS the config file is at `~/Library/Application Support/Claude/claude_desktop_config.json`. On Windows it is `%APPDATA%\Claude\claude_desktop_config.json`. Add the `skillai` entry under `mcpServers`:
+
+```json
+{
+  "mcpServers": {
+    "skillai": {
+      "url": "https://your-skillai-host/api/mcp",
+      "headers": {
+        "Authorization": "Bearer skl_prod_replace_with_your_token"
+      }
+    }
+  }
+}
+```
+
+If you have other MCP servers configured (filesystem, GitHub, etc.) leave them alone — just add the `skillai` block alongside them.
+
+Restart claude-desktop. In a new conversation you should see a "skillai" connection indicator near the input bar.
+
+## 3. Test the connection
+
+Type:
+
+> List my candidates.
+
+claude-desktop should call the `list_candidates` tool and reply with the first page of results in your tenant. If you get a 401 instead, see Troubleshooting below.
+
+## What you can ask for
+
+The tool catalogue covers (one example per category):
+
+- **Candidates** — `list_candidates`, `find_candidate_by_email`, `update_candidate_status`, `archive_candidate`. Try: *"Find the candidate with email ada@example.com and move her to interviewing."*
+- **Roles** — `list_roles`, `get_role_with_candidates`. Try: *"Which candidates are top-ranked on role <role-id> with a score above 80?"*
+- **Agencies & customers** — `list_agencies`, `list_customers`, `get_agency`, `get_customer`. Read-only; use the dashboard to create agencies.
+- **Scoring** — `get_candidate_score`, `rescore_candidate`. Try: *"Rescore candidate <id> against role <id>."*
+- **Interviews** — `list_interview_packs`, `get_interview_pack`. Pack generation itself is dashboard-only because it's a long-running AI job.
+- **Approvals** (hiring manager) — `get_approvals_for_role`, `approve_candidate`, `reject_candidate`. Try: *"Approve candidate <id> on role <id> with comment 'Strong technical, fits the team.'"*
+- **Notes** — `create_note`, `update_note`, `delete_note`. Try: *"Add a note to candidate <id>: 'Confirmed availability from June 2026.'"*
+- **Users** (admin) — `list_users`, `update_user_role`, `deactivate_user`.
+- **Settings** (admin) — `list_configured_keys`.
+
+You can also reference resources directly:
+
+- `skillai://candidates/<id>` — full snapshot of one candidate.
+- `skillai://roles/<id>` — role plus ranked candidates.
+- `skillai://interview-packs/<id>` — pack with all questions.
+- `skillai://my-shortlists` — for hiring managers, the roles awaiting your decision.
+
+## Confirmation gating on writes
+
+Every state-changing tool requires `confirmed: true` in its arguments. claude-desktop will normally show you the proposed write and ask you to approve it before sending. If you see an error like *"confirmation_required: 'create_note' is a write action"*, that means the model tried to call the tool without your explicit go-ahead — re-confirm in the chat and it will retry.
+
+This is by design: SkillAi never lets the model silently mutate your data.
+
+## Three example workflows
+
+**Email-with-CV introduction.** *"Draft an introduction email about candidate <id> for role <id> to hiring.manager@customer.com."* Use the `email-candidate-introduction` prompt — it pulls the score and CV summary, then composes the email body grounded in actual data.
+
+**Weekly hiring-manager review.** *"Run my weekly review for role <id>."* Use the `weekly-shortlist-review` prompt — it summarises pending decisions and surfaces the top candidates still to look at.
+
+**Bulk shortlist triage.** *"List active roles, then for the top 3 by recency show me the shortlisted candidates with their overall scores."* Pure read flow; no confirmation needed.
+
+## Troubleshooting
+
+**401 unauthorized / "Token is invalid, expired, or revoked".** The token has been revoked, has expired, or you've copied it incorrectly. Generate a new token in Settings and replace the value in `claude_desktop_config.json`.
+
+**403 / "insufficient_scope".** Your token does not have the scope this tool requires. Read tokens cannot do writes; write tokens cannot manage users. Either generate a higher-scope token or use a different one.
+
+**429 / "rate_limit_exceeded".** You've exceeded the per-token rate limit. Wait the number of seconds in the `Retry-After` response header (typically under a minute) and try again.
+
+**404 / no rows returned.** Most often this means the entity exists in a different tenant. Tokens are tenant-scoped; a token issued in tenant A cannot see tenant B's data.
+
+**Connection indicator missing.** Restart claude-desktop. If still missing, run claude-desktop from the terminal to surface its log output and check the URL/header values in your config.

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -35,6 +35,7 @@ export type AuditAction =
   | 'role.manager_assigned'
   | 'api_token.created' | 'api_token.revoked' | 'api_token.used'
   | 'api.rate_limit_exceeded'
+  | 'mcp.tool_called' | 'mcp.confirmed_action'
 
 type AuditEntry = {
   action: AuditAction

--- a/src/lib/auth/action-context.ts
+++ b/src/lib/auth/action-context.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
 import { headers } from 'next/headers'
 import type { UserRole } from '@/lib/auth/types'
 
@@ -8,11 +9,39 @@ export type ActionContext = {
 }
 
 /**
- * Extracts tenant/user context from middleware-injected headers.
- * Returns null if the request is unauthenticated (no tenant ID).
- * Safe to use in server actions — headers are set by Next.js middleware from JWT.
+ * AsyncLocalStorage-backed context override.
+ *
+ * Used when an action is called outside the normal HTTP middleware path
+ * (e.g. from the MCP adapter at /api/mcp). The MCP route validates a
+ * bearer token, looks up tenant/user/role, and runs the tool handler
+ * inside `withActionContext(ctx, () => ...)`. Server actions then read
+ * the ALS first, falling back to request headers for the standard flow.
+ */
+const actionContextStorage = new AsyncLocalStorage<ActionContext>()
+
+/**
+ * runWithActionContext — establish an ActionContext for the duration of
+ * the callback. Server actions called inside `fn` will see this context
+ * regardless of request headers. Used by the MCP adapter.
+ */
+export function runWithActionContext<T>(ctx: ActionContext, fn: () => Promise<T>): Promise<T> {
+  return actionContextStorage.run(ctx, fn)
+}
+
+/**
+ * Extracts tenant/user context.
+ *
+ * Resolution order:
+ *   1. AsyncLocalStorage override (set by `runWithActionContext`)
+ *   2. Middleware-injected request headers (the normal browser flow)
+ *
+ * Returns null if neither source provides a tenantId.
  */
 export async function getActionContext(): Promise<ActionContext | null> {
+  // ALS override — set by non-HTTP entry points (MCP, jobs, scripts)
+  const overridden = actionContextStorage.getStore()
+  if (overridden) return overridden
+
   const headersList = await headers()
   const tenantId = headersList.get('x-tenant-id')
   const userId = headersList.get('x-user-id') ?? ''

--- a/src/lib/mcp/attachment.ts
+++ b/src/lib/mcp/attachment.ts
@@ -1,0 +1,49 @@
+/**
+ * Attachment helper — converts files and buffers into the structured
+ * attachment shape used by export tools in the MCP adapter.
+ *
+ * Format:
+ *   { filename, mimeType, dataBase64, sizeBytes }
+ *
+ * Tools that produce binaries (PDFs, CV files) return one or more of these
+ * objects in their structured content so MCP clients can save / preview them.
+ */
+
+import { readFile } from 'node:fs/promises'
+
+export type Attachment = {
+  filename: string
+  mimeType: string
+  dataBase64: string
+  sizeBytes: number
+}
+
+/**
+ * fileToAttachment — read an absolute file path and wrap it as an Attachment.
+ * Throws if the file is missing or unreadable.
+ */
+export async function fileToAttachment(
+  absolutePath: string,
+  filename: string,
+  mimeType: string
+): Promise<Attachment> {
+  const buf = await readFile(absolutePath)
+  return bufferToAttachment(buf, filename, mimeType)
+}
+
+/**
+ * bufferToAttachment — wrap an in-memory Buffer/Uint8Array as an Attachment.
+ */
+export function bufferToAttachment(
+  buffer: Buffer | Uint8Array,
+  filename: string,
+  mimeType: string
+): Attachment {
+  const b = Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer)
+  return {
+    filename,
+    mimeType,
+    dataBase64: b.toString('base64'),
+    sizeBytes: b.byteLength,
+  }
+}

--- a/src/lib/mcp/context.ts
+++ b/src/lib/mcp/context.ts
@@ -1,0 +1,104 @@
+/**
+ * MCP per-request context + tool helpers.
+ *
+ * Every MCP request validates a bearer token and produces an `McpContext`.
+ * Tool handlers close over this context so they know who's calling and
+ * what scopes they hold.
+ *
+ * Scope inclusion mirrors `requireScope` in `src/lib/api/auth-middleware.ts`:
+ *   admin > write > read
+ */
+
+import { runWithActionContext } from '@/lib/auth/action-context'
+import { writeAuditLog } from '@/lib/audit'
+import type { ApiTokenScope } from '@/db/schema/api-tokens'
+import type { UserRole } from '@/lib/auth/types'
+
+export type McpContext = {
+  tenantId: string
+  userId: string
+  tokenId: string
+  scopes: ApiTokenScope[]
+  /**
+   * The user's product-role (admin/recruiter/viewer) inferred from the user
+   * record at token-issue time. Server actions use this to gate writes.
+   */
+  userRole: UserRole
+}
+
+/**
+ * mcpRequireScope — returns true if the granted scopes satisfy `required`.
+ * admin satisfies all; write satisfies write+read; read only satisfies read.
+ */
+export function mcpRequireScope(required: ApiTokenScope, granted: ApiTokenScope[]): boolean {
+  for (const s of granted) {
+    if (s === 'admin') return true
+    if (s === 'write' && (required === 'write' || required === 'read')) return true
+    if (s === 'read' && required === 'read') return true
+  }
+  return false
+}
+
+/**
+ * Error thrown when a tool is invoked without sufficient scope. Surfaced as
+ * an MCP tool error rather than an HTTP error.
+ */
+export class McpScopeError extends Error {
+  constructor(required: ApiTokenScope) {
+    super(`insufficient_scope: this tool requires '${required}' scope`)
+    this.name = 'McpScopeError'
+  }
+}
+
+/**
+ * Error thrown when a write tool is invoked without `confirmed: true`.
+ */
+export class McpConfirmRequiredError extends Error {
+  constructor(toolName: string) {
+    super(
+      `confirmation_required: '${toolName}' is a write action. ` +
+        `Re-call with confirmed: true once the user has explicitly approved the change.`
+    )
+    this.name = 'McpConfirmRequiredError'
+  }
+}
+
+/**
+ * Wraps a tool handler with: scope check, action-context ALS setup, and
+ * audit logging. Used by every tool registered on the MCP server.
+ */
+export async function runTool<T>(
+  ctx: McpContext,
+  toolName: string,
+  requiredScope: ApiTokenScope,
+  isWrite: boolean,
+  args: unknown,
+  fn: () => Promise<T>
+): Promise<T> {
+  if (!mcpRequireScope(requiredScope, ctx.scopes)) {
+    throw new McpScopeError(requiredScope)
+  }
+
+  if (isWrite) {
+    // Write tools require an explicit { confirmed: true } gate
+    const a = (args ?? {}) as Record<string, unknown>
+    if (a.confirmed !== true) {
+      throw new McpConfirmRequiredError(toolName)
+    }
+  }
+
+  // Audit before running so we have a trace even if the handler throws
+  void writeAuditLog(ctx.tenantId, {
+    action: isWrite ? 'mcp.confirmed_action' : 'mcp.tool_called',
+    entityType: 'mcp_tool',
+    entityLabel: toolName,
+    metadata: { tokenId: ctx.tokenId, userId: ctx.userId, scopes: ctx.scopes },
+  })
+
+  // Establish ActionContext so server actions called inside the tool see
+  // the right tenant/user/role without depending on HTTP middleware headers.
+  return runWithActionContext(
+    { tenantId: ctx.tenantId, userId: ctx.userId, userRole: ctx.userRole },
+    fn
+  )
+}

--- a/src/lib/mcp/prompts/index.ts
+++ b/src/lib/mcp/prompts/index.ts
@@ -1,0 +1,139 @@
+/**
+ * MCP prompts — opinionated prompt templates that orchestrate multi-step
+ * SkillAi workflows for the LLM client.
+ *
+ * Prompts return a list of messages the client renders into the user's
+ * conversation. They do NOT execute the workflow — they suggest the
+ * sequence of tools/resources for the LLM to call. The LLM still drives
+ * the actual work.
+ *
+ * Templates:
+ *   - prepare-interview-brief         — pull CV, score, pack, notes for an interviewer
+ *   - weekly-shortlist-review         — manager-flow weekly digest of pending decisions
+ *   - email-candidate-introduction    — orchestrate compose-email + score-summary
+ */
+
+import { z } from 'zod'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { McpContext } from '../context'
+
+const PrepareBriefArgs = {
+  candidateId: z.string().uuid(),
+  roleId: z.string().uuid(),
+}
+
+const ShortlistReviewArgs = {
+  roleId: z.string().uuid(),
+}
+
+const EmailIntroArgs = {
+  candidateId: z.string().uuid(),
+  roleId: z.string().uuid(),
+  recipientEmail: z.string().email(),
+}
+
+function userMessage(text: string) {
+  return {
+    role: 'user' as const,
+    content: { type: 'text' as const, text },
+  }
+}
+
+export function registerAllPrompts(server: McpServer, _ctx: McpContext): void {
+  // -- prepare-interview-brief ------------------------------------------------
+  server.registerPrompt(
+    'prepare-interview-brief',
+    {
+      title: 'Prepare interview brief for a candidate',
+      description:
+        'Assemble everything an interviewer needs to walk into a conversation with a specific ' +
+        'candidate against a specific role: CV summary, dimension scores with reasoning, the ' +
+        'generated interview pack, and any prior notes or transcript analyses.',
+      argsSchema: PrepareBriefArgs,
+    },
+    (args) => ({
+      messages: [
+        userMessage(
+          `I'm preparing to interview a candidate. Please assemble a brief for me using these steps:
+
+1. Read the candidate record: call \`get_candidate\` with candidateId="${args.candidateId}".
+2. Read the role: call \`get_role\` with roleId="${args.roleId}".
+3. Read the score: call \`get_candidate_score\` with candidateId="${args.candidateId}" and roleId="${args.roleId}". Pay particular attention to per-dimension reasoning.
+4. List interview packs for this candidate+role: call \`list_interview_packs\` with both ids set, then \`get_interview_pack\` for the most recent complete one.
+5. Optionally also call resource skillai://candidates/${args.candidateId} for a richer candidate snapshot.
+
+Then produce a one-page interviewer brief in en-GB English with these sections:
+- "At a glance" (overall score, location, availability, agency)
+- "Strengths" (drawn from per-dimension reasoning above ~75)
+- "Risks / things to probe" (drawn from per-dimension reasoning below ~65)
+- "Recommended questions" (the top 5–7 from the interview pack)
+- "Open questions for the candidate"`
+        ),
+      ],
+    })
+  )
+
+  // -- weekly-shortlist-review ------------------------------------------------
+  server.registerPrompt(
+    'weekly-shortlist-review',
+    {
+      title: 'Weekly shortlist review (hiring manager)',
+      description:
+        'For a hiring manager, summarise the current state of approvals on a role and surface ' +
+        'the top candidates still awaiting a decision.',
+      argsSchema: ShortlistReviewArgs,
+    },
+    (args) => ({
+      messages: [
+        userMessage(
+          `I'd like a weekly review of role ${args.roleId}. Please:
+
+1. Call \`get_role\` to summarise the role title, customer, deadlines, and budget.
+2. Call \`get_role_with_candidates\` to see the ranked candidates.
+3. Call \`get_approvals_for_role\` to see which approvals are still pending.
+
+Then in en-GB English produce:
+- A 2–3 sentence headline (role title, days until cutoffDate, count pending, count decided).
+- A "still to decide" table with overallScore, status, and a one-sentence rationale per candidate.
+- An "already decided" appendix with name + decision + comment.
+
+Use markdown.`
+        ),
+      ],
+    })
+  )
+
+  // -- email-candidate-introduction ------------------------------------------
+  server.registerPrompt(
+    'email-candidate-introduction',
+    {
+      title: 'Compose candidate introduction email',
+      description:
+        'Draft an introduction email to a third party (typically a hiring manager) about a ' +
+        'specific candidate against a specific role. Pulls the CV summary and score so the ' +
+        'narrative is grounded in actual SkillAi data.',
+      argsSchema: EmailIntroArgs,
+    },
+    (args) => ({
+      messages: [
+        userMessage(
+          `Please draft a candidate introduction email to ${args.recipientEmail}.
+
+Steps:
+1. \`get_candidate\` with candidateId="${args.candidateId}" — note name, location, availability.
+2. \`get_role\` with roleId="${args.roleId}" — note title, customer, location.
+3. \`get_candidate_score\` with both ids — read the AI summary and any per-dimension reasoning above 75.
+
+Then produce a single-paragraph subject line + 4–6 short paragraphs of body in en-GB English:
+- Why this candidate, in one sentence (drawn from the AI summary).
+- Their relevant strengths (max 3 bullets, grounded in the dimension reasoning).
+- Their availability and location (from the candidate record).
+- A clear next-step ask (a 30-minute call, a CV download from the dashboard, etc.)
+- Sign-off referencing SkillAi and the calling user.
+
+Do not invent skills or experience the data does not support. If a dimension is below 60, do not mention it in the email — flag it back to me separately.`
+        ),
+      ],
+    })
+  )
+}

--- a/src/lib/mcp/resources/index.ts
+++ b/src/lib/mcp/resources/index.ts
@@ -1,0 +1,152 @@
+/**
+ * MCP resources — URI-templated handles for the most-frequently-referenced
+ * SkillAi entities. Resources let an LLM client say "open
+ * skillai://candidates/<id>" and get back a JSON snapshot, without first
+ * having to call a tool.
+ *
+ * Templates exposed:
+ *   - skillai://candidates/{id}        — candidate record + agency name
+ *   - skillai://roles/{id}             — role record + ranked candidates
+ *   - skillai://interview-packs/{id}   — pack header + questions
+ *   - skillai://my-shortlists          — manager flow: roles awaiting my decision
+ */
+
+import { eq, desc } from 'drizzle-orm'
+import { withTenant } from '@/db'
+import {
+  candidates,
+  agencies,
+  roles,
+  scores,
+  interviewPacks,
+  interviewQuestions,
+} from '@/db/schema'
+import { runWithActionContext } from '@/lib/auth/action-context'
+import { getMyAssignedRoles } from '@/actions/role-managers'
+import {
+  McpServer,
+  ResourceTemplate,
+} from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { McpContext } from '../context'
+
+function jsonContents(uri: URL, value: unknown) {
+  return {
+    contents: [
+      {
+        uri: uri.href,
+        mimeType: 'application/json',
+        text: JSON.stringify(value, null, 2),
+      },
+    ],
+  }
+}
+
+export function registerAllResources(server: McpServer, ctx: McpContext): void {
+  // -- candidates/{id} --------------------------------------------------------
+  server.registerResource(
+    'candidate',
+    new ResourceTemplate('skillai://candidates/{id}', { list: undefined }),
+    {
+      title: 'SkillAi candidate',
+      description: 'A single candidate record with their agency name and contact details.',
+      mimeType: 'application/json',
+    },
+    async (uri, variables) => {
+      const id = String(variables.id)
+      const result = await withTenant(ctx.tenantId, async (tx) => {
+        const [row] = await tx
+          .select({
+            candidate: candidates,
+            agencyName: agencies.name,
+          })
+          .from(candidates)
+          .leftJoin(agencies, eq(candidates.agencyId, agencies.id))
+          .where(eq(candidates.id, id))
+          .limit(1)
+        return row ?? null
+      })
+      return jsonContents(uri, result)
+    }
+  )
+
+  // -- roles/{id} -------------------------------------------------------------
+  server.registerResource(
+    'role',
+    new ResourceTemplate('skillai://roles/{id}', { list: undefined }),
+    {
+      title: 'SkillAi role with ranked candidates',
+      description:
+        'A role record together with all candidates scored against it, sorted by overallScore.',
+      mimeType: 'application/json',
+    },
+    async (uri, variables) => {
+      const id = String(variables.id)
+      const result = await withTenant(ctx.tenantId, async (tx) => {
+        const [role] = await tx.select().from(roles).where(eq(roles.id, id)).limit(1)
+        if (!role) return { role: null, candidates: [] }
+        const ranked = await tx
+          .select({
+            candidateId: candidates.id,
+            firstName: candidates.firstName,
+            lastName: candidates.lastName,
+            overallScore: scores.overallScore,
+            scoreStatus: scores.scoreStatus,
+          })
+          .from(scores)
+          .innerJoin(candidates, eq(scores.candidateId, candidates.id))
+          .where(eq(scores.roleId, id))
+          .orderBy(desc(scores.overallScore))
+        return { role, candidates: ranked }
+      })
+      return jsonContents(uri, result)
+    }
+  )
+
+  // -- interview-packs/{id} ---------------------------------------------------
+  server.registerResource(
+    'interview-pack',
+    new ResourceTemplate('skillai://interview-packs/{id}', { list: undefined }),
+    {
+      title: 'SkillAi interview pack',
+      description: 'An interview pack with all generated questions.',
+      mimeType: 'application/json',
+    },
+    async (uri, variables) => {
+      const id = String(variables.id)
+      const result = await withTenant(ctx.tenantId, async (tx) => {
+        const [pack] = await tx
+          .select()
+          .from(interviewPacks)
+          .where(eq(interviewPacks.id, id))
+          .limit(1)
+        if (!pack) return { pack: null, questions: [] }
+        const questions = await tx
+          .select()
+          .from(interviewQuestions)
+          .where(eq(interviewQuestions.packId, id))
+        return { pack, questions }
+      })
+      return jsonContents(uri, result)
+    }
+  )
+
+  // -- my-shortlists (static URI) --------------------------------------------
+  server.registerResource(
+    'my-shortlists',
+    'skillai://my-shortlists',
+    {
+      title: 'My shortlists (hiring manager)',
+      description: 'For the calling user, the roles where you have approvals to make.',
+      mimeType: 'application/json',
+    },
+    async (uri) => {
+      // getMyAssignedRoles uses getActionContext internally — establish the
+      // context for the duration of the read.
+      const result = await runWithActionContext(
+        { tenantId: ctx.tenantId, userId: ctx.userId, userRole: ctx.userRole },
+        () => getMyAssignedRoles()
+      )
+      return jsonContents(uri, { assignedRoles: result })
+    }
+  )
+}

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -1,0 +1,40 @@
+/**
+ * MCP server builder.
+ *
+ * `buildMcpServer(ctx)` returns a configured `McpServer` with every
+ * tool / resource / prompt registered. Each is a closure over the
+ * caller's `McpContext`, so handlers don't need to thread the tenant
+ * through the SDK's `args`.
+ *
+ * A new server instance is constructed per HTTP request (the streamable
+ * HTTP transport is per-request stateless in our deployment). Cost is
+ * negligible: registration is just metadata + closure allocation.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { registerAllTools } from './tools'
+import { registerAllResources } from './resources'
+import { registerAllPrompts } from './prompts'
+import type { McpContext } from './context'
+
+const SERVER_INFO = {
+  name: 'skillai',
+  version: '1.0.0',
+  title: 'SkillAi',
+}
+
+export function buildMcpServer(ctx: McpContext): McpServer {
+  const server = new McpServer(SERVER_INFO, {
+    capabilities: {
+      tools: {},
+      resources: {},
+      prompts: {},
+    },
+  })
+
+  registerAllTools(server, ctx)
+  registerAllResources(server, ctx)
+  registerAllPrompts(server, ctx)
+
+  return server
+}

--- a/src/lib/mcp/tools/agencies.ts
+++ b/src/lib/mcp/tools/agencies.ts
@@ -1,0 +1,69 @@
+/**
+ * Agency MCP tools — read-only listing for now. Creation/edit go through
+ * the dashboard server actions; LLM-driven agency creation is intentionally
+ * out of scope for the MVP.
+ */
+
+import { z } from 'zod'
+import { eq, desc } from 'drizzle-orm'
+import { withTenant } from '@/db'
+import { agencies } from '@/db/schema'
+import { runTool } from '../context'
+import type { McpContext } from '../context'
+import { jsonResult } from './candidates'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+export const ListAgenciesInput = {
+  includeArchived: z.boolean().optional().default(false),
+}
+
+export const GetAgencyInput = {
+  agencyId: z.string().uuid(),
+}
+
+export function registerAgencyTools(server: McpServer, ctx: McpContext): void {
+  server.registerTool(
+    'list_agencies',
+    {
+      title: 'List agencies',
+      description:
+        'List recruitment agencies in the active tenant. The internal-employee bench is exposed ' +
+        'as the system "Internal" agency (isInternal=true). Hides archived rows by default.',
+      inputSchema: ListAgenciesInput,
+    },
+    async (args) =>
+      runTool(ctx, 'list_agencies', 'read', false, args, async () => {
+        const result = await withTenant(ctx.tenantId, async (tx) => {
+          const where = args.includeArchived ? undefined : eq(agencies.isActive, true)
+          const rows = await tx
+            .select()
+            .from(agencies)
+            .where(where)
+            .orderBy(desc(agencies.isInternal), agencies.name)
+          return rows
+        })
+        return jsonResult({ agencies: result })
+      })
+  )
+
+  server.registerTool(
+    'get_agency',
+    {
+      title: 'Get agency',
+      description: 'Fetch a single agency by id with its contact details and notes.',
+      inputSchema: GetAgencyInput,
+    },
+    async (args) =>
+      runTool(ctx, 'get_agency', 'read', false, args, async () => {
+        const result = await withTenant(ctx.tenantId, async (tx) => {
+          const [row] = await tx
+            .select()
+            .from(agencies)
+            .where(eq(agencies.id, args.agencyId))
+            .limit(1)
+          return row ?? null
+        })
+        return jsonResult({ agency: result })
+      })
+  )
+}

--- a/src/lib/mcp/tools/approvals.ts
+++ b/src/lib/mcp/tools/approvals.ts
@@ -1,0 +1,83 @@
+/**
+ * Approval MCP tools — hiring-manager-side surface for shortlist approvals.
+ *
+ * Reads (`get_approvals_for_role`) and writes (`approve_candidate`,
+ * `reject_candidate`) all delegate to the canonical actions in
+ * `src/actions/approvals.ts`. The actions enforce role-based gating
+ * (manager/admin) via the resolved ActionContext.
+ */
+
+import { z } from 'zod'
+import {
+  approveCandidate,
+  rejectCandidate,
+  getApprovalsForRole,
+} from '@/actions/approvals'
+import { runTool } from '../context'
+import type { McpContext } from '../context'
+import { jsonResult } from './candidates'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+export const GetApprovalsInput = {
+  roleId: z.string().uuid(),
+}
+
+export const DecisionInput = {
+  roleId: z.string().uuid(),
+  candidateId: z.string().uuid(),
+  comment: z.string().max(2000).optional(),
+  confirmed: z.literal(true),
+}
+
+export function registerApprovalTools(server: McpServer, ctx: McpContext): void {
+  server.registerTool(
+    'get_approvals_for_role',
+    {
+      title: 'Get approvals for role',
+      description:
+        'Fetch the approval state for every shortlisted candidate × assigned manager combination ' +
+        'on a role. Returns approval status (pending/approved/rejected), decided-at timestamps, ' +
+        'and comments. Used by recruiters to track shortlist progress.',
+      inputSchema: GetApprovalsInput,
+    },
+    async (args) =>
+      runTool(ctx, 'get_approvals_for_role', 'read', false, args, async () => {
+        const result = await getApprovalsForRole(args.roleId)
+        return jsonResult({ approvals: result })
+      })
+  )
+
+  server.registerTool(
+    'approve_candidate',
+    {
+      title: 'Approve candidate (hiring manager)',
+      description:
+        'Record a manager approval for a candidate on a role. Only assigned managers (or admins) ' +
+        'may decide. Optional comment. Requires write scope and confirmed: true.',
+      inputSchema: DecisionInput,
+    },
+    async (args) =>
+      runTool(ctx, 'approve_candidate', 'write', true, args, async () => {
+        const result = await approveCandidate(args.roleId, args.candidateId, args.comment)
+        if (!result.success) throw new Error(result.error)
+        return jsonResult({ ok: true })
+      })
+  )
+
+  server.registerTool(
+    'reject_candidate',
+    {
+      title: 'Reject candidate (hiring manager)',
+      description:
+        'Record a manager rejection for a candidate on a role. Only assigned managers (or admins) ' +
+        'may decide. Optional comment. Requires write scope and confirmed: true.',
+      inputSchema: DecisionInput,
+    },
+    async (args) =>
+      runTool(ctx, 'reject_candidate', 'write', true, args, async () => {
+        const result = await rejectCandidate(args.roleId, args.candidateId, args.comment)
+        if (!result.success) throw new Error(result.error)
+        return jsonResult({ ok: true })
+      })
+  )
+}

--- a/src/lib/mcp/tools/approvals.ts
+++ b/src/lib/mcp/tools/approvals.ts
@@ -12,6 +12,8 @@ import {
   approveCandidate,
   rejectCandidate,
   getApprovalsForRole,
+  sendShortlistForApproval,
+  approveAllRemaining,
 } from '@/actions/approvals'
 import { runTool } from '../context'
 import type { McpContext } from '../context'
@@ -25,6 +27,17 @@ export const GetApprovalsInput = {
 export const DecisionInput = {
   roleId: z.string().uuid(),
   candidateId: z.string().uuid(),
+  comment: z.string().max(2000).optional(),
+  confirmed: z.literal(true),
+}
+
+export const SendShortlistInput = {
+  roleId: z.string().uuid(),
+  confirmed: z.literal(true),
+}
+
+export const ApproveAllInput = {
+  roleId: z.string().uuid(),
   comment: z.string().max(2000).optional(),
   confirmed: z.literal(true),
 }
@@ -61,6 +74,42 @@ export function registerApprovalTools(server: McpServer, ctx: McpContext): void 
         const result = await approveCandidate(args.roleId, args.candidateId, args.comment)
         if (!result.success) throw new Error(result.error)
         return jsonResult({ ok: true })
+      })
+  )
+
+  server.registerTool(
+    'send_shortlist_for_approval',
+    {
+      title: 'Send shortlist for approval',
+      description:
+        'Mark a role\'s shortlist as sent to its assigned hiring managers and seed pending ' +
+        'approval rows for every (shortlisted candidate × manager) pair. Idempotent — re-sending ' +
+        'does not reset existing decisions. Recruiter/admin only. Requires write scope and confirmed: true.',
+      inputSchema: SendShortlistInput,
+    },
+    async (args) =>
+      runTool(ctx, 'send_shortlist_for_approval', 'write', true, args, async () => {
+        const result = await sendShortlistForApproval(args.roleId)
+        if (!result.success) throw new Error(result.error)
+        return jsonResult({ ok: true, roleId: args.roleId })
+      })
+  )
+
+  server.registerTool(
+    'approve_all_remaining',
+    {
+      title: 'Approve all remaining candidates (hiring manager)',
+      description:
+        'Bulk-approve every still-pending approval row owned by the calling manager on the role. ' +
+        'Manager scope (the calling user must be assigned as a manager on the role). Optional ' +
+        'comment is applied to every row. Requires write scope and confirmed: true.',
+      inputSchema: ApproveAllInput,
+    },
+    async (args) =>
+      runTool(ctx, 'approve_all_remaining', 'write', true, args, async () => {
+        const result = await approveAllRemaining(args.roleId, args.comment)
+        if (!result.success) throw new Error(result.error)
+        return jsonResult({ ok: true, roleId: args.roleId })
       })
   )
 

--- a/src/lib/mcp/tools/candidates.ts
+++ b/src/lib/mcp/tools/candidates.ts
@@ -1,0 +1,237 @@
+/**
+ * Candidate MCP tools — read + write surface for the candidate archive.
+ *
+ * Read tools query the DB directly inside `withTenant` (RLS enforced).
+ * Write tools delegate to the canonical server actions in
+ * `src/actions/candidates.ts` via the AsyncLocalStorage context shim
+ * established by `runTool`.
+ */
+
+import { z } from 'zod'
+import { eq, and, desc, ilike } from 'drizzle-orm'
+import { withTenant } from '@/db'
+import { candidates, scores, agencies } from '@/db/schema'
+import {
+  updateCandidateStatus,
+  updateCandidateAvailability,
+  archiveCandidate,
+} from '@/actions/candidates'
+import { runTool } from '../context'
+import type { McpContext } from '../context'
+import type { CandidateStatus, AvailabilityStatus } from '@/db/schema/candidates'
+
+// ─── Input schemas ────────────────────────────────────────────────────────────
+
+export const ListCandidatesInput = {
+  search: z.string().optional().describe('Optional case-insensitive substring match on first or last name'),
+  agencyId: z.string().uuid().optional(),
+  status: z.enum(['new', 'shortlisted', 'interviewing', 'offered', 'rejected', 'hired']).optional(),
+  availabilityStatus: z.enum(['available', 'on_project', 'unavailable']).optional(),
+  limit: z.number().int().min(1).max(200).optional().default(50),
+  offset: z.number().int().min(0).optional().default(0),
+}
+
+export const GetCandidateInput = {
+  candidateId: z.string().uuid(),
+}
+
+export const FindByEmailInput = {
+  email: z.string().email(),
+}
+
+export const UpdateStatusInput = {
+  candidateId: z.string().uuid(),
+  status: z.enum(['new', 'shortlisted', 'interviewing', 'offered', 'rejected', 'hired']),
+  confirmed: z.literal(true).describe('Must be true. Write tools require explicit confirmation.'),
+}
+
+export const UpdateAvailabilityInput = {
+  candidateId: z.string().uuid(),
+  availabilityStatus: z.enum(['available', 'on_project', 'unavailable']),
+  availableFrom: z.string().optional().describe('ISO date string (YYYY-MM-DD)'),
+  confirmed: z.literal(true),
+}
+
+export const ArchiveCandidateInput = {
+  candidateId: z.string().uuid(),
+  confirmed: z.literal(true),
+}
+
+// ─── Tool registration ────────────────────────────────────────────────────────
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+export function registerCandidateTools(server: McpServer, ctx: McpContext): void {
+  // -- list_candidates ----------------------------------------------------------
+  server.registerTool(
+    'list_candidates',
+    {
+      title: 'List candidates',
+      description:
+        'List candidates in the active tenant. Optional filters: substring search on name, ' +
+        'agencyId, pipeline status, availability status. Returns id, name, email, agency, status, ' +
+        'and (if scored) overallScore. Pagination via limit (max 200) and offset.',
+      inputSchema: ListCandidatesInput,
+    },
+    async (args) =>
+      runTool(ctx, 'list_candidates', 'read', false, args, async () => {
+        const limit = args.limit ?? 50
+        const offset = args.offset ?? 0
+        const result = await withTenant(ctx.tenantId, async (tx) => {
+          const conditions = [] as ReturnType<typeof eq>[]
+          if (args.agencyId) conditions.push(eq(candidates.agencyId, args.agencyId))
+          if (args.status) conditions.push(eq(candidates.status, args.status as CandidateStatus))
+          if (args.availabilityStatus) {
+            conditions.push(eq(candidates.availabilityStatus, args.availabilityStatus as AvailabilityStatus))
+          }
+          if (args.search) {
+            conditions.push(ilike(candidates.firstName, `%${args.search}%`))
+          }
+          const whereClause = conditions.length > 0 ? and(...conditions) : undefined
+
+          const rows = await tx
+            .select({
+              id: candidates.id,
+              firstName: candidates.firstName,
+              lastName: candidates.lastName,
+              email: candidates.email,
+              status: candidates.status,
+              availabilityStatus: candidates.availabilityStatus,
+              availableFrom: candidates.availableFrom,
+              agencyId: candidates.agencyId,
+              agencyName: agencies.name,
+              createdAt: candidates.createdAt,
+            })
+            .from(candidates)
+            .leftJoin(agencies, eq(candidates.agencyId, agencies.id))
+            .where(whereClause)
+            .orderBy(desc(candidates.createdAt))
+            .limit(limit)
+            .offset(offset)
+          return rows
+        })
+        return jsonResult({ candidates: result, limit, offset })
+      })
+  )
+
+  // -- get_candidate ------------------------------------------------------------
+  server.registerTool(
+    'get_candidate',
+    {
+      title: 'Get candidate',
+      description:
+        'Fetch a single candidate by id with their CV text, agency, contact details, rates, ' +
+        'and availability. Returns null if the candidate does not exist or belongs to another tenant.',
+      inputSchema: GetCandidateInput,
+    },
+    async (args) =>
+      runTool(ctx, 'get_candidate', 'read', false, args, async () => {
+        const result = await withTenant(ctx.tenantId, async (tx) => {
+          const [row] = await tx
+            .select()
+            .from(candidates)
+            .where(eq(candidates.id, args.candidateId))
+            .limit(1)
+          return row ?? null
+        })
+        return jsonResult({ candidate: result })
+      })
+  )
+
+  // -- find_candidate_by_email --------------------------------------------------
+  server.registerTool(
+    'find_candidate_by_email',
+    {
+      title: 'Find candidate by email',
+      description:
+        'Look up a candidate by their email address (case-insensitive). Returns the candidate ' +
+        'record or null. Useful when an external system references a person by email.',
+      inputSchema: FindByEmailInput,
+    },
+    async (args) =>
+      runTool(ctx, 'find_candidate_by_email', 'read', false, args, async () => {
+        const result = await withTenant(ctx.tenantId, async (tx) => {
+          const [row] = await tx
+            .select()
+            .from(candidates)
+            .where(ilike(candidates.email, args.email))
+            .limit(1)
+          return row ?? null
+        })
+        return jsonResult({ candidate: result })
+      })
+  )
+
+  // -- update_candidate_status -------------------------------------------------
+  server.registerTool(
+    'update_candidate_status',
+    {
+      title: 'Update candidate pipeline status',
+      description:
+        'Move a candidate to a new pipeline stage (new / shortlisted / interviewing / offered / ' +
+        'hired / rejected). Requires write scope and confirmed: true.',
+      inputSchema: UpdateStatusInput,
+    },
+    async (args) =>
+      runTool(ctx, 'update_candidate_status', 'write', true, args, async () => {
+        await updateCandidateStatus(args.candidateId, args.status as CandidateStatus)
+        return jsonResult({ ok: true, candidateId: args.candidateId, status: args.status })
+      })
+  )
+
+  // -- update_candidate_availability -------------------------------------------
+  server.registerTool(
+    'update_candidate_availability',
+    {
+      title: 'Update candidate availability',
+      description:
+        'Set a candidate\'s availability flag (available / on_project / unavailable) and an ' +
+        'optional availableFrom date. Requires write scope and confirmed: true.',
+      inputSchema: UpdateAvailabilityInput,
+    },
+    async (args) =>
+      runTool(ctx, 'update_candidate_availability', 'write', true, args, async () => {
+        const result = await updateCandidateAvailability(args.candidateId, {
+          availabilityStatus: args.availabilityStatus as AvailabilityStatus,
+          availableFrom: args.availableFrom ?? null,
+        })
+        if (!result.success) throw new Error(result.error)
+        return jsonResult({ ok: true })
+      })
+  )
+
+  // -- archive_candidate -------------------------------------------------------
+  server.registerTool(
+    'archive_candidate',
+    {
+      title: 'Archive candidate',
+      description:
+        'Soft-archive a candidate (sets isActive = false). The candidate remains queryable for ' +
+        'audit/history. Requires write scope and confirmed: true.',
+      inputSchema: ArchiveCandidateInput,
+    },
+    async (args) =>
+      runTool(ctx, 'archive_candidate', 'write', true, args, async () => {
+        await archiveCandidate(args.candidateId)
+        return jsonResult({ ok: true, candidateId: args.candidateId })
+      })
+  )
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Wraps a JSON-serialisable value into the MCP `CallToolResult` shape so
+ * clients can render it. JSON.stringify is safe here because all our return
+ * values are plain data (no functions, no class instances).
+ */
+export function jsonResult(value: unknown) {
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(value, null, 2),
+      },
+    ],
+  }
+}

--- a/src/lib/mcp/tools/candidates.ts
+++ b/src/lib/mcp/tools/candidates.ts
@@ -8,14 +8,16 @@
  */
 
 import { z } from 'zod'
-import { eq, and, desc, ilike } from 'drizzle-orm'
+import { eq, and, desc, ilike, sql } from 'drizzle-orm'
 import { withTenant } from '@/db'
-import { candidates, scores, agencies } from '@/db/schema'
+import { candidates, scores, agencies, roles } from '@/db/schema'
 import {
   updateCandidateStatus,
   updateCandidateAvailability,
   archiveCandidate,
+  createCandidate,
 } from '@/actions/candidates'
+import { getSuggestedCandidates } from '@/actions/matching'
 import { runTool } from '../context'
 import type { McpContext } from '../context'
 import type { CandidateStatus, AvailabilityStatus } from '@/db/schema/candidates'
@@ -54,6 +56,68 @@ export const UpdateAvailabilityInput = {
 
 export const ArchiveCandidateInput = {
   candidateId: z.string().uuid(),
+  confirmed: z.literal(true),
+}
+
+export const FindByNameInput = {
+  name: z.string().min(1).describe(
+    'Case-insensitive substring match against the concatenated "first last" name. Max 20 results.'
+  ),
+}
+
+export const SemanticSearchInput = {
+  roleId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe(
+      'Find candidates whose embeddings are most similar to this role\'s description. ' +
+        'Already-scored candidates on the role are excluded.'
+    ),
+  query: z
+    .string()
+    .optional()
+    .describe(
+      'Free-text query (LIMITATION v1: not yet supported by the underlying matching action; ' +
+        'returns a clear error when used without roleId).'
+    ),
+  limit: z.number().int().min(1).max(50).optional().default(10),
+}
+
+// CV-file payload for create_candidate. Mirrors the file-upload contract used
+// by the dashboard: the LLM hands us the raw bytes base64-encoded, we
+// reconstitute a Web `File` and feed it through the same server action the
+// browser uses, so validation, parsing, persistence, scoring, and embedding
+// behave identically across paths.
+const CvFilePayload = z.object({
+  filename: z.string().min(1).max(300),
+  mimeType: z.enum([
+    'application/pdf',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'application/vnd.oasis.opendocument.text',
+    'application/rtf',
+    'text/rtf',
+    'text/plain',
+    'text/markdown',
+  ]),
+  dataBase64: z.string().min(1).describe('Base64-encoded file bytes (max 10MB after decode)'),
+})
+
+export const CreateCandidateInput = {
+  firstName: z.string().min(1).max(100),
+  lastName: z.string().min(1).max(100),
+  // The createCandidate server action requires roleId — the candidate's first
+  // score row is created against this role at insert time. Surfaced as required
+  // here even though the spec listed it as optional, because the action itself
+  // will reject without it.
+  roleId: z.string().uuid().describe('The role to score the candidate against on creation'),
+  email: z.string().email().optional(),
+  phone: z.string().max(50).optional(),
+  agencyId: z.string().uuid().optional(),
+  candidateRate: z.number().min(0).optional(),
+  customerRate: z.number().min(0).optional(),
+  rateCurrency: z.enum(['GBP', 'EUR', 'USD', 'PLN']).optional(),
+  cvFile: CvFilePayload,
   confirmed: z.literal(true),
 }
 
@@ -197,6 +261,175 @@ export function registerCandidateTools(server: McpServer, ctx: McpContext): void
         })
         if (!result.success) throw new Error(result.error)
         return jsonResult({ ok: true })
+      })
+  )
+
+  // -- find_candidate_by_name --------------------------------------------------
+  server.registerTool(
+    'find_candidate_by_name',
+    {
+      title: 'Find candidate by name',
+      description:
+        'Case-insensitive substring match against `firstName + " " + lastName`. Returns up to ' +
+        '20 matches with their agency. Useful when the LLM has only a free-text name.',
+      inputSchema: FindByNameInput,
+    },
+    async (args) =>
+      runTool(ctx, 'find_candidate_by_name', 'read', false, args, async () => {
+        // Match against the concatenated "first last" so a query like "ada lovelace"
+        // hits both halves at once. Single ILIKE keeps the index strategy simple
+        // and avoids ranking trade-offs.
+        const pattern = `%${args.name.trim()}%`
+        const result = await withTenant(ctx.tenantId, async (tx) => {
+          const rows = await tx
+            .select({
+              id: candidates.id,
+              firstName: candidates.firstName,
+              lastName: candidates.lastName,
+              email: candidates.email,
+              status: candidates.status,
+              agencyName: agencies.name,
+            })
+            .from(candidates)
+            .leftJoin(agencies, eq(candidates.agencyId, agencies.id))
+            .where(
+              ilike(sql`${candidates.firstName} || ' ' || ${candidates.lastName}`, pattern)
+            )
+            .orderBy(candidates.lastName, candidates.firstName)
+            .limit(20)
+          return rows
+        })
+        return jsonResult({ candidates: result })
+      })
+  )
+
+  // -- semantic_search_candidates ----------------------------------------------
+  server.registerTool(
+    'semantic_search_candidates',
+    {
+      title: 'Semantic candidate search',
+      description:
+        'Vector-similarity search for candidates against a role\'s description using pgvector ' +
+        'cosine distance. Provide `roleId` (the action embeds the role text). Already-scored ' +
+        'candidates on the role are excluded. NOTE v1: free-text `query` is accepted by the ' +
+        'schema but returns a clear error — the underlying matching action only supports ' +
+        'roleId-based search at present.',
+      inputSchema: SemanticSearchInput,
+    },
+    async (args) =>
+      runTool(ctx, 'semantic_search_candidates', 'read', false, args, async () => {
+        if (!args.roleId && !args.query) {
+          throw new Error('Either roleId or query is required')
+        }
+        if (!args.roleId) {
+          // Free-text mode is documented as unsupported in v1. Fail loudly so
+          // the LLM knows to switch strategies rather than silently returning
+          // an empty list.
+          throw new Error(
+            'semantic_search_candidates: free-text `query` mode is not supported in v1. ' +
+              'Pass `roleId` instead — the matching action embeds the role text for you.'
+          )
+        }
+        // Look up the role text (description + requirements) so the matching
+        // action has something to embed.
+        const roleRow = await withTenant(ctx.tenantId, async (tx) => {
+          const [r] = await tx
+            .select({
+              description: roles.description,
+              requirements: roles.requirements,
+              title: roles.title,
+            })
+            .from(roles)
+            .where(eq(roles.id, args.roleId!))
+            .limit(1)
+          return r ?? null
+        })
+        if (!roleRow) throw new Error('Role not found')
+        const roleText = [roleRow.title, roleRow.description, roleRow.requirements]
+          .filter(Boolean)
+          .join('\n\n')
+        const limit = args.limit ?? 10
+        const suggestions = await getSuggestedCandidates(args.roleId, roleText, limit)
+        // Re-shape into { id, name, email, score, agencyName }. similarity is
+        // already 0-100 from the action.
+        const ids = suggestions.map((s) => s.id)
+        const agencyMap = new Map<string, string | null>()
+        if (ids.length > 0) {
+          await withTenant(ctx.tenantId, async (tx) => {
+            const rows = await tx
+              .select({
+                id: candidates.id,
+                agencyName: agencies.name,
+              })
+              .from(candidates)
+              .leftJoin(agencies, eq(candidates.agencyId, agencies.id))
+              .where(eq(candidates.tenantId, ctx.tenantId))
+            for (const r of rows) {
+              if (ids.includes(r.id)) agencyMap.set(r.id, r.agencyName ?? null)
+            }
+          })
+        }
+        return jsonResult({
+          candidates: suggestions.map((s) => ({
+            id: s.id,
+            firstName: s.firstName,
+            lastName: s.lastName,
+            email: s.email,
+            score: s.similarity,
+            agencyName: agencyMap.get(s.id) ?? null,
+          })),
+        })
+      })
+  )
+
+  // -- create_candidate --------------------------------------------------------
+  server.registerTool(
+    'create_candidate',
+    {
+      title: 'Create candidate from CV',
+      description:
+        'Create a new candidate by uploading a CV (base64-encoded). The CV is validated, ' +
+        'parsed, stored, and a pending score row is queued against the supplied roleId. ' +
+        'Embedding generation runs in the background. Max 10MB per file. Requires write scope ' +
+        'and confirmed: true.',
+      inputSchema: CreateCandidateInput,
+    },
+    async (args) =>
+      runTool(ctx, 'create_candidate', 'write', true, args, async () => {
+        // Decode + size-check before we hit the action so we can return a clean
+        // error rather than a generic "validation failed" downstream.
+        const buf = Buffer.from(args.cvFile.dataBase64, 'base64')
+        if (buf.byteLength === 0) {
+          throw new Error('cvFile.dataBase64 decoded to zero bytes')
+        }
+        if (buf.byteLength > 10 * 1024 * 1024) {
+          throw new Error('cvFile exceeds 10MB limit')
+        }
+        // Synthesize a Web File so we can reuse the createCandidate FormData
+        // path. `File` is a `Blob` with a name — node 22 has both globally.
+        const file = new File([buf], args.cvFile.filename, { type: args.cvFile.mimeType })
+        const fd = new FormData()
+        fd.set('firstName', args.firstName)
+        fd.set('lastName', args.lastName)
+        fd.set('roleId', args.roleId)
+        if (args.email) fd.set('email', args.email)
+        if (args.phone) fd.set('phone', args.phone)
+        if (args.agencyId) fd.set('agencyId', args.agencyId)
+        if (typeof args.candidateRate === 'number') fd.set('candidateRate', String(args.candidateRate))
+        if (typeof args.customerRate === 'number') fd.set('customerRate', String(args.customerRate))
+        if (args.rateCurrency) fd.set('rateCurrency', args.rateCurrency)
+        fd.set('cvFile', file)
+        const result = await createCandidate(null, fd)
+        if (!result.success) {
+          throw new Error(result.error || 'Failed to create candidate')
+        }
+        return jsonResult({
+          candidateId: result.candidateId,
+          status: 'parsing',
+          message:
+            'Candidate created. Scoring + embedding generation are running in the background — ' +
+            'use get_candidate_score to poll.',
+        })
       })
   )
 

--- a/src/lib/mcp/tools/customers.ts
+++ b/src/lib/mcp/tools/customers.ts
@@ -1,0 +1,67 @@
+/**
+ * Customer MCP tools — list and fetch the customer entities used as the
+ * client-side of role engagements.
+ */
+
+import { z } from 'zod'
+import { eq, desc } from 'drizzle-orm'
+import { withTenant } from '@/db'
+import { customers } from '@/db/schema'
+import { runTool } from '../context'
+import type { McpContext } from '../context'
+import { jsonResult } from './candidates'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+export const ListCustomersInput = {
+  includeArchived: z.boolean().optional().default(false),
+}
+
+export const GetCustomerInput = {
+  customerId: z.string().uuid(),
+}
+
+export function registerCustomerTools(server: McpServer, ctx: McpContext): void {
+  server.registerTool(
+    'list_customers',
+    {
+      title: 'List customers',
+      description: 'List customer entities (the companies we hire for). Archived rows hidden by default.',
+      inputSchema: ListCustomersInput,
+    },
+    async (args) =>
+      runTool(ctx, 'list_customers', 'read', false, args, async () => {
+        const result = await withTenant(ctx.tenantId, async (tx) => {
+          const where = args.includeArchived ? undefined : eq(customers.isActive, true)
+          const rows = await tx
+            .select()
+            .from(customers)
+            .where(where)
+            .orderBy(desc(customers.createdAt))
+          return rows
+        })
+        return jsonResult({ customers: result })
+      })
+  )
+
+  server.registerTool(
+    'get_customer',
+    {
+      title: 'Get customer',
+      description:
+        'Fetch a single customer by id with portal URL, contact details, and active status.',
+      inputSchema: GetCustomerInput,
+    },
+    async (args) =>
+      runTool(ctx, 'get_customer', 'read', false, args, async () => {
+        const result = await withTenant(ctx.tenantId, async (tx) => {
+          const [row] = await tx
+            .select()
+            .from(customers)
+            .where(eq(customers.id, args.customerId))
+            .limit(1)
+          return row ?? null
+        })
+        return jsonResult({ customer: result })
+      })
+  )
+}

--- a/src/lib/mcp/tools/exports.ts
+++ b/src/lib/mcp/tools/exports.ts
@@ -1,0 +1,723 @@
+/**
+ * Export MCP tools — produce binary attachments (PDFs and the raw CV) so an
+ * LLM client can attach them to an email/draft in a single tool call.
+ *
+ * Implementation rule from the wave 3b brief: do NOT call the REST export
+ * routes from here. We import the canonical react-pdf renderers
+ * (`CandidatePDF`, `RolePDF`, `ShortlistPDF`, `InterviewPackPDF`) directly and
+ * render to a Buffer with `@react-pdf/renderer`'s `renderToBuffer`. The data
+ * gathering mirrors the shape used by the REST routes (see
+ * `src/app/api/export/...`).
+ *
+ * The killer workflow tool — `compose_candidate_email_attachments` —
+ * delegates to the per-PDF helpers and the score/pack lookup so the LLM can
+ * say "fetch everything for the email" once instead of orchestrating 3-4
+ * tool calls.
+ */
+
+import { z } from 'zod'
+import React from 'react'
+import { join } from 'path'
+import fs from 'fs/promises'
+import { eq, and, desc, asc } from 'drizzle-orm'
+import { renderToBuffer } from '@react-pdf/renderer'
+import { withTenant } from '@/db'
+import {
+  candidates,
+  scores,
+  roles,
+  agencies,
+  customers,
+  notes,
+  interviewTranscripts,
+  transcriptAnalyses,
+  candidateEnrichments,
+  interviewPacks,
+  interviewQuestions,
+  codeChallenges,
+} from '@/db/schema'
+import type { WebHit, GitHubProfile } from '@/db/schema/candidate-enrichments'
+import type { QuestionResponse } from '@/db/schema/transcript-analyses'
+import {
+  CandidatePDF,
+  RolePDF,
+  ShortlistPDF,
+  InterviewPackPDF,
+} from '@/lib/pdf'
+import { getLogoAbsolutePath } from '@/lib/branding/store'
+import { runTool } from '../context'
+import type { McpContext } from '../context'
+import { jsonResult } from './candidates'
+import { bufferToAttachment, fileToAttachment, type Attachment } from '../attachment'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+// ─── Input schemas ────────────────────────────────────────────────────────────
+
+export const ExportCandidateCvInput = {
+  candidateId: z.string().uuid(),
+}
+
+export const ExportCandidatePdfInput = {
+  candidateId: z.string().uuid(),
+  roleId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('If supplied, the active score/role used in the PDF is the score for this role'),
+}
+
+export const ExportRolePdfInput = {
+  roleId: z.string().uuid(),
+}
+
+export const ExportShortlistPdfInput = {
+  roleId: z.string().uuid(),
+  audience: z.enum(['recruiter', 'customer']).default('recruiter'),
+}
+
+export const ExportInterviewPackPdfInput = {
+  packId: z.string().uuid(),
+}
+
+export const ComposeEmailInput = {
+  candidateId: z.string().uuid(),
+  roleId: z.string().uuid(),
+}
+
+// ─── PDF MIME ─────────────────────────────────────────────────────────────────
+
+const PDF_MIME = 'application/pdf'
+
+// ─── Internal helpers (used by both per-PDF tools and compose) ───────────────
+
+/**
+ * Resolve a CV file's on-disk absolute path from the DB-stored relative path.
+ * Mirrors the helper inside `deleteCvFile` in src/lib/cv/store.ts — no public
+ * `getCvAbsolutePath` exists at the moment, so this is the same one-line rule.
+ */
+function resolveCvAbsolutePath(filePath: string): string {
+  const relative = filePath.startsWith('/') ? filePath.slice(1) : filePath
+  return join(process.cwd(), relative)
+}
+
+/**
+ * Render the candidate CV file to an Attachment. If the candidate has no
+ * stored file path or the file is missing, returns null. We always declare
+ * the MIME via the fileType column (already canonicalised at upload time).
+ */
+async function fetchCandidateCvAttachment(
+  tenantId: string,
+  candidateId: string
+): Promise<Attachment | null> {
+  const [cand] = await withTenant(tenantId, async (tx) =>
+    tx
+      .select({
+        firstName: candidates.firstName,
+        lastName: candidates.lastName,
+        filePath: candidates.filePath,
+        fileType: candidates.fileType,
+      })
+      .from(candidates)
+      .where(and(eq(candidates.id, candidateId), eq(candidates.tenantId, tenantId)))
+      .limit(1)
+  )
+  if (!cand || !cand.filePath || !cand.fileType) return null
+  const abs = resolveCvAbsolutePath(cand.filePath)
+  // Map fileType to MIME for the attachment header.
+  const mime: Record<string, string> = {
+    pdf: 'application/pdf',
+    docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    odt: 'application/vnd.oasis.opendocument.text',
+    rtf: 'application/rtf',
+    txt: 'text/plain',
+    md: 'text/markdown',
+  }
+  const filename = `${cand.firstName}-${cand.lastName}-cv.${cand.fileType}`
+  try {
+    return await fileToAttachment(abs, filename, mime[cand.fileType] ?? 'application/octet-stream')
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Build the full data bundle the CandidatePDF needs and render it. Audience
+ * gates which fields are visible inside the PDF; sanitisation of the DB-side
+ * data happens in the REST export route for customer audiences. We keep the
+ * same data set on the MCP path because the prop itself controls visibility.
+ */
+async function renderCandidatePdf(
+  tenantId: string,
+  candidateId: string,
+  audience: 'internal' | 'customer',
+  roleIdHint?: string
+): Promise<Attachment | null> {
+  const data = await withTenant(tenantId, async (tx) => {
+    const [candidate] = await tx
+      .select()
+      .from(candidates)
+      .where(and(eq(candidates.id, candidateId), eq(candidates.tenantId, tenantId)))
+      .limit(1)
+    if (!candidate) return null
+
+    const [agencyResult, allScores, analyses, candidateNotes, enrichmentResult] =
+      await Promise.all([
+        candidate.agencyId
+          ? tx.select().from(agencies).where(eq(agencies.id, candidate.agencyId!)).limit(1)
+          : Promise.resolve([null]),
+        tx
+          .select({ score: scores, role: roles })
+          .from(scores)
+          .innerJoin(roles, eq(scores.roleId, roles.id))
+          .where(eq(scores.candidateId, candidateId))
+          .orderBy(desc(scores.updatedAt)),
+        tx
+          .select({
+            transcript_analyses: transcriptAnalyses,
+            interview_transcripts: interviewTranscripts,
+          })
+          .from(transcriptAnalyses)
+          .innerJoin(
+            interviewTranscripts,
+            eq(transcriptAnalyses.transcriptId, interviewTranscripts.id)
+          )
+          .where(eq(interviewTranscripts.candidateId, candidateId))
+          .orderBy(desc(transcriptAnalyses.createdAt)),
+        tx
+          .select()
+          .from(notes)
+          .where(eq(notes.candidateId, candidateId))
+          .orderBy(desc(notes.createdAt)),
+        tx
+          .select()
+          .from(candidateEnrichments)
+          .where(eq(candidateEnrichments.candidateId, candidateId))
+          .limit(1),
+      ])
+
+    return { candidate, agencyResult, allScores, analyses, candidateNotes, enrichmentResult }
+  })
+
+  if (!data) return null
+  const { candidate, agencyResult, allScores, analyses, candidateNotes, enrichmentResult } = data
+  const agency = agencyResult[0] ?? null
+  const enrichmentRow = enrichmentResult[0] ?? null
+
+  // Pick active score: prefer the hinted role, then any complete score, then
+  // any score at all. Mirrors the REST route fallback logic.
+  let activeScore = null
+  let activeRole = null
+  if (roleIdHint) {
+    const match = allScores.find((s) => s.score.roleId === roleIdHint)
+    if (match) {
+      activeScore = match.score
+      activeRole = match.role
+    }
+  }
+  if (!activeScore) {
+    const firstComplete = allScores.find((s) => s.score.scoreStatus === 'complete')
+    const fallback = firstComplete ?? allScores[0]
+    if (fallback) {
+      activeScore = fallback.score
+      activeRole = fallback.role
+    }
+  }
+
+  const rawAnalyses = analyses.map((a) => ({
+    overallScore: a.transcript_analyses.overallScore,
+    communicationScore: a.transcript_analyses.communicationScore,
+    technicalDepthScore: a.transcript_analyses.technicalDepthScore,
+    problemSolvingScore: a.transcript_analyses.problemSolvingScore,
+    socialFitScore: a.transcript_analyses.socialFitScore,
+    communicationReasoning: a.transcript_analyses.communicationReasoning,
+    technicalDepthReasoning: a.transcript_analyses.technicalDepthReasoning,
+    problemSolvingReasoning: a.transcript_analyses.problemSolvingReasoning,
+    socialFitReasoning: a.transcript_analyses.socialFitReasoning,
+    summary: a.transcript_analyses.summary,
+    strengths: a.transcript_analyses.strengths,
+    redFlags: a.transcript_analyses.redFlags,
+    recommendedDecision: a.transcript_analyses.recommendedDecision,
+    questionResponses: a.transcript_analyses.questionResponses,
+    createdAt: a.transcript_analyses.createdAt,
+  }))
+
+  // For customer PDFs we mirror the REST route's redaction: drop notes,
+  // suppress redFlags / recommendedDecision, blank low-score reasoning.
+  const finalAnalyses =
+    audience === 'customer'
+      ? rawAnalyses.map((a) => {
+          const blank = (r: string | null, s: number | null) =>
+            s !== null && s < 60 ? null : r
+          const safeQR: QuestionResponse[] | null = Array.isArray(a.questionResponses)
+            ? (a.questionResponses as QuestionResponse[]).filter(
+                (q) => q.quality !== 'weak'
+              )
+            : (a.questionResponses as QuestionResponse[] | null)
+          return {
+            ...a,
+            redFlags: null,
+            recommendedDecision: null,
+            communicationReasoning: blank(a.communicationReasoning, a.communicationScore),
+            technicalDepthReasoning: blank(a.technicalDepthReasoning, a.technicalDepthScore),
+            problemSolvingReasoning: blank(a.problemSolvingReasoning, a.problemSolvingScore),
+            socialFitReasoning: blank(a.socialFitReasoning, a.socialFitScore),
+            questionResponses: safeQR,
+          }
+        })
+      : rawAnalyses
+  const finalNotes =
+    audience === 'customer'
+      ? []
+      : candidateNotes.map((n) => ({ body: n.body, createdAt: n.createdAt, isEdited: n.isEdited }))
+
+  // Inline the agency logo (internal PDFs only) — tolerant of missing file.
+  let agencyLogoBase64: string | undefined
+  if (audience === 'internal' && agency?.logoPath) {
+    try {
+      const absPath = getLogoAbsolutePath(agency.logoPath)
+      const logoBuffer = await fs.readFile(absPath)
+      const ext = agency.logoPath.split('.').pop()?.toLowerCase() ?? 'png'
+      const mime =
+        ext === 'jpg' || ext === 'jpeg'
+          ? 'image/jpeg'
+          : ext === 'webp'
+            ? 'image/webp'
+            : ext === 'svg'
+              ? 'image/svg+xml'
+              : 'image/png'
+      agencyLogoBase64 = `data:${mime};base64,${logoBuffer.toString('base64')}`
+    } catch {
+      // swallow — logo is best-effort
+    }
+  }
+
+  const buffer = await renderToBuffer(
+    React.createElement(CandidatePDF, {
+      candidate,
+      agencyName: agency?.name ?? null,
+      agencyLogoBase64,
+      audience,
+      activeScore,
+      activeRole,
+      roleHistory: allScores
+        .filter((s) => s.score.scoreStatus === 'complete')
+        .map((s) => ({
+          roleTitle: s.role.title,
+          overallScore: s.score.overallScore,
+          technicalScore: s.score.technicalScore,
+          experienceScore: s.score.experienceScore,
+          culturalFitScore: s.score.culturalFitScore,
+          communicationScore: s.score.communicationScore,
+          scoredAt: s.score.updatedAt,
+        })),
+      transcriptAnalyses: finalAnalyses,
+      notes: finalNotes,
+      enrichment: enrichmentRow
+        ? {
+            webHits: (enrichmentRow.webHits ?? []) as WebHit[],
+            githubProfile: (enrichmentRow.githubProfile ?? null) as GitHubProfile | null,
+          }
+        : null,
+      generatedAt: new Date(),
+    // @react-pdf JSX typing wrinkle — same `as any` used by the REST routes.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any
+  )
+
+  const filename =
+    audience === 'customer'
+      ? `customer-profile-${candidate.firstName}-${candidate.lastName}.pdf`
+      : `${candidate.firstName}-${candidate.lastName}-profile.pdf`
+  return bufferToAttachment(buffer, filename, PDF_MIME)
+}
+
+/**
+ * Render the role brief PDF.
+ */
+async function renderRolePdf(tenantId: string, roleId: string): Promise<Attachment | null> {
+  const result = await withTenant(tenantId, async (tx) => {
+    const [role] = await tx
+      .select()
+      .from(roles)
+      .where(and(eq(roles.id, roleId), eq(roles.tenantId, tenantId)))
+      .limit(1)
+    if (!role) return null
+    let customerName: string | null = null
+    if (role.customerId) {
+      const [customer] = await tx
+        .select({ name: customers.name })
+        .from(customers)
+        .where(eq(customers.id, role.customerId!))
+        .limit(1)
+      customerName = customer?.name ?? null
+    }
+    return { role, customerName }
+  })
+  if (!result) return null
+  const { role, customerName } = result
+  const buffer = await renderToBuffer(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    React.createElement(RolePDF, { role, customerName }) as any
+  )
+  return bufferToAttachment(
+    buffer,
+    `role-${role.title.replace(/\s+/g, '-')}.pdf`,
+    PDF_MIME
+  )
+}
+
+/**
+ * Render the shortlist PDF for a role. `audience` here is the same shape as
+ * the REST route — recruiter (internal) keeps notes/rates/margin, customer
+ * has them suppressed by upstream logic. Since ShortlistPDF itself accepts
+ * the entries verbatim, the audience flag mainly drives margin omission for
+ * customer (when role.customerDayRate is masked we skip the margin calc).
+ */
+async function renderShortlistPdf(
+  tenantId: string,
+  roleId: string,
+  audience: 'recruiter' | 'customer'
+): Promise<Attachment | null> {
+  const result = await withTenant(tenantId, async (tx) => {
+    const [role] = await tx
+      .select()
+      .from(roles)
+      .where(and(eq(roles.id, roleId), eq(roles.tenantId, tenantId)))
+      .limit(1)
+    if (!role) return null
+    const candidateScores = await tx
+      .select({ candidate: candidates, score: scores })
+      .from(scores)
+      .innerJoin(candidates, eq(scores.candidateId, candidates.id))
+      .where(and(eq(scores.roleId, roleId), eq(scores.scoreStatus, 'complete')))
+      .orderBy(desc(scores.overallScore))
+      .limit(100)
+    const agencyRows = await tx.select({ id: agencies.id, name: agencies.name }).from(agencies)
+    const agencyMap = new Map(agencyRows.map((a) => [a.id, a.name]))
+    let customerName: string | null = null
+    if (role.customerId) {
+      const [customer] = await tx
+        .select({ name: customers.name })
+        .from(customers)
+        .where(eq(customers.id, role.customerId!))
+        .limit(1)
+      customerName = customer?.name ?? null
+    }
+    return { role, candidateScores, agencyMap, customerName }
+  })
+  if (!result) return null
+  const { role, candidateScores, agencyMap, customerName } = result
+  const entries = candidateScores.map(({ candidate, score }) => {
+    let margin: { amount: number; currency: string; mismatch: boolean } | null = null
+    // For customer audience, hide the recruiter-side margin calculation.
+    if (audience === 'recruiter' && role.customerDayRate && candidate.candidateRate) {
+      const mismatch = Boolean(
+        role.rateCurrency && candidate.rateCurrency && role.rateCurrency !== candidate.rateCurrency
+      )
+      margin = {
+        amount: Number(role.customerDayRate) - Number(candidate.candidateRate),
+        currency: role.rateCurrency ?? candidate.rateCurrency ?? '',
+        mismatch,
+      }
+    }
+    return {
+      candidate,
+      score,
+      agencyName: candidate.agencyId ? (agencyMap.get(candidate.agencyId) ?? null) : null,
+      margin,
+    }
+  })
+  const buffer = await renderToBuffer(
+    React.createElement(ShortlistPDF, {
+      entries,
+      roleTitle: role.title,
+      role,
+      customerName,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any
+  )
+  const stem = audience === 'customer' ? 'shortlist-customer' : 'shortlist'
+  return bufferToAttachment(
+    buffer,
+    `${stem}-${role.title.replace(/\s+/g, '-')}.pdf`,
+    PDF_MIME
+  )
+}
+
+/**
+ * Render an interview pack PDF. Returns null if the pack is missing or not
+ * yet complete.
+ */
+async function renderInterviewPackPdf(
+  tenantId: string,
+  packId: string
+): Promise<Attachment | null> {
+  const result = await withTenant(tenantId, async (tx) => {
+    const [pack] = await tx
+      .select()
+      .from(interviewPacks)
+      .where(and(eq(interviewPacks.id, packId), eq(interviewPacks.tenantId, tenantId)))
+      .limit(1)
+    if (!pack) return null
+    if (pack.generationStatus !== 'complete') return null
+    const [candidate] = await tx
+      .select()
+      .from(candidates)
+      .where(eq(candidates.id, pack.candidateId))
+      .limit(1)
+    const [role] = await tx.select().from(roles).where(eq(roles.id, pack.roleId)).limit(1)
+    const questions = await tx
+      .select()
+      .from(interviewQuestions)
+      .where(eq(interviewQuestions.packId, packId))
+      .orderBy(asc(interviewQuestions.orderIndex))
+    const [codeChallenge] = await tx
+      .select()
+      .from(codeChallenges)
+      .where(eq(codeChallenges.packId, packId))
+      .limit(1)
+    return { pack, candidate, role, questions, codeChallenge: codeChallenge ?? null }
+  })
+  if (!result) return null
+  const { pack, candidate, role, questions, codeChallenge } = result
+  const candidateName = candidate ? `${candidate.firstName} ${candidate.lastName}` : 'Candidate'
+  const roleTitle = role?.title ?? 'Unknown Role'
+  const buffer = await renderToBuffer(
+    React.createElement(InterviewPackPDF, {
+      pack,
+      questions,
+      codeChallenge,
+      candidateName,
+      roleTitle,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any
+  )
+  return bufferToAttachment(
+    buffer,
+    `interview-pack-${candidateName.replace(/\s+/g, '-')}.pdf`,
+    PDF_MIME
+  )
+}
+
+// ─── Tool registration ────────────────────────────────────────────────────────
+
+export function registerExportTools(server: McpServer, ctx: McpContext): void {
+  // -- export_candidate_cv_pdf -------------------------------------------------
+  server.registerTool(
+    'export_candidate_cv_pdf',
+    {
+      title: 'Export candidate CV (raw file)',
+      description:
+        'Return the candidate\'s stored CV file as a base64 attachment. The file is whatever ' +
+        'format was uploaded (PDF/DOCX/ODT/RTF/TXT/MD) — not necessarily PDF. Returns null ' +
+        'attachment if the candidate has no stored file.',
+      inputSchema: ExportCandidateCvInput,
+    },
+    async (args) =>
+      runTool(ctx, 'export_candidate_cv_pdf', 'read', false, args, async () => {
+        const att = await fetchCandidateCvAttachment(ctx.tenantId, args.candidateId)
+        return jsonResult({ attachment: att })
+      })
+  )
+
+  // -- export_candidate_internal_pdf -------------------------------------------
+  server.registerTool(
+    'export_candidate_internal_pdf',
+    {
+      title: 'Export candidate profile PDF (internal)',
+      description:
+        'Render the full internal candidate profile PDF — includes scores, agency, rates, ' +
+        'recruiter notes, transcript red flags, and recommended decision. If roleId is supplied ' +
+        'the PDF\'s "active role" section uses that role\'s score; otherwise the most recent ' +
+        'complete score is used.',
+      inputSchema: ExportCandidatePdfInput,
+    },
+    async (args) =>
+      runTool(ctx, 'export_candidate_internal_pdf', 'read', false, args, async () => {
+        const att = await renderCandidatePdf(
+          ctx.tenantId,
+          args.candidateId,
+          'internal',
+          args.roleId
+        )
+        return jsonResult({ attachment: att })
+      })
+  )
+
+  // -- export_candidate_customer_pdf -------------------------------------------
+  server.registerTool(
+    'export_candidate_customer_pdf',
+    {
+      title: 'Export candidate profile PDF (customer-safe)',
+      description:
+        'Render the customer-facing candidate profile PDF — strips recruiter notes, candidate ' +
+        'rate, margin, red flags, recommended decision, and blanks low-confidence transcript ' +
+        'reasoning. Safe to forward outside the company.',
+      inputSchema: ExportCandidatePdfInput,
+    },
+    async (args) =>
+      runTool(ctx, 'export_candidate_customer_pdf', 'read', false, args, async () => {
+        const att = await renderCandidatePdf(
+          ctx.tenantId,
+          args.candidateId,
+          'customer',
+          args.roleId
+        )
+        return jsonResult({ attachment: att })
+      })
+  )
+
+  // -- export_role_brief_pdf ---------------------------------------------------
+  server.registerTool(
+    'export_role_brief_pdf',
+    {
+      title: 'Export role brief PDF',
+      description:
+        'Render a one-role-brief PDF with title, customer, location, work mode, language ' +
+        'requirements, key skills, top requirements, budget, and the full description + requirements.',
+      inputSchema: ExportRolePdfInput,
+    },
+    async (args) =>
+      runTool(ctx, 'export_role_brief_pdf', 'read', false, args, async () => {
+        const att = await renderRolePdf(ctx.tenantId, args.roleId)
+        return jsonResult({ attachment: att })
+      })
+  )
+
+  // -- export_shortlist_pdf ----------------------------------------------------
+  server.registerTool(
+    'export_shortlist_pdf',
+    {
+      title: 'Export shortlist PDF',
+      description:
+        'Render the ranked shortlist for a role as a single PDF. audience="recruiter" includes ' +
+        'agency + margin per candidate; audience="customer" suppresses the margin column.',
+      inputSchema: ExportShortlistPdfInput,
+    },
+    async (args) =>
+      runTool(ctx, 'export_shortlist_pdf', 'read', false, args, async () => {
+        const audience = args.audience ?? 'recruiter'
+        const att = await renderShortlistPdf(ctx.tenantId, args.roleId, audience)
+        return jsonResult({ attachment: att })
+      })
+  )
+
+  // -- export_interview_pack_pdf -----------------------------------------------
+  server.registerTool(
+    'export_interview_pack_pdf',
+    {
+      title: 'Export interview pack PDF',
+      description:
+        'Render a fully-generated interview pack (questions + optional code challenge) as a PDF. ' +
+        'Returns null attachment if the pack does not exist or has not finished generating ' +
+        '(generationStatus must be "complete").',
+      inputSchema: ExportInterviewPackPdfInput,
+    },
+    async (args) =>
+      runTool(ctx, 'export_interview_pack_pdf', 'read', false, args, async () => {
+        const att = await renderInterviewPackPdf(ctx.tenantId, args.packId)
+        return jsonResult({ attachment: att })
+      })
+  )
+
+  // -- compose_candidate_email_attachments -------------------------------------
+  server.registerTool(
+    'compose_candidate_email_attachments',
+    {
+      title: 'Compose candidate email attachments',
+      description:
+        'Killer-workflow tool. Returns everything an LLM needs to draft an email about a ' +
+        'candidate-on-a-role in a single call: { candidate, role, attachments: { cv, ' +
+        'interviewPack?, scoreSummary } }. Sub-fetches: (1) the raw CV file from disk, (2) the ' +
+        'most recent interview pack for this candidate × role pair (omitted if none exists or ' +
+        'the latest is not yet complete), (3) the structured score record (overall, dimensions, ' +
+        'reasoning, summary). Read-only; no confirm.',
+      inputSchema: ComposeEmailInput,
+    },
+    async (args) =>
+      runTool(ctx, 'compose_candidate_email_attachments', 'read', false, args, async () => {
+        const { tenantId } = ctx
+        // Fetch all three sub-pieces in parallel within one withTenant for the
+        // metadata reads; the CV read is filesystem so it sits outside.
+        const meta = await withTenant(tenantId, async (tx) => {
+          const [cand] = await tx
+            .select({
+              id: candidates.id,
+              firstName: candidates.firstName,
+              lastName: candidates.lastName,
+            })
+            .from(candidates)
+            .where(and(eq(candidates.id, args.candidateId), eq(candidates.tenantId, tenantId)))
+            .limit(1)
+          const [role] = await tx
+            .select({ id: roles.id, title: roles.title })
+            .from(roles)
+            .where(and(eq(roles.id, args.roleId), eq(roles.tenantId, tenantId)))
+            .limit(1)
+          const [scoreRow] = await tx
+            .select()
+            .from(scores)
+            .where(
+              and(eq(scores.candidateId, args.candidateId), eq(scores.roleId, args.roleId))
+            )
+            .limit(1)
+          // Most recent interview pack (any status) for this pair — we'll
+          // only attempt to render the PDF if it's complete.
+          const [latestPack] = await tx
+            .select()
+            .from(interviewPacks)
+            .where(
+              and(
+                eq(interviewPacks.candidateId, args.candidateId),
+                eq(interviewPacks.roleId, args.roleId)
+              )
+            )
+            .orderBy(desc(interviewPacks.createdAt))
+            .limit(1)
+          return { cand, role, scoreRow, latestPack }
+        })
+
+        if (!meta.cand) throw new Error('Candidate not found')
+        if (!meta.role) throw new Error('Role not found')
+
+        const cv = await fetchCandidateCvAttachment(tenantId, args.candidateId)
+        let interviewPack: Attachment | null = null
+        if (meta.latestPack && meta.latestPack.generationStatus === 'complete') {
+          interviewPack = await renderInterviewPackPdf(tenantId, meta.latestPack.id)
+        }
+
+        const scoreSummary = meta.scoreRow
+          ? {
+              status: meta.scoreRow.scoreStatus,
+              overall: meta.scoreRow.overallScore,
+              dimensions: {
+                technical: meta.scoreRow.technicalScore,
+                experience: meta.scoreRow.experienceScore,
+                culturalFit: meta.scoreRow.culturalFitScore,
+                communication: meta.scoreRow.communicationScore,
+              },
+              summary: meta.scoreRow.aiSummary,
+              reasoning: {
+                technical: meta.scoreRow.technicalReasoning,
+                experience: meta.scoreRow.experienceReasoning,
+                culturalFit: meta.scoreRow.culturalFitReasoning,
+                communication: meta.scoreRow.communicationReasoning,
+              },
+            }
+          : null
+
+        return jsonResult({
+          candidate: {
+            id: meta.cand.id,
+            name: `${meta.cand.firstName} ${meta.cand.lastName}`,
+          },
+          role: { id: meta.role.id, title: meta.role.title },
+          attachments: {
+            cv,
+            interviewPack,
+            scoreSummary,
+          },
+        })
+      })
+  )
+}

--- a/src/lib/mcp/tools/index.ts
+++ b/src/lib/mcp/tools/index.ts
@@ -1,0 +1,36 @@
+/**
+ * MCP tool registry barrel.
+ *
+ * Each `registerXxx` function takes the MCP server and the per-request
+ * context and registers all tools in its category. Adding a new category
+ * means: write the file, register it here, and update the help article.
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { McpContext } from '../context'
+
+import { registerCandidateTools } from './candidates'
+import { registerRoleTools } from './roles'
+import { registerAgencyTools } from './agencies'
+import { registerCustomerTools } from './customers'
+import { registerScoringTools } from './scoring'
+import { registerInterviewTools } from './interviews'
+import { registerApprovalTools } from './approvals'
+import { registerManagerTools } from './managers'
+import { registerNoteTools } from './notes'
+import { registerUserTools } from './users'
+import { registerSettingsTools } from './settings'
+
+export function registerAllTools(server: McpServer, ctx: McpContext): void {
+  registerCandidateTools(server, ctx)
+  registerRoleTools(server, ctx)
+  registerAgencyTools(server, ctx)
+  registerCustomerTools(server, ctx)
+  registerScoringTools(server, ctx)
+  registerInterviewTools(server, ctx)
+  registerApprovalTools(server, ctx)
+  registerManagerTools(server, ctx)
+  registerNoteTools(server, ctx)
+  registerUserTools(server, ctx)
+  registerSettingsTools(server, ctx)
+}

--- a/src/lib/mcp/tools/index.ts
+++ b/src/lib/mcp/tools/index.ts
@@ -20,6 +20,7 @@ import { registerManagerTools } from './managers'
 import { registerNoteTools } from './notes'
 import { registerUserTools } from './users'
 import { registerSettingsTools } from './settings'
+import { registerExportTools } from './exports'
 
 export function registerAllTools(server: McpServer, ctx: McpContext): void {
   registerCandidateTools(server, ctx)
@@ -33,4 +34,5 @@ export function registerAllTools(server: McpServer, ctx: McpContext): void {
   registerNoteTools(server, ctx)
   registerUserTools(server, ctx)
   registerSettingsTools(server, ctx)
+  registerExportTools(server, ctx)
 }

--- a/src/lib/mcp/tools/interviews.ts
+++ b/src/lib/mcp/tools/interviews.ts
@@ -1,0 +1,85 @@
+/**
+ * Interview MCP tools — read interview packs (full + pre-screening). Pack
+ * GENERATION is intentionally not exposed via MCP in this MVP because it's
+ * a long-running AI workflow with progress streaming; LLM clients should
+ * trigger it via the dashboard. We expose listing + reading for now.
+ */
+
+import { z } from 'zod'
+import { eq, desc, and } from 'drizzle-orm'
+import { withTenant } from '@/db'
+import { interviewPacks, interviewQuestions } from '@/db/schema'
+import { runTool } from '../context'
+import type { McpContext } from '../context'
+import { jsonResult } from './candidates'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+export const ListPacksInput = {
+  candidateId: z.string().uuid().optional(),
+  roleId: z.string().uuid().optional(),
+  limit: z.number().int().min(1).max(100).optional().default(20),
+}
+
+export const GetPackInput = {
+  packId: z.string().uuid(),
+}
+
+export function registerInterviewTools(server: McpServer, ctx: McpContext): void {
+  server.registerTool(
+    'list_interview_packs',
+    {
+      title: 'List interview packs',
+      description:
+        'List interview packs in the active tenant. Filter by candidateId and/or roleId. ' +
+        'Includes generation status (pending/processing/complete/failed), packType, language, ' +
+        'and recommended duration.',
+      inputSchema: ListPacksInput,
+    },
+    async (args) =>
+      runTool(ctx, 'list_interview_packs', 'read', false, args, async () => {
+        const limit = args.limit ?? 20
+        const result = await withTenant(ctx.tenantId, async (tx) => {
+          const conds: ReturnType<typeof eq>[] = []
+          if (args.candidateId) conds.push(eq(interviewPacks.candidateId, args.candidateId))
+          if (args.roleId) conds.push(eq(interviewPacks.roleId, args.roleId))
+          const where = conds.length > 0 ? and(...conds) : undefined
+          const rows = await tx
+            .select()
+            .from(interviewPacks)
+            .where(where)
+            .orderBy(desc(interviewPacks.createdAt))
+            .limit(limit)
+          return rows
+        })
+        return jsonResult({ packs: result })
+      })
+  )
+
+  server.registerTool(
+    'get_interview_pack',
+    {
+      title: 'Get interview pack',
+      description:
+        'Fetch a full interview pack (the pack record plus all generated questions). Returns ' +
+        '{ pack: null, questions: [] } if the pack id is not found in the active tenant.',
+      inputSchema: GetPackInput,
+    },
+    async (args) =>
+      runTool(ctx, 'get_interview_pack', 'read', false, args, async () => {
+        const result = await withTenant(ctx.tenantId, async (tx) => {
+          const [pack] = await tx
+            .select()
+            .from(interviewPacks)
+            .where(eq(interviewPacks.id, args.packId))
+            .limit(1)
+          if (!pack) return { pack: null, questions: [] }
+          const questions = await tx
+            .select()
+            .from(interviewQuestions)
+            .where(eq(interviewQuestions.packId, args.packId))
+          return { pack, questions }
+        })
+        return jsonResult(result)
+      })
+  )
+}

--- a/src/lib/mcp/tools/interviews.ts
+++ b/src/lib/mcp/tools/interviews.ts
@@ -9,6 +9,7 @@ import { z } from 'zod'
 import { eq, desc, and } from 'drizzle-orm'
 import { withTenant } from '@/db'
 import { interviewPacks, interviewQuestions } from '@/db/schema'
+import { createInterviewPack } from '@/actions/interview'
 import { runTool } from '../context'
 import type { McpContext } from '../context'
 import { jsonResult } from './candidates'
@@ -22,6 +23,24 @@ export const ListPacksInput = {
 
 export const GetPackInput = {
   packId: z.string().uuid(),
+}
+
+export const GenerateInterviewPackInput = {
+  candidateId: z.string().uuid(),
+  roleId: z.string().uuid(),
+  language: z
+    .string()
+    .optional()
+    .describe('ISO 639-1 language code, e.g. "en", "pl". Defaults to "en".'),
+  includeCodeChallenge: z
+    .boolean()
+    .optional()
+    .describe('Only honoured for level=full_technical. Pre-screening packs never include code.'),
+  level: z
+    .enum(['pre_screening', 'full_technical'])
+    .optional()
+    .describe('Pack type. Defaults to "full_technical".'),
+  confirmed: z.literal(true),
 }
 
 export function registerInterviewTools(server: McpServer, ctx: McpContext): void {
@@ -52,6 +71,34 @@ export function registerInterviewTools(server: McpServer, ctx: McpContext): void
           return rows
         })
         return jsonResult({ packs: result })
+      })
+  )
+
+  server.registerTool(
+    'generate_interview_pack',
+    {
+      title: 'Generate interview pack',
+      description:
+        'Queue an interview pack generation job for a candidate × role pair. The pack is created ' +
+        'with status="pending" — actual AI generation runs in the background; the LLM should poll ' +
+        'get_interview_pack to fetch the questions once status="complete". Pre-screening packs ' +
+        'are short, full_technical packs are longer and may include a code challenge. Recruiter/admin only. ' +
+        'Requires write scope and confirmed: true.',
+      inputSchema: GenerateInterviewPackInput,
+    },
+    async (args) =>
+      runTool(ctx, 'generate_interview_pack', 'write', true, args, async () => {
+        const fd = new FormData()
+        fd.set('candidateId', args.candidateId)
+        fd.set('roleId', args.roleId)
+        fd.set('packType', args.level ?? 'full_technical')
+        fd.set('language', args.language ?? 'en')
+        // The action coerces 'true'/'false' strings to bool. Pre-screening
+        // path always wins regardless of this flag (server-side override).
+        fd.set('includeCodeChallenge', args.includeCodeChallenge ? 'true' : 'false')
+        const result = await createInterviewPack(null, fd)
+        if (!result.success) throw new Error(result.error)
+        return jsonResult({ packId: result.packId, status: 'queued' })
       })
   )
 

--- a/src/lib/mcp/tools/managers.ts
+++ b/src/lib/mcp/tools/managers.ts
@@ -1,0 +1,33 @@
+/**
+ * Hiring-manager MCP tools — surfaces the manager's assigned-roles view so
+ * an LLM client (e.g. claude-desktop running as a manager) can fetch a
+ * personalised dashboard.
+ */
+
+import { z } from 'zod'
+import { getMyAssignedRoles } from '@/actions/role-managers'
+import { runTool } from '../context'
+import type { McpContext } from '../context'
+import { jsonResult } from './candidates'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+// Empty input schema — uses no arguments, just the calling user's identity
+export const NoInput = {} as const
+
+export function registerManagerTools(server: McpServer, ctx: McpContext): void {
+  server.registerTool(
+    'get_my_assigned_roles',
+    {
+      title: 'Get my assigned roles (hiring manager)',
+      description:
+        'For the calling hiring manager, list every role that has been assigned to them with ' +
+        'pending and decided counts. Returns an empty list if the caller is not a manager.',
+      inputSchema: NoInput,
+    },
+    async (args) =>
+      runTool(ctx, 'get_my_assigned_roles', 'read', false, args, async () => {
+        const result = await getMyAssignedRoles()
+        return jsonResult({ assignedRoles: result })
+      })
+  )
+}

--- a/src/lib/mcp/tools/managers.ts
+++ b/src/lib/mcp/tools/managers.ts
@@ -5,7 +5,12 @@
  */
 
 import { z } from 'zod'
-import { getMyAssignedRoles } from '@/actions/role-managers'
+import {
+  getMyAssignedRoles,
+  assignRoleManagers,
+  removeRoleManager,
+  getRoleManagers,
+} from '@/actions/role-managers'
 import { runTool } from '../context'
 import type { McpContext } from '../context'
 import { jsonResult } from './candidates'
@@ -13,6 +18,30 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 
 // Empty input schema — uses no arguments, just the calling user's identity
 export const NoInput = {} as const
+
+export const AssignManagersInput = {
+  roleId: z.string().uuid(),
+  userIds: z.array(z.string().uuid()).describe(
+    'Replacement set of hiring-manager user IDs. Pass [] to clear all assignments. ' +
+      'Non-hiring_manager users are silently dropped by the action.'
+  ),
+  primaryUserId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('Optional — must also appear in userIds to take effect'),
+  confirmed: z.literal(true),
+}
+
+export const RemoveManagerInput = {
+  roleId: z.string().uuid(),
+  userId: z.string().uuid(),
+  confirmed: z.literal(true),
+}
+
+export const GetRoleManagersInput = {
+  roleId: z.string().uuid(),
+}
 
 export function registerManagerTools(server: McpServer, ctx: McpContext): void {
   server.registerTool(
@@ -28,6 +57,57 @@ export function registerManagerTools(server: McpServer, ctx: McpContext): void {
       runTool(ctx, 'get_my_assigned_roles', 'read', false, args, async () => {
         const result = await getMyAssignedRoles()
         return jsonResult({ assignedRoles: result })
+      })
+  )
+
+  server.registerTool(
+    'get_role_managers',
+    {
+      title: 'Get role managers',
+      description:
+        'List the hiring managers currently assigned to a role, with email, name, primary flag, ' +
+        'and added-at timestamp. Returns [] if no managers are assigned (or role does not exist).',
+      inputSchema: GetRoleManagersInput,
+    },
+    async (args) =>
+      runTool(ctx, 'get_role_managers', 'read', false, args, async () => {
+        const result = await getRoleManagers(args.roleId)
+        return jsonResult({ managers: result })
+      })
+  )
+
+  server.registerTool(
+    'assign_role_managers',
+    {
+      title: 'Assign role managers',
+      description:
+        'Replace the full set of hiring managers for a role with the supplied userIds. Non-' +
+        'hiring_manager users are silently dropped. If primaryUserId is supplied AND is in the ' +
+        'valid set it is flagged as primary. Recruiter/admin only. Requires write scope and confirmed: true.',
+      inputSchema: AssignManagersInput,
+    },
+    async (args) =>
+      runTool(ctx, 'assign_role_managers', 'write', true, args, async () => {
+        const result = await assignRoleManagers(args.roleId, args.userIds, args.primaryUserId)
+        if (!result.success) throw new Error(result.error)
+        return jsonResult({ ok: true, roleId: args.roleId })
+      })
+  )
+
+  server.registerTool(
+    'remove_role_manager',
+    {
+      title: 'Remove role manager',
+      description:
+        'Detach a single hiring manager from a role. Recruiter/admin only. Requires write scope ' +
+        'and confirmed: true.',
+      inputSchema: RemoveManagerInput,
+    },
+    async (args) =>
+      runTool(ctx, 'remove_role_manager', 'write', true, args, async () => {
+        const result = await removeRoleManager(args.roleId, args.userId)
+        if (!result.success) throw new Error(result.error)
+        return jsonResult({ ok: true })
       })
   )
 }

--- a/src/lib/mcp/tools/notes.ts
+++ b/src/lib/mcp/tools/notes.ts
@@ -1,0 +1,84 @@
+/**
+ * Note MCP tools — create / update / delete candidate notes. All three
+ * delegate to the canonical actions in `src/actions/notes.ts` which enforce
+ * "author or admin" edit rules.
+ */
+
+import { z } from 'zod'
+import { createNote, updateNote, deleteNote } from '@/actions/notes'
+import { runTool } from '../context'
+import type { McpContext } from '../context'
+import { jsonResult } from './candidates'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+export const CreateNoteInput = {
+  candidateId: z.string().uuid(),
+  body: z.string().min(1).max(5000),
+  confirmed: z.literal(true),
+}
+
+export const UpdateNoteInput = {
+  noteId: z.string().uuid(),
+  candidateId: z.string().uuid(),
+  body: z.string().min(1).max(5000),
+  confirmed: z.literal(true),
+}
+
+export const DeleteNoteInput = {
+  noteId: z.string().uuid(),
+  candidateId: z.string().uuid(),
+  confirmed: z.literal(true),
+}
+
+export function registerNoteTools(server: McpServer, ctx: McpContext): void {
+  server.registerTool(
+    'create_note',
+    {
+      title: 'Create candidate note',
+      description:
+        'Add a timestamped note to a candidate. Body is plain text up to 5000 chars. The note ' +
+        'is attributed to the calling user. Requires write scope and confirmed: true.',
+      inputSchema: CreateNoteInput,
+    },
+    async (args) =>
+      runTool(ctx, 'create_note', 'write', true, args, async () => {
+        const result = await createNote(args.candidateId, args.body)
+        if (!result.success) throw new Error(result.error)
+        return jsonResult({ ok: true })
+      })
+  )
+
+  server.registerTool(
+    'update_note',
+    {
+      title: 'Update candidate note',
+      description:
+        'Edit the body of an existing note. Only the original author or an admin may edit. ' +
+        'Sets isEdited=true. Requires write scope and confirmed: true.',
+      inputSchema: UpdateNoteInput,
+    },
+    async (args) =>
+      runTool(ctx, 'update_note', 'write', true, args, async () => {
+        const result = await updateNote(args.noteId, args.candidateId, args.body)
+        if (!result.success) throw new Error(result.error)
+        return jsonResult({ ok: true })
+      })
+  )
+
+  server.registerTool(
+    'delete_note',
+    {
+      title: 'Delete candidate note',
+      description:
+        'Permanently delete a note. Only the original author or an admin may delete. ' +
+        'Requires write scope and confirmed: true.',
+      inputSchema: DeleteNoteInput,
+    },
+    async (args) =>
+      runTool(ctx, 'delete_note', 'write', true, args, async () => {
+        const result = await deleteNote(args.noteId, args.candidateId)
+        if (!result.success) throw new Error(result.error)
+        return jsonResult({ ok: true })
+      })
+  )
+}

--- a/src/lib/mcp/tools/roles.ts
+++ b/src/lib/mcp/tools/roles.ts
@@ -1,0 +1,162 @@
+/**
+ * Role MCP tools — read + lifecycle for roles in the active tenant.
+ */
+
+import { z } from 'zod'
+import { eq, desc, and } from 'drizzle-orm'
+import { withTenant } from '@/db'
+import { roles, scores, candidates, customers } from '@/db/schema'
+import { archiveRole } from '@/actions/roles'
+import { runTool } from '../context'
+import type { McpContext } from '../context'
+import { jsonResult } from './candidates'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+export const ListRolesInput = {
+  activeOnly: z.boolean().optional().default(true).describe('Hide archived roles'),
+  limit: z.number().int().min(1).max(200).optional().default(50),
+  offset: z.number().int().min(0).optional().default(0),
+}
+
+export const GetRoleInput = {
+  roleId: z.string().uuid(),
+}
+
+export const GetRoleWithCandidatesInput = {
+  roleId: z.string().uuid(),
+  minScore: z.number().int().min(0).max(100).optional().describe('Minimum overallScore filter'),
+  limit: z.number().int().min(1).max(200).optional().default(50),
+}
+
+export const ArchiveRoleInput = {
+  roleId: z.string().uuid(),
+  confirmed: z.literal(true),
+}
+
+export function registerRoleTools(server: McpServer, ctx: McpContext): void {
+  // -- list_roles ---------------------------------------------------------------
+  server.registerTool(
+    'list_roles',
+    {
+      title: 'List roles',
+      description:
+        'List job roles in the active tenant with their customer, location, deadlines, and ' +
+        'budget. By default hides archived roles (set activeOnly=false to include them).',
+      inputSchema: ListRolesInput,
+    },
+    async (args) =>
+      runTool(ctx, 'list_roles', 'read', false, args, async () => {
+        const limit = args.limit ?? 50
+        const offset = args.offset ?? 0
+        const activeOnly = args.activeOnly ?? true
+        const result = await withTenant(ctx.tenantId, async (tx) => {
+          const where = activeOnly ? eq(roles.isActive, true) : undefined
+          const rows = await tx
+            .select({
+              id: roles.id,
+              title: roles.title,
+              isActive: roles.isActive,
+              customerId: roles.customerId,
+              customerName: customers.name,
+              country: roles.country,
+              city: roles.city,
+              workMode: roles.workMode,
+              targetFillDate: roles.targetFillDate,
+              cutoffDate: roles.cutoffDate,
+              customerDayRate: roles.customerDayRate,
+              rateCurrency: roles.rateCurrency,
+              createdAt: roles.createdAt,
+            })
+            .from(roles)
+            .leftJoin(customers, eq(roles.customerId, customers.id))
+            .where(where)
+            .orderBy(desc(roles.createdAt))
+            .limit(limit)
+            .offset(offset)
+          return rows
+        })
+        return jsonResult({ roles: result, limit, offset })
+      })
+  )
+
+  // -- get_role -----------------------------------------------------------------
+  server.registerTool(
+    'get_role',
+    {
+      title: 'Get role',
+      description:
+        'Fetch a single role by id with description, requirements, key skills, top requirements, ' +
+        'language requirements, and budget. Returns null if not found.',
+      inputSchema: GetRoleInput,
+    },
+    async (args) =>
+      runTool(ctx, 'get_role', 'read', false, args, async () => {
+        const result = await withTenant(ctx.tenantId, async (tx) => {
+          const [row] = await tx.select().from(roles).where(eq(roles.id, args.roleId)).limit(1)
+          return row ?? null
+        })
+        return jsonResult({ role: result })
+      })
+  )
+
+  // -- get_role_with_candidates ------------------------------------------------
+  server.registerTool(
+    'get_role_with_candidates',
+    {
+      title: 'Get role with ranked candidates',
+      description:
+        'Fetch a role and the candidates scored against it, sorted by overallScore descending. ' +
+        'Includes per-dimension scores. Optional minScore filter.',
+      inputSchema: GetRoleWithCandidatesInput,
+    },
+    async (args) =>
+      runTool(ctx, 'get_role_with_candidates', 'read', false, args, async () => {
+        const limit = args.limit ?? 50
+        const result = await withTenant(ctx.tenantId, async (tx) => {
+          const [role] = await tx.select().from(roles).where(eq(roles.id, args.roleId)).limit(1)
+          if (!role) return { role: null, candidates: [] }
+          const conditions = [eq(scores.roleId, args.roleId)]
+          // overallScore filter applied at app layer; null-safe
+          const rows = await tx
+            .select({
+              candidateId: candidates.id,
+              firstName: candidates.firstName,
+              lastName: candidates.lastName,
+              status: candidates.status,
+              overallScore: scores.overallScore,
+              technicalScore: scores.technicalScore,
+              experienceScore: scores.experienceScore,
+              culturalFitScore: scores.culturalFitScore,
+              communicationScore: scores.communicationScore,
+              scoreStatus: scores.scoreStatus,
+            })
+            .from(scores)
+            .innerJoin(candidates, eq(scores.candidateId, candidates.id))
+            .where(and(...conditions))
+            .orderBy(desc(scores.overallScore))
+            .limit(limit)
+          const filtered =
+            args.minScore !== undefined
+              ? rows.filter((r) => (r.overallScore ?? -1) >= args.minScore!)
+              : rows
+          return { role, candidates: filtered }
+        })
+        return jsonResult(result)
+      })
+  )
+
+  // -- archive_role -------------------------------------------------------------
+  server.registerTool(
+    'archive_role',
+    {
+      title: 'Archive role',
+      description: 'Soft-archive a role (isActive=false). Requires write scope and confirmed: true.',
+      inputSchema: ArchiveRoleInput,
+    },
+    async (args) =>
+      runTool(ctx, 'archive_role', 'write', true, args, async () => {
+        await archiveRole(args.roleId)
+        return jsonResult({ ok: true, roleId: args.roleId })
+      })
+  )
+}

--- a/src/lib/mcp/tools/roles.ts
+++ b/src/lib/mcp/tools/roles.ts
@@ -6,7 +6,7 @@ import { z } from 'zod'
 import { eq, desc, and } from 'drizzle-orm'
 import { withTenant } from '@/db'
 import { roles, scores, candidates, customers } from '@/db/schema'
-import { archiveRole } from '@/actions/roles'
+import { archiveRole, updateRole, regenerateRoleTags } from '@/actions/roles'
 import { runTool } from '../context'
 import type { McpContext } from '../context'
 import { jsonResult } from './candidates'
@@ -29,6 +29,37 @@ export const GetRoleWithCandidatesInput = {
 }
 
 export const ArchiveRoleInput = {
+  roleId: z.string().uuid(),
+  confirmed: z.literal(true),
+}
+
+// updateRole's server action validates these via UpdateRoleSchema. The action
+// requires title/description/requirements every time (it does a full replace,
+// not a patch), so we surface them as required here too — the MCP caller must
+// pass the canonical values they want stored. Optional keys remain optional.
+export const UpdateRoleInput = {
+  roleId: z.string().uuid(),
+  title: z.string().min(1).max(200),
+  description: z.string().min(10),
+  requirements: z.string().min(10),
+  customerId: z.string().uuid().nullable().optional(),
+  country: z.string().max(100).optional(),
+  city: z.string().max(100).optional(),
+  workMode: z.enum(['remote', 'hybrid', 'onsite']).optional(),
+  languageRequirements: z
+    .string()
+    .optional()
+    .describe('Comma-separated language list, e.g. "English, Polish"'),
+  customerDayRate: z.number().min(0).optional(),
+  rateCurrency: z.enum(['GBP', 'EUR', 'USD', 'PLN']).optional(),
+  targetFillDate: z.string().optional().describe('ISO date YYYY-MM-DD'),
+  cutoffDate: z.string().optional().describe('ISO date YYYY-MM-DD'),
+  customerPortalPath: z.string().max(500).optional(),
+  priorityKeywords: z.array(z.string().min(2).max(120)).max(15).optional(),
+  confirmed: z.literal(true),
+}
+
+export const RegenerateRoleTagsInput = {
   roleId: z.string().uuid(),
   confirmed: z.literal(true),
 }
@@ -142,6 +173,71 @@ export function registerRoleTools(server: McpServer, ctx: McpContext): void {
           return { role, candidates: filtered }
         })
         return jsonResult(result)
+      })
+  )
+
+  // -- update_role --------------------------------------------------------------
+  server.registerTool(
+    'update_role',
+    {
+      title: 'Update role',
+      description:
+        'Edit an existing role. The server action does a full replace of the editable fields — ' +
+        'title/description/requirements are always required. Optional fields default to null/empty ' +
+        'when omitted. Tag regeneration runs after the response. Requires write scope and confirmed: true.',
+      inputSchema: UpdateRoleInput,
+    },
+    async (args) =>
+      runTool(ctx, 'update_role', 'write', true, args, async () => {
+        // Mirror the FormData shape that the dashboard form uses, since the
+        // server action signature is `updateRole(roleId, _prev, formData)`.
+        const fd = new FormData()
+        fd.set('title', args.title)
+        fd.set('description', args.description)
+        fd.set('requirements', args.requirements)
+        if (args.customerId) fd.set('customerId', args.customerId)
+        if (args.country) fd.set('country', args.country)
+        if (args.city) fd.set('city', args.city)
+        if (args.workMode) fd.set('workMode', args.workMode)
+        if (args.languageRequirements) fd.set('languageRequirements', args.languageRequirements)
+        if (typeof args.customerDayRate === 'number') {
+          fd.set('customerDayRate', String(args.customerDayRate))
+        }
+        if (args.rateCurrency) fd.set('rateCurrency', args.rateCurrency)
+        if (args.targetFillDate) fd.set('targetFillDate', args.targetFillDate)
+        if (args.cutoffDate) fd.set('cutoffDate', args.cutoffDate)
+        if (args.customerPortalPath) fd.set('customerPortalPath', args.customerPortalPath)
+        // Action expects priorityKeywords as JSON-stringified array (matches the
+        // form encoding path documented in roles.ts).
+        if (args.priorityKeywords) {
+          fd.set('priorityKeywords', JSON.stringify(args.priorityKeywords))
+        }
+        const result = await updateRole(args.roleId, null, fd)
+        if (!result.success) {
+          throw new Error(result.error || 'Failed to update role')
+        }
+        return jsonResult({ ok: true, roleId: args.roleId })
+      })
+  )
+
+  // -- regenerate_role_tags ----------------------------------------------------
+  server.registerTool(
+    'regenerate_role_tags',
+    {
+      title: 'Regenerate role tags',
+      description:
+        'Re-run AI tag extraction (key skills + top requirements) for a role using its current ' +
+        'description and requirements. Runs in the background after the response. Requires write ' +
+        'scope and confirmed: true.',
+      inputSchema: RegenerateRoleTagsInput,
+    },
+    async (args) =>
+      runTool(ctx, 'regenerate_role_tags', 'write', true, args, async () => {
+        const result = await regenerateRoleTags(args.roleId)
+        if (!result.success) {
+          throw new Error(result.error || 'Failed to regenerate tags')
+        }
+        return jsonResult({ ok: true, roleId: args.roleId })
       })
   )
 

--- a/src/lib/mcp/tools/scoring.ts
+++ b/src/lib/mcp/tools/scoring.ts
@@ -1,0 +1,72 @@
+/**
+ * Scoring MCP tools — read existing scores and trigger a rescore.
+ *
+ * `rescore_candidate` is fire-and-forget; the actual AI work runs in the
+ * background. The tool returns immediately and clients should poll
+ * `get_candidate_score` to see the updated score once it completes.
+ */
+
+import { z } from 'zod'
+import { eq, and } from 'drizzle-orm'
+import { withTenant } from '@/db'
+import { scores } from '@/db/schema'
+import { rescoreCandidate } from '@/actions/scores'
+import { runTool } from '../context'
+import type { McpContext } from '../context'
+import { jsonResult } from './candidates'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+export const GetScoreInput = {
+  candidateId: z.string().uuid(),
+  roleId: z.string().uuid(),
+}
+
+export const RescoreInput = {
+  candidateId: z.string().uuid(),
+  roleId: z.string().uuid(),
+  confirmed: z.literal(true),
+}
+
+export function registerScoringTools(server: McpServer, ctx: McpContext): void {
+  server.registerTool(
+    'get_candidate_score',
+    {
+      title: 'Get candidate score',
+      description:
+        'Fetch the score row for a candidate against a specific role, including all four ' +
+        'dimension scores (technical, experience, cultural fit, communication), AI reasoning ' +
+        'per dimension, and the AI summary. Returns null if no scoring run exists yet.',
+      inputSchema: GetScoreInput,
+    },
+    async (args) =>
+      runTool(ctx, 'get_candidate_score', 'read', false, args, async () => {
+        const result = await withTenant(ctx.tenantId, async (tx) => {
+          const [row] = await tx
+            .select()
+            .from(scores)
+            .where(and(eq(scores.candidateId, args.candidateId), eq(scores.roleId, args.roleId)))
+            .limit(1)
+          return row ?? null
+        })
+        return jsonResult({ score: result })
+      })
+  )
+
+  server.registerTool(
+    'rescore_candidate',
+    {
+      title: 'Rescore candidate against role',
+      description:
+        'Re-run AI scoring for a candidate against a role. The score is reset to pending and ' +
+        'the AI pipeline runs in the background. Poll get_candidate_score for results. ' +
+        'Requires write scope and confirmed: true.',
+      inputSchema: RescoreInput,
+    },
+    async (args) =>
+      runTool(ctx, 'rescore_candidate', 'write', true, args, async () => {
+        const result = await rescoreCandidate(args.candidateId, args.roleId)
+        if (!result.success) throw new Error(result.error ?? 'rescore failed')
+        return jsonResult({ ok: true, candidateId: args.candidateId, roleId: args.roleId })
+      })
+  )
+}

--- a/src/lib/mcp/tools/settings.ts
+++ b/src/lib/mcp/tools/settings.ts
@@ -1,0 +1,30 @@
+/**
+ * Settings MCP tools — read-only listing for now. Save/remove API keys
+ * involve secret material and are kept dashboard-only for the MVP.
+ */
+
+import { getConfiguredKeys } from '@/actions/settings'
+import { runTool } from '../context'
+import type { McpContext } from '../context'
+import { jsonResult } from './candidates'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+export const NoInput = {} as const
+
+export function registerSettingsTools(server: McpServer, ctx: McpContext): void {
+  server.registerTool(
+    'list_configured_keys',
+    {
+      title: 'List configured API keys',
+      description:
+        'List which AI provider keys (anthropic / google / openai) are configured for the active ' +
+        'tenant. Returns just the key NAMES, never the secret values. Admin scope required.',
+      inputSchema: NoInput,
+    },
+    async (args) =>
+      runTool(ctx, 'list_configured_keys', 'admin', false, args, async () => {
+        const keys = await getConfiguredKeys(ctx.tenantId)
+        return jsonResult({ configuredKeys: keys })
+      })
+  )
+}

--- a/src/lib/mcp/tools/users.ts
+++ b/src/lib/mcp/tools/users.ts
@@ -1,0 +1,113 @@
+/**
+ * User-management MCP tools (admin scope).
+ *
+ * `list_users` delegates to `listTenantUsers` (uses ActionContext).
+ *
+ * `update_user_role` and `deactivate_user` need a small implementation
+ * mirror because the underlying server actions read `auth()` — which is a
+ * NextAuth session helper that only works inside the standard HTTP/cookie
+ * flow. We can't synthesise a session from a bearer token without
+ * modifying the action. We therefore reproduce the (small, audited) logic
+ * here against `withTenant` so the MCP path stays clean.
+ */
+
+import { z } from 'zod'
+import { eq, and } from 'drizzle-orm'
+import { withTenant } from '@/db'
+import { users } from '@/db/schema'
+import { listTenantUsers } from '@/actions/users'
+import { writeAuditLog } from '@/lib/audit'
+import { runTool } from '../context'
+import type { McpContext } from '../context'
+import { jsonResult } from './candidates'
+import type { UserRole } from '@/lib/auth/types'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+export const ListUsersInput = {} as const
+
+export const UpdateRoleInput = {
+  userId: z.string().uuid(),
+  role: z.enum(['admin', 'recruiter', 'hiring_manager', 'viewer']),
+  confirmed: z.literal(true),
+}
+
+export const DeactivateUserInput = {
+  userId: z.string().uuid(),
+  confirmed: z.literal(true),
+}
+
+export function registerUserTools(server: McpServer, ctx: McpContext): void {
+  server.registerTool(
+    'list_users',
+    {
+      title: 'List tenant users',
+      description: 'List all users in the active tenant. Admin scope required.',
+      inputSchema: ListUsersInput,
+    },
+    async (args) =>
+      runTool(ctx, 'list_users', 'admin', false, args, async () => {
+        const result = await listTenantUsers()
+        return jsonResult({ users: result })
+      })
+  )
+
+  server.registerTool(
+    'update_user_role',
+    {
+      title: 'Update user role',
+      description:
+        'Change a user\'s product-role (admin / recruiter / hiring_manager / viewer). You cannot ' +
+        'change your own role. Admin scope required, confirmed: true required.',
+      inputSchema: UpdateRoleInput,
+    },
+    async (args) =>
+      runTool(ctx, 'update_user_role', 'admin', true, args, async () => {
+        if (args.userId === ctx.userId) {
+          throw new Error('You cannot change your own role')
+        }
+        await withTenant(ctx.tenantId, async (tx) => {
+          await tx
+            .update(users)
+            .set({ role: args.role as UserRole })
+            .where(and(eq(users.id, args.userId), eq(users.tenantId, ctx.tenantId)))
+        })
+        void writeAuditLog(ctx.tenantId, {
+          action: 'user.role_changed',
+          entityType: 'user',
+          entityId: args.userId,
+          metadata: { newRole: args.role, by: ctx.userId, via: 'mcp' },
+        })
+        return jsonResult({ ok: true, userId: args.userId, role: args.role })
+      })
+  )
+
+  server.registerTool(
+    'deactivate_user',
+    {
+      title: 'Deactivate user',
+      description:
+        'Soft-deactivate a user (sets isActive=false). You cannot deactivate yourself. Admin ' +
+        'scope and confirmed: true required.',
+      inputSchema: DeactivateUserInput,
+    },
+    async (args) =>
+      runTool(ctx, 'deactivate_user', 'admin', true, args, async () => {
+        if (args.userId === ctx.userId) {
+          throw new Error('You cannot deactivate your own account')
+        }
+        await withTenant(ctx.tenantId, async (tx) => {
+          await tx
+            .update(users)
+            .set({ isActive: false })
+            .where(and(eq(users.id, args.userId), eq(users.tenantId, ctx.tenantId)))
+        })
+        void writeAuditLog(ctx.tenantId, {
+          action: 'user.deactivated',
+          entityType: 'user',
+          entityId: args.userId,
+          metadata: { by: ctx.userId, via: 'mcp' },
+        })
+        return jsonResult({ ok: true, userId: args.userId })
+      })
+  )
+}

--- a/src/lib/mcp/tools/users.ts
+++ b/src/lib/mcp/tools/users.ts
@@ -12,9 +12,10 @@
  */
 
 import { z } from 'zod'
+import { randomBytes } from 'crypto'
 import { eq, and } from 'drizzle-orm'
-import { withTenant } from '@/db'
-import { users } from '@/db/schema'
+import { db, withTenant } from '@/db'
+import { users, userInvitations } from '@/db/schema'
 import { listTenantUsers } from '@/actions/users'
 import { writeAuditLog } from '@/lib/audit'
 import { runTool } from '../context'
@@ -33,6 +34,12 @@ export const UpdateRoleInput = {
 
 export const DeactivateUserInput = {
   userId: z.string().uuid(),
+  confirmed: z.literal(true),
+}
+
+export const InviteUserInput = {
+  email: z.string().email().optional().describe('If omitted, the invite is single-use without email pre-fill'),
+  role: z.enum(['admin', 'recruiter', 'hiring_manager', 'viewer']),
   confirmed: z.literal(true),
 }
 
@@ -78,6 +85,50 @@ export function registerUserTools(server: McpServer, ctx: McpContext): void {
           metadata: { newRole: args.role, by: ctx.userId, via: 'mcp' },
         })
         return jsonResult({ ok: true, userId: args.userId, role: args.role })
+      })
+  )
+
+  server.registerTool(
+    'invite_user',
+    {
+      title: 'Invite user',
+      description:
+        'Create a single-use invitation for a new user in the active tenant. Returns the ' +
+        'invitation id, raw token, and a fully-qualified invite URL the admin can share. The ' +
+        'role can be any of admin/recruiter/hiring_manager/viewer. Note: createInvitation ' +
+        'server action reads its tenant from HTTP headers, so we mirror its (small) logic here ' +
+        'against withTenant — same pattern used by update_user_role and deactivate_user. ' +
+        'Admin scope and confirmed: true required.',
+      inputSchema: InviteUserInput,
+    },
+    async (args) =>
+      runTool(ctx, 'invite_user', 'admin', true, args, async () => {
+        // Mirror src/actions/invitations.ts createInvitation. The user_invitations
+        // table has no RLS so we insert via plain `db`, but tenant + user are
+        // taken from the MCP context (not headers).
+        const token = randomBytes(32).toString('hex')
+        const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000) // 7d
+        const [inserted] = await db
+          .insert(userInvitations)
+          .values({
+            tenantId: ctx.tenantId,
+            token,
+            email: args.email ?? null,
+            role: args.role,
+            createdBy: ctx.userId,
+            expiresAt,
+          })
+          .returning({ id: userInvitations.id })
+        const baseUrl = process.env.NEXTAUTH_URL ?? 'http://localhost:3001'
+        const inviteUrl = `${baseUrl}/invite/${token}`
+        void writeAuditLog(ctx.tenantId, {
+          action: 'user.invited',
+          entityType: 'user_invitation',
+          entityId: inserted.id,
+          entityLabel: args.email ?? '(no email)',
+          metadata: { role: args.role, by: ctx.userId, via: 'mcp' },
+        })
+        return jsonResult({ invitationId: inserted.id, token, inviteUrl })
       })
   )
 

--- a/tests/integration/api/mcp.test.ts
+++ b/tests/integration/api/mcp.test.ts
@@ -1,0 +1,304 @@
+// @vitest-environment node
+
+/**
+ * Integration tests for the MCP HTTP route at /api/mcp.
+ *
+ * Mocks the bearer-token validator, the rate-limiter, and the user-row
+ * lookup. Mocks server actions invoked by write tools so the test never
+ * touches the database. Read tools have their target tables shimmed by
+ * mocking `withTenant` to return canned rows.
+ *
+ * Test matrix:
+ *   1. Missing Authorization → 401
+ *   2. Invalid bearer token → 401
+ *   3. Insufficient scope on a write tool → MCP tool error
+ *   4. Read tool happy path → structured content
+ *   5. Write tool without confirmed=true → MCP tool error (no action call)
+ *   6. Write tool with confirmed=true → server action invoked
+ *   7. Cross-tenant read enforced via withTenant — different tenantId
+ *      passed through to the database call
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockValidateApiToken = vi.fn()
+vi.mock('@/lib/api-tokens/validate', () => ({
+  validateApiToken: (...args: unknown[]) => mockValidateApiToken(...args),
+}))
+
+const mockCheckRateLimit = vi.fn()
+vi.mock('@/lib/api/rate-limit', () => ({
+  checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
+}))
+
+const mockWriteAuditLog = vi.fn().mockResolvedValue(undefined)
+vi.mock('@/lib/audit', () => ({
+  writeAuditLog: (...args: unknown[]) => mockWriteAuditLog(...args),
+}))
+
+// db.select().from(users) for the role lookup, and db.transaction(...) for
+// withTenant. We stub both via factory mocks.
+const mockUserRoleLookup = vi.fn()
+const mockWithTenantImpl = vi.fn()
+vi.mock('@/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async (_n: number) => mockUserRoleLookup(),
+        }),
+      }),
+    }),
+  },
+  withTenant: async <T,>(tenantId: string, fn: (tx: unknown) => Promise<T>): Promise<T> =>
+    mockWithTenantImpl(tenantId, fn),
+}))
+
+const mockUpdateCandidateStatus = vi.fn()
+vi.mock('@/actions/candidates', () => ({
+  updateCandidateStatus: (...args: unknown[]) => mockUpdateCandidateStatus(...args),
+  updateCandidateAvailability: vi.fn(),
+  archiveCandidate: vi.fn(),
+}))
+
+// Mock the rest of the action modules so the tool imports resolve without
+// pulling in `next/server`, `next/navigation`, `next-auth`, etc.
+vi.mock('@/actions/roles', () => ({ archiveRole: vi.fn() }))
+vi.mock('@/actions/scores', () => ({ rescoreCandidate: vi.fn() }))
+vi.mock('@/actions/notes', () => ({
+  createNote: vi.fn(),
+  updateNote: vi.fn(),
+  deleteNote: vi.fn(),
+}))
+vi.mock('@/actions/approvals', () => ({
+  approveCandidate: vi.fn(),
+  rejectCandidate: vi.fn(),
+  getApprovalsForRole: vi.fn(),
+}))
+vi.mock('@/actions/role-managers', () => ({ getMyAssignedRoles: vi.fn() }))
+vi.mock('@/actions/users', () => ({ listTenantUsers: vi.fn() }))
+vi.mock('@/actions/settings', () => ({ getConfiguredKeys: vi.fn() }))
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const TENANT_A = '11111111-1111-1111-1111-111111111111'
+const TENANT_B = '22222222-2222-2222-2222-222222222222'
+const USER_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+const TOKEN_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+const TOKEN = 'skl_dev_validtoken1234'
+
+function makeReq(body: unknown, headers: Record<string, string> = {}): Request {
+  return new Request('http://localhost/api/mcp', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      accept: 'application/json, text/event-stream',
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+function rpcCall(id: number, method: string, params?: unknown) {
+  return { jsonrpc: '2.0', id, method, params }
+}
+
+function rateOk() {
+  return { ok: true, remaining: { token: 59, tenant: 99, write: 29 } }
+}
+
+function setHappyAuth(scopes: ('read' | 'write' | 'admin')[] = ['read'], tenantId = TENANT_A) {
+  mockValidateApiToken.mockResolvedValue({ tenantId, userId: USER_ID, scopes, tokenId: TOKEN_ID })
+  mockCheckRateLimit.mockResolvedValue(rateOk())
+  mockUserRoleLookup.mockResolvedValue([{ role: 'recruiter' }])
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('/api/mcp route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockWithTenantImpl.mockReset()
+  })
+
+  it('returns 401 when Authorization header is missing', async () => {
+    const { POST } = await import('@/app/api/mcp/route')
+    const res = await POST(
+      new Request('http://localhost/api/mcp', { method: 'POST', body: '{}' })
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 when bearer token is invalid', async () => {
+    mockValidateApiToken.mockResolvedValue(null)
+    const { POST } = await import('@/app/api/mcp/route')
+    const res = await POST(
+      makeReq(rpcCall(1, 'initialize', { protocolVersion: '2025-06-18', capabilities: {} }), {
+        authorization: `Bearer ${TOKEN}`,
+      })
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('write tool with read-only token surfaces an MCP scope error', async () => {
+    setHappyAuth(['read'])
+    const { POST } = await import('@/app/api/mcp/route')
+
+    const res = await POST(
+      makeReq(
+        rpcCall(2, 'tools/call', {
+          name: 'update_candidate_status',
+          arguments: {
+            candidateId: '00000000-0000-4000-8000-000000000001',
+            status: 'shortlisted',
+            confirmed: true,
+          },
+        }),
+        { authorization: `Bearer ${TOKEN}` }
+      )
+    )
+    // The route returns 200 with a JSON-RPC body; the tool error is in
+    // the body under result.isError or error fields.
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toMatch(/insufficient_scope|scope/i)
+    // updateCandidateStatus must NOT have been called
+    expect(mockUpdateCandidateStatus).not.toHaveBeenCalled()
+  })
+
+  it('read tool happy path returns structured content for the calling tenant', async () => {
+    setHappyAuth(['read'], TENANT_A)
+    // withTenant mock returns canned rows for list_candidates
+    mockWithTenantImpl.mockImplementation(async (tenantId: string) => {
+      // Verify the route passed the right tenantId through to the DB layer
+      expect(tenantId).toBe(TENANT_A)
+      return [
+        {
+          id: '00000000-0000-4000-8000-000000000001',
+          firstName: 'Ada',
+          lastName: 'Lovelace',
+          email: 'ada@example.com',
+          status: 'new',
+          availabilityStatus: 'available',
+          availableFrom: null,
+          agencyId: null,
+          agencyName: null,
+          createdAt: new Date('2026-04-28T00:00:00Z'),
+        },
+      ]
+    })
+
+    const { POST } = await import('@/app/api/mcp/route')
+    const res = await POST(
+      makeReq(
+        rpcCall(3, 'tools/call', {
+          name: 'list_candidates',
+          arguments: { limit: 10 },
+        }),
+        { authorization: `Bearer ${TOKEN}` }
+      )
+    )
+
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toContain('Ada')
+    expect(text).toContain('Lovelace')
+    // checkRateLimit should have been called as a read
+    expect(mockCheckRateLimit).toHaveBeenCalledWith(TENANT_A, TOKEN_ID, false)
+  })
+
+  it('write tool without confirmed: true is rejected before any action call', async () => {
+    setHappyAuth(['write'])
+    const { POST } = await import('@/app/api/mcp/route')
+
+    const res = await POST(
+      makeReq(
+        rpcCall(4, 'tools/call', {
+          name: 'update_candidate_status',
+          arguments: {
+            candidateId: '00000000-0000-4000-8000-000000000001',
+            status: 'shortlisted',
+            // confirmed intentionally omitted
+          },
+        }),
+        { authorization: `Bearer ${TOKEN}` }
+      )
+    )
+
+    expect(res.status).toBe(200)
+    expect(mockUpdateCandidateStatus).not.toHaveBeenCalled()
+  })
+
+  it('write tool with confirmed: true delegates to the server action', async () => {
+    setHappyAuth(['write'])
+    mockUpdateCandidateStatus.mockResolvedValue(undefined)
+
+    const { POST } = await import('@/app/api/mcp/route')
+    const res = await POST(
+      makeReq(
+        rpcCall(5, 'tools/call', {
+          name: 'update_candidate_status',
+          arguments: {
+            candidateId: '00000000-0000-4000-8000-000000000001',
+            status: 'shortlisted',
+            confirmed: true,
+          },
+        }),
+        { authorization: `Bearer ${TOKEN}` }
+      )
+    )
+
+    expect(res.status).toBe(200)
+    expect(mockUpdateCandidateStatus).toHaveBeenCalledWith(
+      '00000000-0000-4000-8000-000000000001',
+      'shortlisted'
+    )
+    // checkRateLimit should be invoked as a write
+    expect(mockCheckRateLimit).toHaveBeenCalledWith(TENANT_A, TOKEN_ID, true)
+  })
+
+  it('cross-tenant: token bound to tenant B propagates tenant B to withTenant, not tenant A', async () => {
+    setHappyAuth(['read'], TENANT_B)
+    const seenTenants: string[] = []
+    mockWithTenantImpl.mockImplementation(async (tenantId: string) => {
+      seenTenants.push(tenantId)
+      return [] // no rows for tenant B in this fixture
+    })
+
+    const { POST } = await import('@/app/api/mcp/route')
+    const res = await POST(
+      makeReq(
+        rpcCall(6, 'tools/call', {
+          name: 'list_candidates',
+          arguments: { limit: 10 },
+        }),
+        { authorization: `Bearer ${TOKEN}` }
+      )
+    )
+
+    expect(res.status).toBe(200)
+    expect(seenTenants).toEqual([TENANT_B])
+    expect(seenTenants).not.toContain(TENANT_A)
+  })
+
+  it('returns 429 when rate-limit denies the request', async () => {
+    mockValidateApiToken.mockResolvedValue({
+      tenantId: TENANT_A,
+      userId: USER_ID,
+      scopes: ['read'],
+      tokenId: TOKEN_ID,
+    })
+    mockUserRoleLookup.mockResolvedValue([{ role: 'recruiter' }])
+    mockCheckRateLimit.mockResolvedValue({ ok: false, retryAfter: 30, limit: 'token' })
+
+    const { POST } = await import('@/app/api/mcp/route')
+    const res = await POST(
+      makeReq(rpcCall(7, 'tools/list'), { authorization: `Bearer ${TOKEN}` })
+    )
+
+    expect(res.status).toBe(429)
+    expect(res.headers.get('Retry-After')).toBe('30')
+  })
+})


### PR DESCRIPTION
**Closes Epic #105.** Implements sub-issue #110. Final wave — the actual MCP server.

## Summary

Builds on Waves 1 (#111) + 2 (#112). Mounts the streamable-HTTP MCP transport at `/api/mcp` so claude-desktop can pull, create, and edit candidates, roles, agencies, customers, manager approvals, interview packs — and pass attachments through to other MCP servers (Gmail, Drive, etc.) for end-to-end workflows like *"email Bob's CV + interview pack to recruiter@x.com with a one-paragraph summary."*

### 48 tools across 12 modules

**Read** (15): candidates list/get/find_by_name/find_by_email; roles list/get/get_with_candidates; agencies/customers list/get; scoring get_score; interviews list_packs/get_pack; semantic_search_candidates; approvals get_for_role; managers get_my_assigned_roles + get_role_managers; settings list_configured_keys; users list

**Write** (read scope unless flagged) — every write tool requires `confirmed: true`:
- candidates: update_status, update_availability, archive, bulk_update_status, **create_candidate** (base64 CV upload, PDF/DOCX/ODT/RTF/TXT/MD, 10MB cap)
- roles: **create**, update, regenerate_tags, archive
- approvals: approve, reject, send_shortlist_for_approval, approve_all_remaining
- managers: assign_role_managers, remove_role_manager
- notes: create, update, delete
- scoring: rescore_candidate
- interviews: generate_interview_pack (async; poll via get_interview_pack)

**Admin** (`admin` scope): invite_user (others — settings writes, role changes, deactivation — also live)

**Exports** (read scope, returns `{ filename, mimeType, dataBase64, sizeBytes }` — composable with Gmail/Drive MCPs):
- export_candidate_cv_pdf (reads on-disk file)
- export_candidate_internal_pdf, export_candidate_customer_pdf (CandidatePDF audience variants)
- export_role_brief_pdf, export_shortlist_pdf, export_interview_pack_pdf
- **compose_candidate_email_attachments** — the killer one-call workflow tool: returns `{ candidate, role, attachments: { cv, interviewPack?, scoreSummary } }` so the LLM can construct an email in a single round-trip

### Resources

`skillai://candidates/{id}`, `skillai://roles/{id}`, `skillai://interview-packs/{id}`, `skillai://my-shortlists`

### Prompts

- `email-candidate-introduction(candidateId, roleId, recipientEmail)` — opinionated workflow for the email-with-CV-and-pack flow
- `prepare-interview-brief(candidateId, roleId)` — interviewer cheat sheet
- `weekly-shortlist-review(roleId)` — hiring manager review

## Architecture

`/api/mcp` route (POST + GET):
1. Reads `Authorization: Bearer <token>` header
2. `validateApiToken` (#106) — null → 401
3. `checkRateLimit(tenantId, tokenId, isWrite)` (#109) — exceeded → 429 with `Retry-After` + `X-RateLimit-*`
4. Constructs a per-request `McpServer` instance with all tools/resources/prompts registered, closing over `{ tenantId, userId, scopes }`
5. `WebStandardStreamableHTTPServerTransport` from `@modelcontextprotocol/sdk@^1.29.0` (stateless mode: `sessionIdGenerator: undefined`, `enableJsonResponse: true`) handles the protocol
6. Each tool runs inside `runWithActionContext({ tenantId, userId, userRole }, ...)` — an AsyncLocalStorage shim added to `src/lib/auth/action-context.ts` — so delegated server actions read tenant/user via `getActionContext()` even though `proxy.ts` middleware doesn't run on `/api/mcp`. The HTTP middleware path is unchanged.

### Scope inclusion: `admin > write > read`

### Write-tool safety: `confirmed: true` required

LLM must opt in explicitly to mutations. Prevents Claude from mass-archiving on a typo. The MCP `tools/list` description for each write tool says so.

### Audit

Every tool call logs `mcp.tool_called`. Confirmed writes additionally log `mcp.confirmed_action`.

## Verification

- ✅ `tsc --noEmit` zero errors
- ✅ 8/8 MCP integration tests pass (auth, scope, confirm gating, dispatch, withTenant flow)
- ✅ `/login=200` and `/api/health=200` — running portal undisturbed throughout
- ✅ App container never restarted

## Files changed (this PR — 32 files)

| | Wave 3a (`fe76dc2`) | Wave 3b (`e7dac56`) |
|---|---|---|
| Route handler | `src/app/api/mcp/route.ts` | — |
| Server builder | `src/lib/mcp/server.ts` + `context.ts` | — |
| Helpers | `src/lib/mcp/attachment.ts` | — |
| Tool modules | 11 modules (26 tools) | 7 modules extended + 1 new (`exports.ts`); 19 new tools |
| Resources | `src/lib/mcp/resources/index.ts` | — |
| Prompts | `src/lib/mcp/prompts/index.ts` | — |
| Audit + ALS | `src/lib/audit.ts` (+2 actions); `src/lib/auth/action-context.ts` (ALS shim) | — |
| Tests | `tests/integration/api/mcp.test.ts` (8 tests) | — |
| Help | `src/content/help/mcp-server-claude-desktop.md` | — |

## End-to-end test plan

1. Generate a token at `/settings/api-tokens` (write scope)
2. Add to claude-desktop's `mcp.config.json`:
   ```json
   {
     "mcpServers": {
       "skillai": {
         "url": "https://your-skillai-host/api/mcp",
         "headers": { "Authorization": "Bearer skl_prod_..." }
       }
     }
   }
   ```
3. *"List candidates I haven't reviewed for the DevOps role"* → `find_candidate_by_name` / `semantic_search_candidates` work
4. *"Create a Senior Data Engineer role for HSBC, £700/day, hybrid"* → `create_role` works
5. *"Here's Alice's CV [PDF attached] — upload her against the DevOps role"* → `create_candidate` with base64 file works; AI scoring kicks off
6. *"Email recruiter@hsbc.com — attach Bob's CV and DevOps interview pack with a one-paragraph summary of why he's a fit"* → `compose_candidate_email_attachments` returns CV + pack + score summary in one tool call → Gmail MCP sends with attachments
7. *"Approve Alice and reject Bob, both with comment X"* → write-scope tools (with `confirmed: true`) → audit log entries appear → recruiter sees decisions in the web UI
8. Try a tool with a read-only token → 403 from the scope check
9. Make 61 calls in a minute → 429 with `Retry-After`

## What's NOT in this PR (future)

- OAuth 2.0 / PKCE flow (post-MVP follow-on)
- Per-tool fine-grained scopes (`candidates:read`, `approvals:write`, etc.) instead of coarse `read/write/admin`
- stdio bridge as standalone npm package
- Webhook subscriptions
- Streaming responses for long-running tools (interview pack generation, big semantic searches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)