### PR TITLE
feat(release): GitHub Actions pipeline — Bun binaries + npm publish + .deb/.rpm + GitHub Release (#116)

### DIFF
--- a/.github/workflows/mcp-bridge-release.yml
+++ b/.github/workflows/mcp-bridge-release.yml
@@ -1,0 +1,344 @@
+# mcp-bridge-release.yml
+#
+# Release pipeline for @skillai/mcp-bridge.
+#
+# Trigger: push a tag matching  mcp-bridge-vX.Y.Z
+# Example: git tag mcp-bridge-v1.0.1 && git push origin mcp-bridge-v1.0.1
+#
+# Required repository secrets:
+#   NPM_TOKEN — npm automation token with publish access to @skillai/mcp-bridge.
+#               Create at npmjs.com → Access Tokens → Automation (granular preferred).
+#
+# Produces (attached to the GitHub Release):
+#   skillai-mcp-linux-x64          + .sha256
+#   skillai-mcp-linux-arm64        + .sha256
+#   skillai-mcp-darwin-x64         + .sha256
+#   skillai-mcp-darwin-arm64       + .sha256
+#   skillai-mcp-windows-x64.exe    + .sha256
+#   skillai-mcp_<ver>_amd64.deb
+#   skillai-mcp_<ver>_arm64.deb
+#   skillai-mcp_<ver>_amd64.rpm
+#   skillai-mcp_<ver>_arm64.rpm
+
+name: mcp-bridge release
+
+on:
+  push:
+    tags:
+      - 'mcp-bridge-v*'
+
+permissions:
+  contents: write   # create GitHub Release + upload artefacts
+  id-token: write   # npm provenance attestation
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # 1. validate — fast sanity checks before spending build matrix minutes
+  # ---------------------------------------------------------------------------
+  validate:
+    name: Validate version + lockfile
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.extract.outputs.version }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Extract version from tag
+        id: extract
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/mcp-bridge-v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Tag version: ${VERSION}"
+
+      - name: Verify package.json version matches tag
+        run: |
+          PKG_VERSION=$(node -p "require('./mcp-server/package.json').version")
+          TAG_VERSION="${{ steps.extract.outputs.version }}"
+          echo "package.json: ${PKG_VERSION}  |  tag: ${TAG_VERSION}"
+          if [ "${PKG_VERSION}" != "${TAG_VERSION}" ]; then
+            echo "::error::Version mismatch — package.json has ${PKG_VERSION} but tag is mcp-bridge-v${TAG_VERSION}"
+            echo "::error::Update mcp-server/package.json version before pushing the tag."
+            exit 1
+          fi
+
+      - name: Validate lockfile is consistent
+        # npm ci with --dry-run verifies the lockfile satisfies package.json
+        # without installing anything.
+        run: |
+          cd mcp-server
+          npm ci --dry-run
+
+  # ---------------------------------------------------------------------------
+  # 2. build-binaries — Bun cross-compile matrix (all on ubuntu; Bun handles cross)
+  # ---------------------------------------------------------------------------
+  build-binaries:
+    name: Build ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    needs: validate
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: bun-linux-x64
+            outfile: dist/skillai-mcp-linux-x64
+            artefact: linux-x64
+
+          - target: bun-linux-arm64
+            outfile: dist/skillai-mcp-linux-arm64
+            artefact: linux-arm64
+
+          - target: bun-darwin-x64
+            outfile: dist/skillai-mcp-darwin-x64
+            artefact: darwin-x64
+
+          - target: bun-darwin-arm64
+            outfile: dist/skillai-mcp-darwin-arm64
+            artefact: darwin-arm64
+
+          - target: bun-windows-x64
+            outfile: dist/skillai-mcp-windows-x64.exe
+            artefact: windows-x64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5  # v2.0.2
+        with:
+          bun-version: '1.2.13'  # pinned for reproducibility; bump deliberately
+
+      - name: Install dependencies
+        working-directory: mcp-server
+        run: bun install --frozen-lockfile
+
+      - name: Compile standalone binary
+        working-directory: mcp-server
+        run: |
+          bun build src/index.ts \
+            --compile \
+            --target=${{ matrix.target }} \
+            --outfile=${{ matrix.outfile }}
+
+      - name: Compute SHA256
+        working-directory: mcp-server
+        run: |
+          OUTFILE="${{ matrix.outfile }}"
+          # Single lowercase hex line — format Scoop autoupdate expects
+          sha256sum "${OUTFILE}" | awk '{print $1}' > "${OUTFILE}.sha256"
+          echo "SHA256: $(cat "${OUTFILE}.sha256")"
+
+      - name: Upload binary artefact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: binary-${{ matrix.artefact }}
+          path: |
+            mcp-server/${{ matrix.outfile }}
+            mcp-server/${{ matrix.outfile }}.sha256
+          if-no-files-found: error
+          retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # 3. npm-publish — compile via tsc + publish to npm registry with provenance
+  # ---------------------------------------------------------------------------
+  npm-publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    needs: validate
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install and build
+        working-directory: mcp-server
+        run: |
+          npm ci
+          npm run build
+
+      - name: Temporarily set package to public for publish
+        # The package.json has "private": true for repo-level hygiene.
+        # We remove that flag only for the publish step so npm doesn't refuse.
+        working-directory: mcp-server
+        run: |
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            delete pkg.private;
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+
+      - name: Publish to npm
+        working-directory: mcp-server
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance
+
+  # ---------------------------------------------------------------------------
+  # 4. package-deb-rpm — build .deb + .rpm for linux-x64 and linux-arm64
+  # ---------------------------------------------------------------------------
+  package-deb-rpm:
+    name: Build deb + rpm packages
+    runs-on: ubuntu-latest
+    needs: build-binaries
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Download linux-x64 binary
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4.2.1
+        with:
+          name: binary-linux-x64
+          path: mcp-server/dist/
+
+      - name: Download linux-arm64 binary
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4.2.1
+        with:
+          name: binary-linux-arm64
+          path: mcp-server/dist/
+
+      - name: Restore binary execute permissions
+        working-directory: mcp-server/dist
+        run: chmod +x skillai-mcp-linux-x64 skillai-mcp-linux-arm64
+
+      - name: Install nfpm (pinned release)
+        # Pinning to nfpm v2.41.3 — goreleaser/nfpm, MIT licence.
+        # SHA256 verified against the upstream release page.
+        env:
+          NFPM_VERSION: '2.41.3'
+          NFPM_SHA256: 'a70c4ad59de3a38e5a77a975d7ba2e4d10b8cd4e5c07b46a6c6aeefc1fcc2f38'
+        run: |
+          wget -q "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz" \
+               -O /tmp/nfpm.tar.gz
+          echo "${NFPM_SHA256}  /tmp/nfpm.tar.gz" | sha256sum -c -
+          tar -xzf /tmp/nfpm.tar.gz -C /tmp nfpm
+          sudo mv /tmp/nfpm /usr/local/bin/nfpm
+          nfpm --version
+
+      - name: Build packages (two-pass per arch)
+        # Judgment call on nfpm arch handling:
+        # nfpm's ${ARCH} variable controls the *package metadata* arch but NOT which src
+        # file to pick up — src paths in nfpm.yaml are evaluated once per run, not per
+        # matrix entry. The cleanest approach is a two-pass build: we set BIN_ARCH to
+        # the platform-specific binary suffix (x64 → x86_64, arm64 → aarch64) and let
+        # the YAML ${BIN_ARCH} expansion pick the right binary on each pass.
+        # We also export ARCH so nfpm sets correct package metadata (amd64/arm64).
+        working-directory: mcp-server
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          for COMBO in "amd64:x64" "arm64:arm64"; do
+            PKG_ARCH="${COMBO%%:*}"
+            BIN_ARCH="${COMBO##*:}"
+
+            export ARCH="${PKG_ARCH}"
+            export BIN_ARCH="${BIN_ARCH}"
+            export VERSION="${VERSION}"
+
+            for PKG_TYPE in deb rpm; do
+              EXT="${PKG_TYPE}"
+              nfpm pkg \
+                --packager="${PKG_TYPE}" \
+                --config=nfpm.yaml \
+                --target="skillai-mcp_${VERSION}_${PKG_ARCH}.${EXT}"
+              echo "Built: skillai-mcp_${VERSION}_${PKG_ARCH}.${EXT}"
+            done
+          done
+
+      - name: Upload package artefacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: packages-deb-rpm
+          path: mcp-server/skillai-mcp_*.{deb,rpm}
+          if-no-files-found: error
+          retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # 5. release — create GitHub Release and attach all 9 artefacts
+  # ---------------------------------------------------------------------------
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs:
+      - validate
+      - build-binaries
+      - package-deb-rpm
+      - npm-publish
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Download all binary artefacts
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4.2.1
+        with:
+          pattern: binary-*
+          path: release-assets/
+          merge-multiple: true
+
+      - name: Download package artefacts
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4.2.1
+        with:
+          name: packages-deb-rpm
+          path: release-assets/
+
+      - name: List artefacts
+        run: find release-assets/ -type f | sort
+
+      - name: Generate release notes via GitHub API
+        id: notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          # Use the GitHub generate-notes API for auto-changelog from PRs/commits.
+          NOTES=$(gh api repos/${{ github.repository }}/releases/generate-notes \
+            -F tag_name="mcp-bridge-v${VERSION}" \
+            --jq '.body')
+          # Prepend install instructions header to the generated notes.
+          HEADER="## Install \`@skillai/mcp-bridge\` v${VERSION}
+
+          **npm (global):**
+          \`\`\`
+          npm install -g @skillai/mcp-bridge@${VERSION}
+          \`\`\`
+
+          **Standalone binary (Linux x64):**
+          \`\`\`
+          curl -fsSL https://github.com/${{ github.repository }}/releases/download/mcp-bridge-v${VERSION}/skillai-mcp-linux-x64 \\
+               -o ~/.local/bin/skillai-mcp && chmod +x ~/.local/bin/skillai-mcp
+          \`\`\`
+
+          **Linux deb/rpm:** download the package below and install with \`dpkg -i\` / \`rpm -i\`.
+
+          ---
+
+          "
+          FULL_NOTES="${HEADER}${NOTES}"
+          # Write to file to safely pass multi-line string
+          printf '%s' "${FULL_NOTES}" > /tmp/release-notes.md
+
+      - name: Create or update GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          TAG="mcp-bridge-v${VERSION}"
+
+          # Delete existing release if re-running on the same tag (idempotency).
+          gh release delete "${TAG}" --yes 2>/dev/null || true
+
+          gh release create "${TAG}" \
+            --title "@skillai/mcp-bridge v${VERSION}" \
+            --notes-file /tmp/release-notes.md \
+            release-assets/*

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -5,6 +5,104 @@ endpoint over HTTPS. claude-desktop spawns this binary as a subprocess and commu
 via JSON-RPC 2.0 over stdin/stdout. The bridge authenticates every request with a
 bearer token you generate in the SkillAi web UI.
 
+---
+
+## Install
+
+### npm (global, any platform with Node 22+)
+
+```bash
+npm install -g @skillai/mcp-bridge
+```
+
+### Standalone binary (no Node required)
+
+Download the binary for your platform from the
+[latest GitHub Release](https://github.com/olafkfreund/SkillAi/releases?q=mcp-bridge-v&expanded=true),
+then make it executable:
+
+**Linux x64**
+```bash
+curl -fsSL https://github.com/olafkfreund/SkillAi/releases/latest/download/skillai-mcp-linux-x64 \
+     -o ~/.local/bin/skillai-mcp
+chmod +x ~/.local/bin/skillai-mcp
+```
+
+**Linux arm64**
+```bash
+curl -fsSL https://github.com/olafkfreund/SkillAi/releases/latest/download/skillai-mcp-linux-arm64 \
+     -o ~/.local/bin/skillai-mcp
+chmod +x ~/.local/bin/skillai-mcp
+```
+
+**macOS x64**
+```bash
+curl -fsSL https://github.com/olafkfreund/SkillAi/releases/latest/download/skillai-mcp-darwin-x64 \
+     -o /usr/local/bin/skillai-mcp
+chmod +x /usr/local/bin/skillai-mcp
+```
+
+**macOS arm64 (Apple Silicon)**
+```bash
+curl -fsSL https://github.com/olafkfreund/SkillAi/releases/latest/download/skillai-mcp-darwin-arm64 \
+     -o /usr/local/bin/skillai-mcp
+chmod +x /usr/local/bin/skillai-mcp
+```
+
+**Windows x64**
+```powershell
+curl -fsSL https://github.com/olafkfreund/SkillAi/releases/latest/download/skillai-mcp-windows-x64.exe `
+     -o "$env:LOCALAPPDATA\Programs\skillai-mcp.exe"
+```
+
+Each binary ships with a `.sha256` sidecar file for integrity verification.
+
+### Linux .deb package (Debian / Ubuntu)
+
+```bash
+# Replace VERSION with the release version, e.g. 1.0.0
+VERSION=1.0.0
+wget https://github.com/olafkfreund/SkillAi/releases/download/mcp-bridge-v${VERSION}/skillai-mcp_${VERSION}_amd64.deb
+sudo dpkg -i skillai-mcp_${VERSION}_amd64.deb
+# or: sudo apt install ./skillai-mcp_${VERSION}_amd64.deb
+```
+
+arm64:
+```bash
+wget https://github.com/olafkfreund/SkillAi/releases/download/mcp-bridge-v${VERSION}/skillai-mcp_${VERSION}_arm64.deb
+sudo dpkg -i skillai-mcp_${VERSION}_arm64.deb
+```
+
+### Linux .rpm package (RHEL / Fedora / openSUSE)
+
+```bash
+VERSION=1.0.0
+sudo rpm -i https://github.com/olafkfreund/SkillAi/releases/download/mcp-bridge-v${VERSION}/skillai-mcp_${VERSION}_amd64.rpm
+# or with dnf:
+sudo dnf install https://github.com/olafkfreund/SkillAi/releases/download/mcp-bridge-v${VERSION}/skillai-mcp_${VERSION}_amd64.rpm
+```
+
+### NixOS
+
+See the [NixOS install section](#install-on-nixos) below.
+
+---
+
+## Releases
+
+Releases are tagged `mcp-bridge-vX.Y.Z` and published automatically by the
+`.github/workflows/mcp-bridge-release.yml` workflow when that tag is pushed.
+
+Each release includes:
+- 5 standalone binaries (linux-x64, linux-arm64, darwin-x64, darwin-arm64, windows-x64)
+- SHA256 checksums for each binary
+- .deb and .rpm packages for linux-x64 and linux-arm64
+- The `@skillai/mcp-bridge` npm package is published with provenance attestation
+
+To view all releases: <https://github.com/olafkfreund/SkillAi/releases?q=mcp-bridge-v&expanded=true>
+
+---
+
 ## Architecture
 
 ```
@@ -126,6 +224,28 @@ nix develop ./mcp-server
 npm install
 npm run dev
 ```
+
+### Build a local standalone binary (Bun)
+
+[Bun](https://bun.sh) compiles the bridge to a single self-contained binary
+with no Node or Bun runtime required on the target machine:
+
+```bash
+cd mcp-server
+bun install --frozen-lockfile
+
+# Linux x64 (run on any linux-x64 machine):
+bun build src/index.ts --compile --target=bun-linux-x64 --outfile=dist/skillai-mcp-linux-x64
+
+# macOS Apple Silicon:
+bun build src/index.ts --compile --target=bun-darwin-arm64 --outfile=dist/skillai-mcp-darwin-arm64
+
+# Windows x64 (cross-compile from Linux/macOS):
+bun build src/index.ts --compile --target=bun-windows-x64 --outfile=dist/skillai-mcp-windows-x64.exe
+```
+
+The CI release workflow runs these cross-compilation commands on Ubuntu and
+uploads the results to the GitHub Release.
 
 ### Manual JSON-RPC test
 

--- a/mcp-server/nfpm.yaml
+++ b/mcp-server/nfpm.yaml
@@ -1,0 +1,50 @@
+# nfpm.yaml — package configuration for skillai-mcp .deb and .rpm builds.
+#
+# Used by the mcp-bridge-release GitHub Actions workflow.
+#
+# nfpm arch templating judgment call:
+#   nfpm's ${ARCH} variable controls package *metadata* (deb Architecture /
+#   rpm BuildArch) but does NOT allow different src paths per arch within a
+#   single config invocation.  We use a two-pass approach in the workflow:
+#     ARCH=amd64  BIN_ARCH=x64   → src: ./dist/skillai-mcp-linux-x64
+#     ARCH=arm64  BIN_ARCH=arm64 → src: ./dist/skillai-mcp-linux-arm64
+#   Both ARCH and BIN_ARCH are exported env vars before each `nfpm pkg` call.
+#   nfpm v2.x expands ${VAR} in yaml values from the process environment.
+
+name: skillai-mcp
+arch: "${ARCH}"
+version: "${VERSION}"
+section: utils
+priority: optional
+homepage: https://github.com/olafkfreund/SkillAi
+maintainer: "Olaf Krasicki-Freund <olaf@freundcloud.com>"
+description: |
+  Stdio MCP bridge between claude-desktop and SkillAi /api/mcp.
+  Reads SKILLAI_URL and SKILLAI_TOKEN from /etc/skillai-mcp/env or
+  from environment variables set in claude-desktop's mcp.config.json.
+license: MIT
+vendor: SkillAi
+
+contents:
+  # Main binary — installed to /usr/bin so it is on PATH system-wide.
+  - src: ./dist/skillai-mcp-linux-${BIN_ARCH}
+    dst: /usr/bin/skillai-mcp
+    file_info:
+      mode: 0755
+
+  # Example env file — installed as .example so dpkg/rpm never overwrites
+  # a user-edited /etc/skillai-mcp/env on upgrade.
+  - src: ./packaging/etc/env.example
+    dst: /etc/skillai-mcp/env.example
+    type: config
+
+  # Package documentation.
+  - src: ./packaging/usr/share/doc/skillai-mcp/README.md
+    dst: /usr/share/doc/skillai-mcp/README.md
+
+deb:
+  fields:
+    Bugs: https://github.com/olafkfreund/SkillAi/issues
+
+rpm:
+  group: System Environment/Base

--- a/mcp-server/packaging/etc/env.example
+++ b/mcp-server/packaging/etc/env.example
@@ -1,0 +1,14 @@
+# /etc/skillai-mcp/env
+# Source this from your shell rc or a systemd EnvironmentFile.
+#
+# claude-desktop reads its own `env` block in claude_desktop_config.json —
+# those values override anything set here.  This file is useful when invoking
+# skillai-mcp from scripts, cron jobs, or a systemd unit that sets
+# EnvironmentFile=/etc/skillai-mcp/env.
+#
+# Copy this file to /etc/skillai-mcp/env and edit the values below.
+# The .example copy is preserved on package upgrade; /etc/skillai-mcp/env
+# (if you create it) is never touched by package operations.
+
+SKILLAI_URL=http://localhost:3000
+SKILLAI_TOKEN=skl_replace_me_with_a_token_from_/settings/api-tokens

--- a/mcp-server/packaging/usr/share/doc/skillai-mcp/README.md
+++ b/mcp-server/packaging/usr/share/doc/skillai-mcp/README.md
@@ -1,0 +1,66 @@
+# skillai-mcp
+
+Stdio MCP bridge that connects **claude-desktop** to the SkillAi `/api/mcp`
+endpoint over HTTPS.  claude-desktop spawns this binary as a subprocess and
+communicates via JSON-RPC 2.0 over stdin/stdout.
+
+Full documentation: <https://github.com/olafkfreund/SkillAi/tree/main/mcp-server>
+
+---
+
+## Quick start (OS package install)
+
+### 1. Obtain an API token
+
+1. Open the SkillAi web UI.
+2. Navigate to **Settings → API Tokens**.
+3. Click **Generate new token** and copy the `skl_...` value.
+
+### 2. Configure the env file (optional)
+
+```bash
+sudo cp /etc/skillai-mcp/env.example /etc/skillai-mcp/env
+sudo nano /etc/skillai-mcp/env
+# Set SKILLAI_URL and SKILLAI_TOKEN
+```
+
+### 3. Configure claude-desktop
+
+Edit `~/.config/claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "skillai": {
+      "command": "skillai-mcp",
+      "env": {
+        "SKILLAI_URL": "http://localhost:3000",
+        "SKILLAI_TOKEN": "skl_your_token_here"
+      }
+    }
+  }
+}
+```
+
+### 4. Restart claude-desktop
+
+The SkillAi tools should appear in the Claude tools panel.
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `SKILLAI_TOKEN environment variable is required` | Set the env var in claude_desktop_config.json |
+| JSON-RPC error `-32001` (401/403) | Token invalid — regenerate at `/settings/api-tokens` |
+| JSON-RPC error `-32603` + `ECONNREFUSED` | Check `SKILLAI_URL` and that SkillAi is running |
+
+Logs are written to **stderr**; check journalctl or claude-desktop's log output.
+
+---
+
+## License
+
+MIT — part of the SkillAi repository.
+See <https://github.com/olafkfreund/SkillAi/blob/main/LICENSE>.


### PR DESCRIPTION
## Summary

Wave A of Epic #115 — the linchpin release pipeline that produces every cross-platform artefact downstream packagers (#117 Homebrew, #118 AUR, #119 Scoop) will consume.

Push tag `mcp-bridge-vX.Y.Z` → workflow does:
1. **5 Bun-compiled binaries** (linux-x64, linux-arm64, darwin-x64, darwin-arm64, windows-x64) — single executables, no Node runtime required
2. **npm publish** of `@skillai/mcp-bridge` to public registry with `--provenance` (cryptographic build attestation)
3. **4 OS packages via nfpm** — `.deb` (amd64+arm64) + `.rpm` (x86_64+aarch64)
4. **GitHub Release** with all 9 artefacts attached + auto-generated changelog

## Workflow shape

```
validate              # tag-version vs package.json check
   ├── build-binaries # matrix x5, Bun cross-compile
   ├── npm-publish    
   └── package-deb-rpm # downloads linux artefacts → nfpm
       └── release    # downloads everything → gh release create
```

## Files

| File | What |
|---|---|
| `.github/workflows/mcp-bridge-release.yml` | Pipeline (344 lines) |
| `mcp-server/nfpm.yaml` | nfpm config — single config drives both deb + rpm via two-pass build |
| `mcp-server/packaging/etc/env.example` | `/etc/skillai-mcp/env.example` shipped in the OS packages |
| `mcp-server/packaging/usr/share/doc/skillai-mcp/README.md` | Trimmed install doc shipped in the OS packages |
| `mcp-server/README.md` | Updated install paths (npm + .deb + .rpm + standalone binary + Bun build) |

## Quality

- ✅ Both YAML files parse cleanly (`js-yaml` validated)
- ✅ Every third-party action SHA-pinned (no `@main`, no `@latest`); list in commit body
- ✅ Bun pinned to 1.2.13
- ✅ Workflow is idempotent — re-running on the same tag deletes-and-recreates the release
- ✅ npm publish uses `--provenance` for build attestation
- ✅ No main-app source touched

## What's NOT verified yet

This PR ships the **pipeline definition** but doesn't trigger it. Verification requires you to:

1. Set up the npm scope: register `@skillai` org on npmjs.com **OR** edit `mcp-server/package.json` to use a different scope (e.g. `@olafkfreund/mcp-bridge`)
2. Mint an npm publish token; add as GitHub repo secret `NPM_TOKEN`
3. Decide first tag version: `mcp-bridge-v0.1.0` (early/unstable) or `v1.0.0` (stable)
4. After merge: push the tag → watch the workflow → verify all 9 artefacts on the GitHub Release

If any of these is uncomfortable, we can do a "dry-run" version of the workflow first that builds binaries but skips npm publish.

## What this unlocks

After Wave A merges + first tag is pushed: Wave B (Homebrew tap #117 + AUR #118 + Scoop #119) can run in parallel — each just references the GitHub Release URL pattern this pipeline produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)