### PR TITLE
feat(packaging): Tier 2 packagers — Homebrew + AUR + Scoop staged for deployment (#117 #118 #119)

### DIFF
--- a/mcp-server/packaging/README.md
+++ b/mcp-server/packaging/README.md
@@ -1,0 +1,123 @@
+# Packaging staging area
+
+This directory holds the source-of-truth packaging files for **non-Nix** distributions of `skillai-mcp`. Files here are **not consumed in-place** — they need to be deployed to **external repos** that the package managers actually read.
+
+The Nix flake (`mcp-server/flake.nix`) is the exception — it's consumed in-place via `github:olafkfreund/SkillAi?dir=mcp-server`.
+
+## Subdirectories
+
+| Subdir | Format | Target external repo / location |
+|---|---|---|
+| `homebrew-tap/` | Homebrew formula | `github.com/olafkfreund/homebrew-tap` |
+| `aur/` | Arch User Repository PKGBUILD | `ssh://aur@aur.archlinux.org/skillai-mcp-bin.git` |
+| `scoop/` | Scoop bucket manifest | `github.com/olafkfreund/scoop-bucket` |
+| `etc/`, `usr/` | Files baked into `.deb` / `.rpm` packages | Consumed by `nfpm.yaml` in this repo |
+
+## Deployment — first time (per format)
+
+Do this once after the first GitHub Release (`mcp-bridge-v0.1.0`) is published by the release pipeline (`.github/workflows/mcp-bridge-release.yml`).
+
+### Homebrew tap
+
+```bash
+# Create the empty repo on GitHub first (UI; name it "homebrew-tap")
+git clone git@github.com:olafkfreund/homebrew-tap.git
+cd homebrew-tap
+
+# Copy staged files
+cp -r ~/Source/GitHub/SkillAi/mcp-server/packaging/homebrew-tap/* .
+cp -r ~/Source/GitHub/SkillAi/mcp-server/packaging/homebrew-tap/.github .
+
+# Replace the four placeholder SHA256 sums in Formula/skillai-mcp.rb with real
+# values from the GitHub Release page. The release attaches .sha256 sidecars:
+#   skillai-mcp-darwin-x64.sha256
+#   skillai-mcp-darwin-arm64.sha256
+#   skillai-mcp-linux-x64.sha256
+#   skillai-mcp-linux-arm64.sha256
+# Each contains a single 64-char hex string.
+
+git add . && git commit -m "Initial release skillai-mcp 0.1.0"
+git push -u origin main
+```
+
+Users then install with:
+
+```bash
+brew tap olafkfreund/tap
+brew install skillai-mcp
+```
+
+### AUR
+
+Requires an AUR account + SSH key registered at <https://aur.archlinux.org>.
+
+```bash
+git clone ssh://aur@aur.archlinux.org/skillai-mcp-bin.git
+cd skillai-mcp-bin
+
+# Copy staged files (the AUR repo wants files at the repo root, not in subdirs)
+cp ~/Source/GitHub/SkillAi/mcp-server/packaging/aur/PKGBUILD .
+cp ~/Source/GitHub/SkillAi/mcp-server/packaging/aur/.SRCINFO .
+
+# On an Arch box (or in an arch-linux Docker image), regenerate sums:
+~/Source/GitHub/SkillAi/mcp-server/packaging/aur/scripts/bump.sh 0.1.0
+
+# Verify with namcap (optional)
+namcap PKGBUILD
+
+git add PKGBUILD .SRCINFO && git commit -m "Initial release 0.1.0"
+git push
+```
+
+Users then install with:
+
+```bash
+yay -S skillai-mcp-bin     # or paru, pamac, etc.
+```
+
+### Scoop bucket
+
+```bash
+# Create the empty repo on GitHub first (name it "scoop-bucket")
+git clone git@github.com:olafkfreund/scoop-bucket.git
+cd scoop-bucket
+
+# Copy staged files
+cp -r ~/Source/GitHub/SkillAi/mcp-server/packaging/scoop/* .
+cp -r ~/Source/GitHub/SkillAi/mcp-server/packaging/scoop/.github .
+
+# Replace the placeholder hash in bucket/skillai-mcp.json with the real value
+# from skillai-mcp-windows-x64.sha256 in the GitHub Release.
+
+git add . && git commit -m "Initial release skillai-mcp 0.1.0"
+git push -u origin main
+```
+
+Users then install with:
+
+```powershell
+scoop bucket add skillai https://github.com/olafkfreund/scoop-bucket
+scoop install skillai/skillai-mcp
+```
+
+## Deployment — subsequent releases
+
+For each new `mcp-bridge-vX.Y.Z` tag:
+
+| Format | Update mechanism |
+|---|---|
+| **Homebrew tap** | `brew bump-formula-pr --tag=mcp-bridge-vX.Y.Z Formula/skillai-mcp.rb` (auto-fills SHA256 sums + opens a PR) |
+| **AUR** | `./scripts/bump.sh X.Y.Z` then `git commit && git push` (requires Arch box) |
+| **Scoop** | `scoop checkver -u skillai-mcp` then `git commit && git push` (Scoop's auto-bumper handles version + hash) |
+
+The Homebrew tap's CI workflow (`.github/workflows/tests.yml`) runs `brew test` and `brew audit` on every PR. The Scoop bucket's CI runs `Test-Bucket.ps1`. AUR has no CI; rely on `namcap` locally before pushing.
+
+## Why this isn't a one-PR-merges-everything story
+
+The three external package managers each demand their own repo / git host:
+
+- Homebrew taps must be at `https://github.com/<user>/homebrew-tap` — the URL pattern is hard-coded in `brew tap`
+- AUR is its own git host (`aur.archlinux.org`)
+- Scoop buckets are conventionally at `https://github.com/<user>/scoop-bucket`, accessed via `scoop bucket add`
+
+We can't avoid that fan-out. What we CAN do is keep the source of truth here and use those external repos as deployment targets — that's the pattern this directory implements.

--- a/mcp-server/packaging/aur/.SRCINFO
+++ b/mcp-server/packaging/aur/.SRCINFO
@@ -1,0 +1,17 @@
+pkgbase = skillai-mcp-bin
+	pkgdesc = Stdio MCP bridge for SkillAI — prebuilt Bun binary
+	pkgver = 0.1.0
+	pkgrel = 1
+	url = https://github.com/olafkfreund/SkillAi
+	arch = x86_64
+	arch = aarch64
+	license = MIT
+	provides = skillai-mcp
+	conflicts = skillai-mcp
+	options = !strip
+	source_x86_64 = skillai-mcp-0.1.0-x86_64::https://github.com/olafkfreund/SkillAi/releases/download/mcp-bridge-v0.1.0/skillai-mcp-linux-x64
+	source_aarch64 = skillai-mcp-0.1.0-aarch64::https://github.com/olafkfreund/SkillAi/releases/download/mcp-bridge-v0.1.0/skillai-mcp-linux-arm64
+	sha256sums_x86_64 = SKIP
+	sha256sums_aarch64 = SKIP
+
+pkgname = skillai-mcp-bin

--- a/mcp-server/packaging/aur/PKGBUILD
+++ b/mcp-server/packaging/aur/PKGBUILD
@@ -1,0 +1,31 @@
+# Maintainer: Olaf Freund <olaf@freundcloud.com>
+
+pkgname=skillai-mcp-bin
+_pkgname=skillai-mcp
+pkgver=0.1.0
+pkgrel=1
+pkgdesc="Stdio MCP bridge for SkillAI — prebuilt Bun binary"
+arch=('x86_64' 'aarch64')
+url="https://github.com/olafkfreund/SkillAi"
+license=('MIT')
+depends=()
+provides=("skillai-mcp")
+conflicts=("skillai-mcp")
+# Bun-compiled binaries are already stripped; running strip breaks them.
+options=('!strip')
+
+source_x86_64=(
+  "skillai-mcp-$pkgver-x86_64::https://github.com/olafkfreund/SkillAi/releases/download/mcp-bridge-v$pkgver/skillai-mcp-linux-x64"
+)
+source_aarch64=(
+  "skillai-mcp-$pkgver-aarch64::https://github.com/olafkfreund/SkillAi/releases/download/mcp-bridge-v$pkgver/skillai-mcp-linux-arm64"
+)
+
+# Replace SKIP with real sum from the GitHub Release page after first release.
+sha256sums_x86_64=('SKIP')
+# Replace SKIP with real sum from the GitHub Release page after first release.
+sha256sums_aarch64=('SKIP')
+
+package() {
+  install -Dm755 "$srcdir/skillai-mcp-$pkgver-$CARCH" "$pkgdir/usr/bin/skillai-mcp"
+}

--- a/mcp-server/packaging/aur/README.md
+++ b/mcp-server/packaging/aur/README.md
@@ -1,0 +1,22 @@
+# skillai-mcp-bin (AUR)
+
+PKGBUILD for the prebuilt binary version of skillai-mcp.
+
+## Install
+
+```bash
+yay -S skillai-mcp-bin
+# or paru, pamac, etc.
+```
+
+## Configure
+
+```bash
+# In your shell rc or claude-desktop env:
+export SKILLAI_URL=https://your-skillai-host
+export SKILLAI_TOKEN=skl_...
+```
+
+## Maintenance
+
+Run `./scripts/bump.sh X.Y.Z` after each release to update pkgver, refresh sha256sums, regenerate .SRCINFO, and prepare a commit. Then `git push` to the AUR remote.

--- a/mcp-server/packaging/aur/scripts/bump.sh
+++ b/mcp-server/packaging/aur/scripts/bump.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# bump.sh — update PKGBUILD + .SRCINFO for a new skillai-mcp-bin release.
+# Usage: ./scripts/bump.sh <version>
+# Run this script from the root of the AUR git clone (where PKGBUILD lives).
+set -euo pipefail
+
+[ "$#" -eq 1 ] || { echo "usage: $0 <version>"; exit 1; }
+
+VERSION="$1"
+PKGBUILD="$(cd "$(dirname "$0")/.." && pwd)/PKGBUILD"
+
+if [ ! -f "$PKGBUILD" ]; then
+  echo "error: PKGBUILD not found at $PKGBUILD"
+  exit 1
+fi
+
+echo "==> Bumping to version $VERSION"
+
+# 1. Update pkgver and reset pkgrel
+sed -i "s/^pkgver=.*/pkgver=$VERSION/" "$PKGBUILD"
+sed -i "s/^pkgrel=.*/pkgrel=1/" "$PKGBUILD"
+
+# 2. Compute sha256 for each architecture artefact
+BASE_URL="https://github.com/olafkfreund/SkillAi/releases/download/mcp-bridge-v${VERSION}"
+
+compute_sha256() {
+  local url="$1"
+  local tmpfile
+  tmpfile="$(mktemp)"
+  echo "    Downloading $url ..."
+  curl -fsSL "$url" -o "$tmpfile"
+  sha256sum "$tmpfile" | awk '{print $1}'
+  rm -f "$tmpfile"
+}
+
+echo "==> Computing sha256sums ..."
+SHA_X64="$(compute_sha256 "${BASE_URL}/skillai-mcp-linux-x64")"
+SHA_ARM64="$(compute_sha256 "${BASE_URL}/skillai-mcp-linux-arm64")"
+echo "    x86_64  : $SHA_X64"
+echo "    aarch64 : $SHA_ARM64"
+
+# 3. Replace SKIP placeholders (or previous sums) in PKGBUILD.
+#    The sed pattern matches the entire sha256sums_<arch>=('...') line.
+sed -i "s/^sha256sums_x86_64=(.*/sha256sums_x86_64=('$SHA_X64')/" "$PKGBUILD"
+sed -i "s/^sha256sums_aarch64=(.*/sha256sums_aarch64=('$SHA_ARM64')/" "$PKGBUILD"
+
+# 4. Regenerate .SRCINFO
+SRCINFO="$(dirname "$PKGBUILD")/.SRCINFO"
+echo "==> Regenerating .SRCINFO ..."
+(cd "$(dirname "$PKGBUILD")" && makepkg --printsrcinfo > .SRCINFO)
+echo "    Written to $SRCINFO"
+
+# 5. Stage both files
+echo "==> Staging changes ..."
+git -C "$(dirname "$PKGBUILD")" add PKGBUILD .SRCINFO
+
+echo ""
+echo "==> Done. Suggested commit message:"
+echo "    Update to $VERSION"
+echo ""
+echo "Run 'git commit -m \"Update to $VERSION\" && git push' to publish."

--- a/mcp-server/packaging/homebrew-tap/.github/workflows/tests.yml
+++ b/mcp-server/packaging/homebrew-tap/.github/workflows/tests.yml
@@ -1,0 +1,61 @@
+# Homebrew tap CI — runs on every push and PR.
+#
+# Uses the official Homebrew test-bot action to:
+#   - Validate formula Ruby syntax  (--only-tap-syntax)
+#   - Run `brew audit --strict`     (included in tap-syntax step)
+#   - Run `brew test`               (--only-formulae)
+#
+# NOTE: Homebrew/actions/setup-homebrew@master is used here for simplicity.
+# In production, pin to a specific commit SHA for supply-chain safety, e.g.:
+#   uses: Homebrew/actions/setup-homebrew@<SHA>
+
+name: brew test-bot
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+      fail-fast: false
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Check out tap repository
+        uses: actions/checkout@v4
+
+      # Sets up Homebrew and all required Ruby/path environment for test-bot
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master  # pin to SHA in production
+
+      # Remove any leftover artefacts from previous test-bot runs
+      - name: test-bot cleanup (before)
+        run: brew test-bot --only-cleanup-before
+
+      # Install test-bot dependencies and prepare the environment
+      - name: test-bot setup
+        run: brew test-bot --only-setup
+
+      # Validates Ruby syntax and runs `brew audit --strict` on all formulas in the tap
+      - name: test-bot tap syntax + audit
+        run: brew test-bot --only-tap-syntax
+
+      # Installs the formula from source and runs the `test do` block.
+      # --root-url points test-bot at THIS tap so it resolves the formula correctly.
+      # Note: the formula uses placeholder SHA256 values before the first release;
+      # this step will be skipped (formula install will fail gracefully) until real
+      # artefacts exist. The tap-syntax step above still validates Ruby correctness.
+      - name: test-bot formulae (install + test)
+        run: |
+          brew test-bot \
+            --only-formulae \
+            --root-url="https://github.com/olafkfreund/SkillAi/releases" \
+            Formula/skillai-mcp.rb
+        # Allow this step to fail while placeholder hashes are in place.
+        # Remove `continue-on-error` once the first real release artefacts exist.
+        continue-on-error: true

--- a/mcp-server/packaging/homebrew-tap/Formula/skillai-mcp.rb
+++ b/mcp-server/packaging/homebrew-tap/Formula/skillai-mcp.rb
@@ -1,0 +1,104 @@
+# Formula for skillai-mcp — Stdio MCP bridge between claude-desktop and SkillAi /api/mcp
+#
+# OPERATOR NOTES
+# --------------
+# 1. After cutting a release tag (mcp-bridge-vX.Y.Z), download each artefact from the
+#    GitHub Releases page and compute SHA256 sums:
+#
+#      shasum -a 256 skillai-mcp-darwin-arm64
+#      shasum -a 256 skillai-mcp-darwin-x86_64
+#      shasum -a 256 skillai-mcp-linux-arm64
+#      shasum -a 256 skillai-mcp-linux-x86_64
+#
+# 2. Replace every REPLACE_WITH_SHA256_FROM_RELEASE_* placeholder below with the
+#    corresponding digest.
+#
+# 3. Bump the `version` field to match the new tag.
+#
+# Alternatively, use:
+#   brew bump-formula-pr --tag=mcp-bridge-vX.Y.Z --revision=<commit-sha> Formula/skillai-mcp.rb
+
+class SkillaiMcp < Formula
+  desc "Stdio MCP bridge between claude-desktop and SkillAi /api/mcp"
+  homepage "https://github.com/olafkfreund/SkillAi"
+  license "MIT"
+  version "0.1.0"
+
+  # GitHub Release artefact base URL — updated automatically by bump-formula-pr
+  BASE_URL = "https://github.com/olafkfreund/SkillAi/releases/download/mcp-bridge-v#{version}"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "#{BASE_URL}/skillai-mcp-darwin-arm64"
+      sha256 "REPLACE_WITH_SHA256_FROM_RELEASE_DARWIN_ARM64"
+    else
+      # Intel Mac
+      url "#{BASE_URL}/skillai-mcp-darwin-x86_64"
+      sha256 "REPLACE_WITH_SHA256_FROM_RELEASE_DARWIN_X86_64"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "#{BASE_URL}/skillai-mcp-linux-arm64"
+      sha256 "REPLACE_WITH_SHA256_FROM_RELEASE_LINUX_ARM64"
+    else
+      # Intel / AMD64 Linux (Linuxbrew)
+      url "#{BASE_URL}/skillai-mcp-linux-x86_64"
+      sha256 "REPLACE_WITH_SHA256_FROM_RELEASE_LINUX_X86_64"
+    end
+  end
+
+  # The release artefact is a single pre-compiled binary with no dependencies.
+  # No bottle block needed — we are distributing the binary directly.
+
+  def install
+    # The downloaded artefact is a bare binary (no archive to unpack).
+    # Dir["skillai-mcp*"].first handles both the case where the file retains
+    # its platform suffix after download and the case where Homebrew strips it.
+    bin.install Dir["skillai-mcp*"].first => "skillai-mcp"
+  end
+
+  def caveats
+    <<~EOS
+      skillai-mcp is a stdio bridge for the Model Context Protocol (MCP).
+      It reads SKILLAI_URL and SKILLAI_TOKEN from the environment and proxies
+      MCP JSON-RPC calls to your SkillAi instance's /api/mcp endpoint.
+
+      ── Environment variables ────────────────────────────────────────────────
+      Add to your shell rc (~/.zshrc, ~/.bashrc, etc.):
+
+        export SKILLAI_URL=https://your-skillai-host
+        export SKILLAI_TOKEN=skl_...
+
+      ── claude-desktop configuration ─────────────────────────────────────────
+      Add the following block to your claude-desktop mcp.config.json
+      (usually ~/Library/Application Support/Claude/mcp.config.json on macOS):
+
+        {
+          "mcpServers": {
+            "skillai": {
+              "command": "#{HOMEBREW_PREFIX}/bin/skillai-mcp",
+              "env": {
+                "SKILLAI_URL": "https://your-skillai-host",
+                "SKILLAI_TOKEN": "skl_..."
+              }
+            }
+          }
+        }
+
+      Restart claude-desktop after editing mcp.config.json.
+      ─────────────────────────────────────────────────────────────────────────
+    EOS
+  end
+
+  test do
+    # With no SKILLAI_URL / SKILLAI_TOKEN set, the binary must exit non-zero
+    # and print a diagnostic to stderr indicating the missing configuration.
+    # We capture stderr and assert the expected message is present.
+    output = shell_output("#{bin}/skillai-mcp 2>&1", 1)
+    assert_match(/SKILLAI_URL|SKILLAI_TOKEN|missing|required|not set/i, output,
+                 "Expected skillai-mcp to print a missing-env-var error when no " \
+                 "SKILLAI_URL or SKILLAI_TOKEN is provided")
+  end
+end

--- a/mcp-server/packaging/homebrew-tap/README.md
+++ b/mcp-server/packaging/homebrew-tap/README.md
@@ -1,0 +1,32 @@
+# olafkfreund/homebrew-tap
+
+Custom Homebrew tap for SkillAi tools.
+
+## Usage
+
+```bash
+brew tap olafkfreund/tap
+brew install skillai-mcp
+```
+
+## Available formulas
+
+- `skillai-mcp` — Stdio MCP bridge between claude-desktop and SkillAi /api/mcp
+
+## Configuration
+
+After install, set environment variables in your shell rc:
+
+```bash
+export SKILLAI_URL=https://your-skillai-host
+export SKILLAI_TOKEN=skl_...
+```
+
+Or pass them via claude-desktop's mcp.config.json (see the formula's caveats output).
+
+## Updating
+
+When a new `mcp-bridge-vX.Y.Z` tag is released:
+
+1. Get the SHA256 sums from the GitHub Release page
+2. Run `brew bump-formula-pr --tag=mcp-bridge-vX.Y.Z --revision=<commit-sha> Formula/skillai-mcp.rb` (or hand-edit + PR)

--- a/mcp-server/packaging/scoop/.github/workflows/ci.yml
+++ b/mcp-server/packaging/scoop/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Scoop
+        # Bootstrap Scoop in the runner's user profile; installs to %USERPROFILE%\scoop
+        run: |
+          Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
+          iwr -useb get.scoop.sh | iex
+        shell: powershell
+
+      - name: Validate manifests
+        # Test-Bucket.ps1 is the official linter shipped with Scoop itself.
+        # After bootstrapping, Scoop lives at $env:USERPROFILE\scoop\apps\scoop\current.
+        # The script accepts a -Dir parameter pointing at the bucket root.
+        run: |
+          $scoopHome = "$env:USERPROFILE\scoop\apps\scoop\current"
+          $testScript = "$scoopHome\test\Test-Bucket.ps1"
+          if (-not (Test-Path $testScript)) {
+            Write-Error "Test-Bucket.ps1 not found at $testScript — check Scoop installation"
+            exit 1
+          }
+          & $testScript -Dir .\bucket
+        shell: powershell

--- a/mcp-server/packaging/scoop/README.md
+++ b/mcp-server/packaging/scoop/README.md
@@ -1,0 +1,43 @@
+# olafkfreund/scoop-bucket
+
+Custom Scoop bucket for SkillAi tools.
+
+## Usage
+
+```powershell
+scoop bucket add skillai https://github.com/olafkfreund/scoop-bucket
+scoop install skillai/skillai-mcp
+```
+
+## Available manifests
+
+- `skillai-mcp` — Stdio MCP bridge between claude-desktop and SkillAi /api/mcp
+
+## Configure
+
+In your PowerShell profile or claude-desktop's `mcp.config.json`:
+
+```json
+{
+  "mcpServers": {
+    "skillai": {
+      "command": "skillai-mcp",
+      "env": {
+        "SKILLAI_URL": "https://your-skillai-host",
+        "SKILLAI_TOKEN": "skl_..."
+      }
+    }
+  }
+}
+```
+
+## Maintenance
+
+The manifest's `checkver` + `autoupdate` blocks let Scoop auto-bump on new SkillAi releases. Manually trigger via:
+
+```powershell
+scoop checkver -u skillai-mcp
+git diff bucket/skillai-mcp.json
+git commit -am "skillai-mcp: bump to X.Y.Z"
+git push
+```

--- a/mcp-server/packaging/scoop/bucket/skillai-mcp.json
+++ b/mcp-server/packaging/scoop/bucket/skillai-mcp.json
@@ -1,0 +1,31 @@
+{
+  "version": "0.1.0",
+  "description": "Stdio MCP bridge between claude-desktop and SkillAi /api/mcp",
+  "homepage": "https://github.com/olafkfreund/SkillAi",
+  "license": "MIT",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/olafkfreund/SkillAi/releases/download/mcp-bridge-v0.1.0/skillai-mcp-windows-x64.exe",
+      "hash": "REPLACE_WITH_SHA256_AFTER_FIRST_RELEASE"
+    }
+  },
+  "bin": [
+    ["skillai-mcp-windows-x64.exe", "skillai-mcp"]
+  ],
+  "checkver": {
+    "github": "https://github.com/olafkfreund/SkillAi",
+    "regex": "mcp-bridge-v([\\d.]+)"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/olafkfreund/SkillAi/releases/download/mcp-bridge-v$version/skillai-mcp-windows-x64.exe"
+      }
+    },
+    "hash": {
+      "url": "$url.sha256"
+    }
+  },
+  "persist": [],
+  "shortcuts": []
+}


### PR DESCRIPTION
## Summary

Wave B of Epic #115. Stages all three Tier 2 packaging formats so the deployment to external repos becomes a one-time copy-paste step after Wave A's first release runs.

| Format | Subdir | External repo target |
|---|---|---|
| Homebrew tap | `mcp-server/packaging/homebrew-tap/` | `olafkfreund/homebrew-tap` (operator creates) |
| AUR PKGBUILD | `mcp-server/packaging/aur/` | `aur.archlinux.org/skillai-mcp-bin.git` |
| Scoop bucket | `mcp-server/packaging/scoop/` | `olafkfreund/scoop-bucket` (operator creates) |

Plus `mcp-server/packaging/README.md` — the deployment guide explaining how to fan out from this staging directory to each external repo.

## Why staged here, not in the external repos directly

I can't create the external repos for you (operator action). The cleanest pattern is: source-of-truth lives here in the SkillAi repo, deployment to external repos is a documented one-time step. Subsequent releases are auto-bumped via `brew bump-formula-pr` (Homebrew), `bump.sh` (AUR), or `scoop checkver -u` (Scoop) — those tools update the external repos directly without needing changes here.

## Files (11 total, 554 insertions)

### `mcp-server/packaging/homebrew-tap/` (#117)

- **`Formula/skillai-mcp.rb`** — Ruby formula with `on_macos` + `on_linux` blocks for both Intel + ARM. `BASE_URL` constant means `bump-formula-pr` updates `version` in one place. `caveats` explains env vars + claude-desktop config. `test` stanza runs the binary asserting it errors on missing token. **Ruby syntax validated** with `ruby -c`.
- **`README.md`** — tap usage + maintenance flow
- **`.github/workflows/tests.yml`** — `brew audit --strict` + `brew test` on macos-latest + ubuntu-latest. `--only-formulae` step has `continue-on-error` until placeholder SHA256s are real.

### `mcp-server/packaging/aur/` (#118)

- **`PKGBUILD`** — `skillai-mcp-bin` (`-bin` suffix per AUR convention for prebuilt binaries). `depends=()` (Bun binaries are static). `options=('!strip')` (already stripped). `provides=skillai-mcp` + `conflicts=skillai-mcp` so a future from-source build coexists cleanly. `arch=(x86_64 aarch64)`. `SKIP` placeholder sums per AUR pre-release convention.
- **`.SRCINFO`** — generated; **tab-indented** per AUR spec (verified via `cat -A`)
- **`README.md`** — install + maintenance
- **`scripts/bump.sh`** — version-bump script: updates `pkgver`, fetches sources, computes real `sha256` sums, regenerates `.SRCINFO` via `makepkg --printsrcinfo`. Run inside the AUR git clone on any Arch box.

### `mcp-server/packaging/scoop/` (#119)

- **`bucket/skillai-mcp.json`** — manifest with `autoupdate` + `checkver` blocks. `bin` alias `[["skillai-mcp-windows-x64.exe", "skillai-mcp"]]` so claude-desktop invokes just `skillai-mcp`. `$url.sha256` sidecar lookup matches what the release pipeline produces. Placeholder hash is **intentionally non-hex** so bad installs fail loud. **JSON parses cleanly** (verified).
- **`README.md`** — bucket usage + maintenance
- **`.github/workflows/ci.yml`** — `Test-Bucket.ps1` on windows-latest with the current `-Dir` flag (older docs say `-Bucket`; the flag was renamed)

### Cross-cutting

- **`mcp-server/packaging/README.md`** — deployment guide. Covers first-time deploy per format and subsequent-release auto-bump workflow.

## What's NOT in this PR

- **External repos themselves** — `olafkfreund/homebrew-tap`, `olafkfreund/scoop-bucket` need to be created by you (UI on github.com). AUR account + SSH key for #118.
- **Real SHA256 sums** — every formula/manifest uses obvious placeholders (`REPLACE_WITH_SHA256_AFTER_FIRST_RELEASE` for Homebrew/Scoop; `SKIP` for AUR per its convention). Replaced after Wave A's first release.

## Verified

- ✅ Ruby formula syntax valid (`ruby -c`)
- ✅ Scoop manifest JSON parses (`node JSON.parse`)
- ✅ AUR `.SRCINFO` tab-indented (`cat -A`)
- ✅ No files outside `mcp-server/packaging/` touched
- ✅ Portal undisturbed throughout

## Order of operations after both Wave A and Wave B PRs merge

1. Push first tag: `git tag mcp-bridge-v0.1.0 && git push origin mcp-bridge-v0.1.0`
2. Wave A workflow runs → 9 artefacts on a GitHub Release
3. Create external repos: `olafkfreund/homebrew-tap`, `olafkfreund/scoop-bucket`
4. Per `mcp-server/packaging/README.md`: copy each subdir's contents to its target repo, replace placeholder hashes with real ones from the release, push
5. Test installs:
   - macOS: `brew tap olafkfreund/tap && brew install skillai-mcp`
   - Arch: `yay -S skillai-mcp-bin`
   - Windows: `scoop bucket add skillai https://github.com/olafkfreund/scoop-bucket && scoop install skillai/skillai-mcp`
   - Anywhere: `npm install -g @skillai/mcp-bridge`

🤖 Generated with [Claude Code](https://claude.com/claude-code)