### PR TITLE
feat(release): npm-optional + reframe packaging docs (no external repos)

### DIFF
--- a/.github/workflows/mcp-bridge-release.yml
+++ b/.github/workflows/mcp-bridge-release.yml
@@ -142,24 +142,52 @@ jobs:
           retention-days: 1
 
   # ---------------------------------------------------------------------------
-  # 3. npm-publish — compile via tsc + publish to npm registry with provenance
+  # 3. npm-publish — OPTIONAL. Only runs if NPM_TOKEN secret is configured.
+  #
+  # The release pipeline is designed to work WITHOUT npm publishing — users can
+  # install via:
+  #   - Direct binary download from the GitHub Release
+  #   - .deb / .rpm files from the GitHub Release
+  #   - Nix flake (github:olafkfreund/SkillAi?dir=mcp-server)
+  #
+  # To enable npm publishing later:
+  #   1. Register an npm scope (e.g. @olafkfreund) — npmjs.com → New Org
+  #      OR rename the package in mcp-server/package.json to an unscoped name
+  #   2. Mint a Granular Access Token with publish rights to that scope
+  #   3. Add it as the NPM_TOKEN repo secret
+  #   4. Re-tag (e.g. mcp-bridge-v0.1.1) — this job will activate
   # ---------------------------------------------------------------------------
   npm-publish:
-    name: Publish to npm
+    name: Publish to npm (optional)
     runs-on: ubuntu-latest
     needs: validate
 
     steps:
+      - name: Check for NPM_TOKEN
+        id: check
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "$NPM_TOKEN" ]; then
+            echo "has_token=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::NPM_TOKEN secret not set — skipping npm publish. Other release artefacts (binaries, .deb, .rpm) will still be produced. Set NPM_TOKEN and re-tag to enable npm publishing."
+          else
+            echo "has_token=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout
+        if: steps.check.outputs.has_token == 'true'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Setup Node.js
+        if: steps.check.outputs.has_token == 'true'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install and build
+        if: steps.check.outputs.has_token == 'true'
         working-directory: mcp-server
         run: |
           npm ci
@@ -168,6 +196,7 @@ jobs:
       - name: Temporarily set package to public for publish
         # The package.json has "private": true for repo-level hygiene.
         # We remove that flag only for the publish step so npm doesn't refuse.
+        if: steps.check.outputs.has_token == 'true'
         working-directory: mcp-server
         run: |
           node -e "
@@ -178,6 +207,7 @@ jobs:
           "
 
       - name: Publish to npm
+        if: steps.check.outputs.has_token == 'true'
         working-directory: mcp-server
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -269,11 +299,13 @@ jobs:
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    # npm-publish is OPTIONAL — release proceeds even if npm publishing was
+    # skipped (NPM_TOKEN missing) or failed. Binaries + .deb/.rpm are the
+    # primary distribution path; npm is an additional channel.
     needs:
       - validate
       - build-binaries
       - package-deb-rpm
-      - npm-publish
 
     steps:
       - name: Checkout

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -9,11 +9,19 @@ bearer token you generate in the SkillAi web UI.
 
 ## Install
 
-### npm (global, any platform with Node 22+)
+The recommended install paths — none require external package-manager repos:
 
-```bash
-npm install -g @skillai/mcp-bridge
-```
+| Method | OS / distro | Notes |
+|---|---|---|
+| **Standalone binary from GitHub Releases** | Linux / macOS / Windows | No runtime deps; works everywhere |
+| **`.deb` from GitHub Releases** | Debian / Ubuntu | Includes `/etc/skillai-mcp/env.example` |
+| **`.rpm` from GitHub Releases** | Fedora / RHEL / openSUSE | Same as above |
+| **Nix flake** | NixOS | `nix profile install github:olafkfreund/SkillAi?dir=mcp-server` |
+| **npm** *(optional — only if `NPM_TOKEN` is configured)* | Anywhere with Node 22+ | `npm install -g @skillai/mcp-bridge` |
+
+> **Note on npm:** the release pipeline can publish to npmjs.com, but only if the operator has set up an npm scope and added an `NPM_TOKEN` repo secret. If you see no `@skillai/mcp-bridge` package on npm, that step is intentionally inactive — use one of the binary or Nix paths instead.
+
+> **Note on Homebrew / AUR / Scoop:** packaging files for these are staged at `mcp-server/packaging/` for possible future deployment, but no external repos exist for them at this time. Install via the binary or Nix paths.
 
 ### Standalone binary (no Node required)
 

--- a/mcp-server/packaging/README.md
+++ b/mcp-server/packaging/README.md
@@ -1,8 +1,26 @@
 # Packaging staging area
 
-This directory holds the source-of-truth packaging files for **non-Nix** distributions of `skillai-mcp`. Files here are **not consumed in-place** — they need to be deployed to **external repos** that the package managers actually read.
+This directory holds the source-of-truth packaging files for `skillai-mcp` distributions.
 
-The Nix flake (`mcp-server/flake.nix`) is the exception — it's consumed in-place via `github:olafkfreund/SkillAi?dir=mcp-server`.
+## In active use (consumed by the release pipeline)
+
+- **`etc/` and `usr/`** — files bundled into `.deb` / `.rpm` packages built by the release pipeline (`.github/workflows/mcp-bridge-release.yml`) via `nfpm.yaml`. Users download the resulting `.deb`/`.rpm` directly from the GitHub Release page — no external repos involved.
+
+## In active use (consumed in-place)
+
+- **`mcp-server/flake.nix`** (one level up) — Nix flake consumed via `github:olafkfreund/SkillAi?dir=mcp-server`. No external repo involved.
+
+## Deferred — staged for possible future deployment
+
+The three subdirectories below contain ready-to-deploy packaging files for external package managers (Homebrew, AUR, Scoop). **They are NOT currently maintained.** The operator decided not to create the external repos these formats require, so users on those platforms install via the alternatives listed in `mcp-server/README.md` (npm, Nix flake, direct binary download from GitHub Releases, or the `.deb`/`.rpm` files).
+
+If you (or a future maintainer) decide to enable any of these, the staged files are a head-start — but expect placeholder SHA256 sums to need replacing and external-repo creation as documented at the bottom of this file.
+
+| Subdir | Format | External target if enabled |
+|---|---|---|
+| `homebrew-tap/` | Homebrew formula | `github.com/<owner>/homebrew-tap` |
+| `aur/` | Arch User Repository PKGBUILD | `ssh://aur@aur.archlinux.org/skillai-mcp-bin.git` |
+| `scoop/` | Scoop bucket manifest | `github.com/<owner>/scoop-bucket` |
 
 ## Subdirectories
 
@@ -13,9 +31,9 @@ The Nix flake (`mcp-server/flake.nix`) is the exception — it's consumed in-pla
 | `scoop/` | Scoop bucket manifest | `github.com/olafkfreund/scoop-bucket` |
 | `etc/`, `usr/` | Files baked into `.deb` / `.rpm` packages | Consumed by `nfpm.yaml` in this repo |
 
-## Deployment — first time (per format)
+## If you decide to enable an external-repo packager later
 
-Do this once after the first GitHub Release (`mcp-bridge-v0.1.0`) is published by the release pipeline (`.github/workflows/mcp-bridge-release.yml`).
+The deployment recipes below are reference material — they don't run automatically. Expect to redo them per format.
 
 ### Homebrew tap
 


### PR DESCRIPTION
## Summary

Adapts the release pipeline + docs to your decision not to create external package repos (Homebrew tap, AUR, Scoop bucket) and not to set up the npm scope. **The release pipeline still produces a fully usable release** — binaries + .deb/.rpm + GitHub Release page — without any operator-side setup.

## What changed

### Workflow (`.github/workflows/mcp-bridge-release.yml`)

- **`npm-publish` is now opt-in.** Runs unconditionally, but its first step probes for `NPM_TOKEN`. If absent, sets a job output `has_token=false` and emits a `::warning::`; all subsequent steps in the job are gated on that output. Job exits successfully (no-op) when no token — doesn't fail the workflow.
- **`release` job no longer depends on `npm-publish`.** A missing or failing npm publish doesn't block the GitHub Release. Binaries and OS packages are the primary distribution; npm is an additional channel.
- Documentation block at the top of the npm-publish job explains how to enable npm later (register a scope, mint the token, add as repo secret, re-tag).

### Docs

- **`mcp-server/README.md` install section** now leads with a table showing the no-external-repo install paths first:
  - Standalone binary from GitHub Releases (Linux / macOS / Windows)
  - `.deb` from GitHub Releases (Debian / Ubuntu)
  - `.rpm` from GitHub Releases (Fedora / RHEL / openSUSE)
  - Nix flake
  - npm (marked optional — only if NPM_TOKEN is set up)
  
  Plus explicit notes that Homebrew / AUR / Scoop are **NOT currently maintained** and users should use one of the above paths.

- **`mcp-server/packaging/README.md`** now clearly distinguishes:
  - **Active** — `etc/`, `usr/` (consumed by the release pipeline's nfpm step)
  - **Active** — `mcp-server/flake.nix` (consumed via flake URL)
  - **Deferred** — `homebrew-tap/`, `aur/`, `scoop/` (staged but external repos don't exist; not maintained)

  Old "first-time deployment" recipes are kept lower in the file as reference material in case someone enables them later — but they're no longer presented as required steps.

## What this PR does NOT change

- The staged `mcp-server/packaging/{aur,homebrew-tap,scoop}/` files **stay in the repo** as harmless head-starts if a future maintainer enables them. Deleting them would discard work and signal "this format will never happen" — staying flexible felt better.
- No code logic changes. No new deps. The build artefacts are exactly the same; only the post-build distribution channels differ.

## Verified

- ✅ Workflow YAML parses cleanly (validated via `js-yaml`)
- ✅ All jobs still defined: validate, build-binaries, npm-publish, package-deb-rpm, release

## Net effect

Before this PR: pushing `mcp-bridge-v0.1.0` would fail because `npm-publish` would error on missing `NPM_TOKEN` and `release` depended on it.

After this PR: pushing `mcp-bridge-v0.1.0` produces:
- 5 binaries (linux x64+arm64, darwin x64+arm64, windows x64) attached to the Release
- 4 OS packages (.deb amd64+arm64, .rpm x86_64+aarch64) attached to the Release
- Auto-generated changelog
- npm publish skipped with a clear warning in the workflow log

Users install via direct download from the GitHub Release page (or Nix flake on NixOS). No external package-manager repos required.

If you decide to enable npm later: register `@skillai` (or rename the package scope), mint `NPM_TOKEN`, push a new tag — npm publish activates automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)