### PR TITLE
fix(release): correct nfpm v2.41.3 SHA256

### DIFF
--- a/.github/workflows/skillai-mcp-release.yml
+++ b/.github/workflows/skillai-mcp-release.yml
@@ -243,10 +243,10 @@ jobs:
 
       - name: Install nfpm (pinned release)
         # Pinning to nfpm v2.41.3 — goreleaser/nfpm, MIT licence.
-        # SHA256 verified against the upstream release page.
+        # Real SHA256 from https://github.com/goreleaser/nfpm/releases/download/v2.41.3/checksums.txt
         env:
           NFPM_VERSION: '2.41.3'
-          NFPM_SHA256: 'a70c4ad59de3a38e5a77a975d7ba2e4d10b8cd4e5c07b46a6c6aeefc1fcc2f38'
+          NFPM_SHA256: '22aa6d3bc2ec239d62d3d190bcb036a47f2b24e0c3c6edfccebb6a55fbb2078e'
         run: |
           wget -q "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz" \
                -O /tmp/nfpm.tar.gz


### PR DESCRIPTION
## Summary

Second attempt at \`skillai-mcp-v0.1.0\` failed at the \`Install nfpm\` step because the pinned hash didn't match.

Real SHA256 from [goreleaser/nfpm v2.41.3 checksums.txt](https://github.com/goreleaser/nfpm/releases/download/v2.41.3/checksums.txt):
\`22aa6d3bc2ec239d62d3d190bcb036a47f2b24e0c3c6edfccebb6a55fbb2078e\`

Workflow had:
\`a70c4ad59de3a38e5a77a975d7ba2e4d10b8cd4e5c07b46a6c6aeefc1fcc2f38\`

Either a typo at authoring time or pinned against an older tarball goreleaser later rebuilt. Updated to match.

## What WORKED in the prior attempt

- Validate ✅ (lockfile fix from #124 worked)
- All 5 Bun cross-compiles ✅ (linux-x64, linux-arm64, darwin-x64, darwin-arm64, windows-x64)
- npm-publish ✅ (no-op skip — NPM_TOKEN not configured, as intended)

## What still needs to run on the next attempt

- Install nfpm + build .deb/.rpm × amd64+arm64
- GitHub Release creation with all 9 artefacts attached

## Diff

1 file changed, 2 lines: just the SHA256 + a comment refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)