### PR TITLE
fix(release): package-deb-rpm — needs.validate + envsubst for nfpm.yaml

### DIFF
--- a/.github/workflows/skillai-mcp-release.yml
+++ b/.github/workflows/skillai-mcp-release.yml
@@ -219,7 +219,9 @@ jobs:
   package-deb-rpm:
     name: Build deb + rpm packages
     runs-on: ubuntu-latest
-    needs: build-binaries
+    needs:
+      - validate       # for VERSION output
+      - build-binaries # for the linux artefacts
 
     steps:
       - name: Checkout
@@ -256,34 +258,44 @@ jobs:
           nfpm --version
 
       - name: Build packages (two-pass per arch)
-        # Judgment call on nfpm arch handling:
-        # nfpm's ${ARCH} variable controls the *package metadata* arch but NOT which src
-        # file to pick up — src paths in nfpm.yaml are evaluated once per run, not per
-        # matrix entry. The cleanest approach is a two-pass build: we set BIN_ARCH to
-        # the platform-specific binary suffix (x64 → x86_64, arm64 → aarch64) and let
-        # the YAML ${BIN_ARCH} expansion pick the right binary on each pass.
-        # We also export ARCH so nfpm sets correct package metadata (amd64/arm64).
+        # nfpm doesn't shell-expand env vars in `src:` paths inside the YAML's
+        # `contents` array (only top-level fields like `version`/`arch`). The
+        # robust fix is to render the YAML with `envsubst` per arch into a
+        # temporary file, then invoke `nfpm pkg --config nfpm.rendered.yaml`.
+        # ARCH and BIN_ARCH determine package metadata (amd64/arm64) and which
+        # linux binary the contents reference (x64/arm64 in the binary name).
         working-directory: skillai-mcp
         env:
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
+          if [ -z "${VERSION}" ]; then
+            echo "::error::VERSION is empty — validate.outputs.version was not propagated"
+            exit 1
+          fi
+
           for COMBO in "amd64:x64" "arm64:arm64"; do
             PKG_ARCH="${COMBO%%:*}"
             BIN_ARCH="${COMBO##*:}"
 
             export ARCH="${PKG_ARCH}"
-            export BIN_ARCH="${BIN_ARCH}"
-            export VERSION="${VERSION}"
+            export BIN_ARCH
+            export VERSION
+
+            # Render nfpm.yaml with env-var expansion (envsubst is in coreutils
+            # on ubuntu-latest, no extra install needed).
+            envsubst '${ARCH} ${BIN_ARCH} ${VERSION}' < nfpm.yaml > nfpm.rendered.yaml
 
             for PKG_TYPE in deb rpm; do
-              EXT="${PKG_TYPE}"
               nfpm pkg \
                 --packager="${PKG_TYPE}" \
-                --config=nfpm.yaml \
-                --target="skillai-mcp_${VERSION}_${PKG_ARCH}.${EXT}"
-              echo "Built: skillai-mcp_${VERSION}_${PKG_ARCH}.${EXT}"
+                --config=nfpm.rendered.yaml \
+                --target="skillai-mcp_${VERSION}_${PKG_ARCH}.${PKG_TYPE}"
+              echo "Built: skillai-mcp_${VERSION}_${PKG_ARCH}.${PKG_TYPE}"
             done
           done
+
+          # Tidy up the rendered scratch file
+          rm -f nfpm.rendered.yaml
 
       - name: Upload package artefacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2


### PR DESCRIPTION
## Summary

Third release attempt failed because the \`package-deb-rpm\` job had two bugs that prior errors had masked:

### Bug 1 — \`VERSION\` was empty
The job's \`needs:\` listed only \`build-binaries\`, not \`validate\`. So \`needs.validate.outputs.version\` evaluated to empty string. The error log showed \`VERSION: \` (no value) and package targets like \`skillai-mcp__amd64.deb\`.

**Fix:** add \`validate\` to the \`needs:\` array.

### Bug 2 — \`\${BIN_ARCH}\` not expanded by nfpm
nfpm v2 expands env vars only in a few top-level fields (\`version\`, \`arch\`), NOT in \`src:\` paths inside \`contents[]\`. So nfpm tried to read \`./dist/skillai-mcp-linux-\${BIN_ARCH}\` literally and got \`glob failed: no matching files\`.

**Fix:** render \`nfpm.yaml\` through \`envsubst\` into a temp \`nfpm.rendered.yaml\` per-arch, then point nfpm at the rendered file. envsubst is in coreutils on ubuntu-latest, no install needed.

## Also

- Explicit guard at the top of the step that fails fast with a clear error if \`VERSION\` is empty — prevents future silent breakage if outputs plumbing regresses.

## Run history this session

| Run | Failed at | Cause | Fixed in |
|---|---|---|---|
| 25060131905 | validate | Lockfile out of sync | #124 (merged) |
| 25060601086 | Install nfpm | Wrong SHA256 | #125 (merged) |
| 25060943923 | Build packages | This PR's two bugs | This PR |

After this lands the only remaining unknowns are nfpm reading the rendered YAML (high confidence) and \`gh release create\` (high confidence).

## Diff

\`.github/workflows/skillai-mcp-release.yml\` — 26 insertions, 14 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)