### PR TITLE
fix(release): upload-artifact path needs multiline globs

### DIFF
--- a/.github/workflows/skillai-mcp-release.yml
+++ b/.github/workflows/skillai-mcp-release.yml
@@ -301,7 +301,11 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: packages-deb-rpm
-          path: skillai-mcp/skillai-mcp_*.{deb,rpm}
+          # actions/upload-artifact uses minimatch globs — no brace expansion.
+          # Two patterns on separate lines.
+          path: |
+            skillai-mcp/skillai-mcp_*.deb
+            skillai-mcp/skillai-mcp_*.rpm
           if-no-files-found: error
           retention-days: 1
 


### PR DESCRIPTION
\`actions/upload-artifact\` uses minimatch globs — no brace-expansion. The previous \`skillai-mcp_*.{deb,rpm}\` pattern matched zero files even though nfpm had successfully built all 4 packages.

Fixed via multiline \`path:\`:

\`\`\`yaml
path: |
  skillai-mcp/skillai-mcp_*.deb
  skillai-mcp/skillai-mcp_*.rpm
\`\`\`

This is now fix #4 of the release pipeline. The build step itself ran cleanly on run 25061209144 — only the upload glob was wrong. After this lands the only remaining unknown is \`gh release create\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)