### PR TITLE
docs: refresh README + architecture + roadmap for MCP + recent epics

### DIFF
--- a/.agent-os/product/roadmap.md
+++ b/.agent-os/product/roadmap.md
@@ -1,8 +1,8 @@
 # Product Roadmap
 
 > Last Updated: 2026-04-28
-> Version: 2.3.0
-> Status: Phases 1–4 shipped; Phase 5 partial; Hiring Manager persona shipped (Epic #73); in-app help, branding logos, candidate-list cleanup, and light/dark mode v1 shipped; further integrations tracked on GitHub
+> Version: 2.4.0
+> Status: Phases 1–4 shipped; Phase 5 partial (health endpoint now shipped); Hiring Manager persona shipped (Epic #73); in-app help, branding logos, candidate-list cleanup, and light/dark mode v1 shipped; REST API parity, API token system, per-tenant rate limiting, and MCP server (Epic #105) shipped; cross-platform `skillai-mcp` packaging (Epic #115) shipped; further integrations tracked on GitHub
 
 ## Phase 1: Foundation & Core MVP ✅ SHIPPED
 
@@ -94,7 +94,7 @@
 ### Must-Have Features
 
 - [x] Audit log — track logins, uploads, role changes, deletions _(implemented)_
-- [ ] Health endpoint — `/api/health` for Docker health check (issue [#35](https://github.com/olafkfreund/SkillAi/issues/35) — corrected 2026-04-27, route does not yet exist)
+- [x] Health endpoint — `/api/health` for Docker health check; returns `{status, db, uptime, timestamp}`, unauthenticated (issue [#35](https://github.com/olafkfreund/SkillAi/issues/35))
 - [x] Security hardening — CSP headers, rate limiting on auth, session guards, RLS audits
 - [ ] Admin panel — user invite shipped (`src/app/(dashboard)/dashboard/users/invite-form.tsx`); tenant/role management pending (Epic [#37](https://github.com/olafkfreund/SkillAi/issues/37))
 - [ ] File storage migration — switch to Garage (S3-compatible) for production
@@ -174,6 +174,17 @@ Features delivered mid-flight, not in the original v1.0.0 plan.
 ### Theme & Polish
 
 - [x] **Light/dark mode toggle (v1 — shell only)** — `next-themes` provider + CSS-var token system in `globals.css`; sidebar, dashboard outer wrapper, and login page converted; toggle lives in the sidebar above sign-out; system preference detected via `enableSystem`. Detail pages, forms, and modals remain dark-only and will migrate incrementally — full conversion tracked in Epic [#103](https://github.com/olafkfreund/SkillAi/issues/103).
+- [x] **Refined Material 3 / Linear-inspired palette** — surface tokens (`--color-bg-app`, `--color-bg-elevated`, `--color-fg`, `--color-fg-muted`, `--color-fg-subtle`, `--color-border`, `--color-accent`) plus 12 status-pill tokens; WCAG AA contrast verified per token in both modes; ~325 components migrated to token references.
+
+### MCP & Integrations (Epic #105)
+
+- [x] **REST API parity** — 36 new HTTP routes wrapping every server-action-only mutation; OpenAPI 3.1 spec served at `/api/openapi.json` (auth-required); `withApiAuth` middleware unifies bearer-token auth, scope, RLS, rate-limit, and audit
+- [x] **API token system** — new `api_tokens` table with argon2-hashed secrets via `@node-rs/argon2`; format `skl_<env>_<24-base62>`; scopes `read` / `write` / `admin` (with `admin > write > read` inclusion); UI at `/settings/api-tokens` to mint, view-once, and revoke
+- [x] **Per-tenant rate limiting** — sliding-window per-token, per-tenant, and per-write; configurable via `tenant_settings`; Postgres-backed; applied to both REST and MCP entry points
+- [x] **MCP server** — hosted at `/api/mcp` via streamable-HTTP transport; **48 tools** across 12 modules, **4 resources**, **3 prompts**; bearer-token auth; scope checks; write tools refuse to execute without `confirmed: true`; per-call audit log entry
+- [x] **Cross-platform packaging (Epic #115)** — standalone `skillai-mcp` stdio bridge for claude-desktop subprocess integration; reads `SKILLAI_URL` + `SKILLAI_TOKEN` from env; cross-platform via Bun-built single-file binaries; **Nix flake + NixOS module shipped**; `.deb` + `.rpm` packages via `nfpm`; Homebrew / AUR / Scoop staged but **deferred** (operator chose not to maintain external repos); release pipeline self-hosted at `.github/workflows/skillai-mcp-release.yml`
+- [x] **First MCP release — `skillai-mcp v0.1.0`** — 14 artefacts on GitHub Releases: 5 Bun-compiled binaries (linux x64, linux arm64, macos x64, macos arm64, windows x64) + 4 OS packages (.deb, .rpm, source tarball, Nix flake) + 5 SHA256 sidecars
+- [x] **Health endpoint** — `/api/health` returns `{status, db, uptime, timestamp}`; unauthenticated for Docker healthchecks; `db` reflects pool reachability
 
 ### Exports & PDFs
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,76 @@ The goal is not to replace an ATS. The goal is to give any recruiter or hiring m
 - Archives all candidates with scoring history so past candidates can be re-evaluated against future roles
 - Provides semantic search across the candidate archive using vector embeddings
 - Tracks recruitment agencies and their candidate submissions
-- Supports multiple users per tenant with role-based access (admin, recruiter, viewer)
+- Supports multiple users per tenant with role-based access (admin, hiring manager, recruiter, viewer)
 - Extracts skill and requirement tags from role descriptions for fast visual comparison
 - Exports candidate profiles, shortlists, and interview packs as PDFs
 - Supports Google Calendar and Microsoft Calendar integration for interview scheduling
+- Routes shortlists through a hiring manager approval flow with sanitised candidate views (no rates, margins, or internal notes)
+- Hosts an in-app help centre with persona-tagged articles surfaced to the right user
+- Supports agency and customer logo branding on lists, detail headers, and PDF exports
+- Ships with a light/dark theme toggle backed by a CSS-variable token system
+- Exposes a full REST API (36 routes) plus an MCP server so claude-desktop and other MCP clients can read and act on SkillAI data
+
+---
+
+## Architecture in three sentences
+
+SkillAI is a multi-tenant Next.js 16 web application backed by PostgreSQL 17 with pgvector, with row-level security enforced via the `app.tenant_id` session variable so cross-tenant reads are architecturally impossible. A REST + MCP API layer sits in the same Next.js process, sharing the same auth, scope, RLS, rate-limit, and audit primitives. The standalone `skillai-mcp` stdio bridge is the canonical way for claude-desktop to talk to a SkillAI instance — it is purely a transport adapter that forwards bearer-token-authenticated calls to `/api/mcp`.
+
+---
+
+## Connecting from claude-desktop and other MCP clients
+
+### Why an MCP server
+
+SkillAI is an internal tool deliberately scoped to one job: rank candidates fast. But recruiters increasingly want to compose their day around chat — "find me bench candidates who match this role, draft an introduction email for the top three, and schedule a screening call." Building email, scheduling, and shared-drive integrations into SkillAI would explode the scope and dilute the focus.
+
+The MCP server takes the opposite approach. It exposes SkillAI's data and actions to any MCP-aware client (claude-desktop is the primary target) so users can compose workflows by combining SkillAI with whichever other MCP servers they already use — Gmail, Calendar, Drive, Slack, anything. SkillAI stays focused on ranking. Orchestration of multi-tool workflows lives in the LLM where it belongs.
+
+### What it unlocks
+
+Three concrete workflows that are now one chat message each:
+
+- **Bench-to-role match.** "Find me available internal bench candidates who match the new platform engineering role at ACME Corp." The model calls `semantic_search_candidates`, filters by availability, and presents ranked matches inline.
+- **Compose introduction email with attachments.** "Draft an intro email to recruiter@example.com for Bob Smith — attach his CV and the interview pack." The model calls `compose_candidate_email_attachments` to fetch the assets from SkillAI, then hands off to the Gmail MCP server to compose the draft.
+- **Manager shortlist decisions.** "Approve Alice Doe and reject Bob Smith for the Senior Backend role with the note 'too junior for this band'." The model calls `approve_candidate` and `reject_candidate` — both are write-scoped tools and require `confirmed: true` so accidental approvals are not possible.
+
+### Install
+
+The bridge is published as a standalone `skillai-mcp` binary via [GitHub Releases](https://github.com/olafkfreund/SkillAi/releases). Pick the channel that matches your platform:
+
+| Platform | Install |
+|---|---|
+| NixOS / Nix | `nix profile install github:olafkfreund/SkillAi?dir=skillai-mcp` |
+| Linux (Debian/Ubuntu) | Download `skillai-mcp_<version>_amd64.deb` from Releases and `sudo dpkg -i` |
+| Linux (RHEL/Fedora) | Download `skillai-mcp-<version>.x86_64.rpm` from Releases and `sudo rpm -i` |
+| macOS / Linux / Windows | Download the matching pre-built binary from Releases and place on `$PATH` |
+
+`npm` distribution is staged behind `NPM_TOKEN` and not currently published to the public registry — use the binary or Nix paths.
+
+### Configure claude-desktop
+
+Add the following to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "skillai": {
+      "command": "skillai-mcp",
+      "env": {
+        "SKILLAI_URL": "https://your-skillai-instance.example.com",
+        "SKILLAI_TOKEN": "skl_prod_xxxxxxxxxxxxxxxxxxxxxxxx"
+      }
+    }
+  }
+}
+```
+
+### Token generation
+
+Tokens are minted in the SkillAI web UI at `/settings/api-tokens`. You choose a scope (`read`, `write`, or `admin`), give the token a name, and the secret is shown **once** — copy it into your client config immediately. Tokens are stored as argon2 hashes, never recoverable, and can be revoked at any time. Rate limits apply per-token and per-tenant.
+
+See [`skillai-mcp/README.md`](skillai-mcp/README.md) for the full tool / resource / prompt catalogue.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,7 +49,7 @@ This means it is architecturally impossible for application code to read data be
 
 Auth.js v5 with a credentials provider. On sign-in, the user's tenant ID and role are embedded in the JWT. The middleware reads the JWT on every request and forwards tenant ID, user ID, and role as HTTP headers to server components and server actions.
 
-Three roles exist: `admin`, `recruiter`, and `viewer`. Role checks use the `requireRole()` helper from `src/lib/auth/require-role.ts`.
+Four roles exist: `admin`, `recruiter`, `hiring_manager`, and `viewer`. Role checks use the `requireRole()` helper from `src/lib/auth/require-role.ts`. Roles are ordered by rank — `viewer` (0), `hiring_manager` (0.5), `recruiter` (1), `admin` (2). The `hiring_manager` rank deliberately sits between `viewer` and `recruiter` so existing `requireRole(_, 'recruiter')` guards continue to block managers without any call-site changes.
 
 ---
 
@@ -138,3 +138,92 @@ src/
 Next.js `after()` (from `next/server`) is used for all background work. This API runs a callback after the HTTP response is sent, with a guaranteed execution promise tracked by the runtime. It is the recommended approach for Next.js 15 and works in both development and production without an external queue.
 
 In development, hot reloads can interrupt `after()` tasks. The application detects and recovers from this automatically by marking stale packs as failed and allowing retry.
+
+---
+
+## MCP Integration Architecture
+
+claude-desktop and other MCP clients talk to SkillAI through a two-tier transport: a standalone stdio bridge (`skillai-mcp`) and an in-process HTTP endpoint (`/api/mcp`).
+
+```
+claude-desktop  <--stdio-->  skillai-mcp (bridge)  <--HTTPS-->  /api/mcp (in-process)  -->  withTenant()  -->  Postgres + RLS
+                                  |                                  |
+                                  |                                  +-- 48 tools / 4 resources / 3 prompts
+                                  |                                  +-- bearer-token auth + scope check
+                                  |                                  +-- per-token + per-tenant rate limit
+                                  |                                  +-- audit log per call
+                                  |                                  +-- write tools require `confirmed: true`
+                                  +-- transport adapter only -- no business logic
+```
+
+The bridge (`skillai-mcp/`) is a transport adapter: a small Node.js binary that reads `SKILLAI_URL` and `SKILLAI_TOKEN` from its environment, speaks MCP stdio to the client, and forwards every call as an HTTPS request to `/api/mcp`. It carries no business logic. All authorisation, scope enforcement, RLS scoping, rate limiting, audit logging, and the 48 tool implementations live in the Next.js app itself (`src/app/api/mcp/route.ts`, `src/lib/mcp/`). This means the same security stack protects MCP calls as protects the web UI and REST API — there is one set of policies, not three.
+
+The MCP endpoint uses the streamable-HTTP transport. Tools are scoped (`read` / `write` / `admin`, with `admin > write > read`) and write tools refuse to execute unless the caller passes `confirmed: true` in the arguments — this is how accidental destructive calls from chat are prevented.
+
+---
+
+## API Tokens & Rate Limiting
+
+A new `api_tokens` table stores tenant-scoped tokens with the following shape:
+
+| Column | Notes |
+|---|---|
+| `id` | UUID PK |
+| `tenant_id` | RLS-scoped |
+| `user_id` | The minting user; the token impersonates this identity |
+| `name` | Human-readable label |
+| `scope` | `read` / `write` / `admin` |
+| `secret_hash` | argon2 hash via `@node-rs/argon2` |
+| `prefix` | First 12 chars of the secret, plaintext, for identification |
+| `last_used_at` | Updated on every authenticated call |
+| `revoked_at` | Soft revoke; `withApiAuth` rejects revoked tokens |
+
+Token format is `skl_<env>_<24-base62>` where `<env>` is `prod` / `staging` / `dev`. The full secret is shown to the user once at mint time and never recoverable — argon2 hashes are one-way.
+
+Authentication runs through `withApiAuth` in `src/lib/api/auth-middleware.ts`. The middleware:
+
+1. Pulls the bearer token from the `Authorization` header
+2. Looks up the row by prefix, then verifies argon2 against `secret_hash`
+3. Confirms the token is not revoked
+4. Sets the tenant context via `withTenant()` so RLS applies for the rest of the request
+5. Enforces scope (`admin > write > read`)
+6. Updates `last_used_at`
+7. Records an audit-log entry
+
+Rate limiting is sliding-window, Postgres-backed, and applied at three layers: per-token, per-tenant, and per-write-operation. Limits are configurable in `tenant_settings`. See `src/lib/api/rate-limit.ts` and `src/lib/api/rate-limit-config.ts`.
+
+---
+
+## Hiring Manager Persona
+
+The `hiring_manager` role is the third user persona alongside `recruiter` and `viewer`. The role is supported by two new tables:
+
+| Table | Purpose |
+|---|---|
+| `role_managers` | Many-to-many: which managers are assigned to which roles. `is_primary` flag distinguishes the lead manager. Any-one-approves semantics in v1. |
+| `candidate_role_approvals` | One row per `(role × candidate × manager)`. Decision is `pending` / `approved` / `rejected` with optional comment. Shortlist state is derived (`pending` / `in_review` / `complete`) — not stored. |
+
+Manager-facing pages reuse the existing audience sanitisation pattern via `audience='manager'`. The `sanitiseForAudience()` helper strips rates, margins, agency information, and internal notes; only notes flagged `is_shareable=true` are exposed. Edit controls become read-only. The same pattern applies to the manager-facing PDF export and to MCP tools called by manager-scoped tokens.
+
+The audit trail gains four new actions: `shortlist.sent`, `candidate.approved_by_manager`, `candidate.rejected_by_manager`, and `role.manager_assigned`.
+
+---
+
+## Theme & Token System
+
+Light / dark mode is implemented via `next-themes` v1 with `enableSystem` for OS preference detection. The token model lives in `src/app/globals.css` as CSS variables, organised into two layers:
+
+- **Surface tokens** — `--color-bg-app`, `--color-bg-elevated`, `--color-fg`, `--color-fg-muted`, `--color-fg-subtle`, `--color-border`, `--color-accent`. Used by every dashboard surface.
+- **Status-pill tokens** — twelve dedicated tokens for status colours (new / shortlisted / interviewing / offered / hired / rejected, plus the four AI-pipeline states and two derived approval states). Each pill has its own background and foreground variable so contrast is correct in both modes.
+
+Each token has a `light` and `dark` value. Both have been verified against WCAG AA contrast thresholds. Approximately 325 components migrated from hard-coded Tailwind colour utilities to token references during the v1 rollout. Detail pages, modals, and forms are migrating incrementally — see Epic [#103](https://github.com/olafkfreund/SkillAi/issues/103) for tracking.
+
+The toggle component lives in `src/components/theme/theme-toggle.tsx` and is mounted in the sidebar above sign-out.
+
+---
+
+## Branding Logo Storage
+
+Agency and customer logos are stored on disk under `{tenantId}/logos/{uuid}.{ext}` within the configured uploads root. Helpers in `src/lib/branding/store.ts` expose two functions: `getLogoRelativePath()` (used for storage in DB columns and as the URL-route segment) and `getLogoAbsolutePath()` (used to read from disk). **The two must agree on the path layout.** A bug in PR #98 broke logo serving because the route handler reconstructed the path from `tenantId + filename` while the store wrote `tenantId + 'logos' + filename` — keep this symmetry intact when extending the path scheme.
+
+Accepted MIME types are PNG, JPEG, and WebP only. SVG is rejected because of the XSS surface on inline rendering. The size cap is 2 MB. Lists render at 32 px, detail headers at 64 px, PDFs at 32 px. The fallback when no logo is set is an initials avatar derived from the entity name.


### PR DESCRIPTION
## Summary

Brings the top-level documentation current with what shipped this session — with explicit emphasis on the MCP server (what it is, why it exists, and what workflows it unlocks).

## Files

| File | Δ | What |
|---|---|---|
| \`README.md\` | +68 | Extended "What It Does" with 5 new bullets; added 3-sentence architecture summary; new section **"Connecting from claude-desktop and other MCP clients"** with the why-MCP rationale + 3 example workflows + install matrix + claude-desktop JSON config + token-generation pointer; \`hiring_manager\` added to the roles list |
| \`docs/architecture.md\` | +91 | Auth section updated for 4 roles + rank explanation; 5 new sections at the end (MCP Integration Architecture with ASCII diagram, API Tokens & Rate Limiting, Hiring Manager Persona, Theme & Token System, Branding Logo Storage with the #98 path-bug retro) |
| \`.agent-os/product/roadmap.md\` | v2.3.0 → **v2.4.0** | Health endpoint flipped to checked; new Phase 6 "MCP & Integrations" subsection covering REST parity, token system, rate limiting, MCP server, cross-platform packaging, v0.1.0 release |

## Out of scope

- \`CLAUDE.md\` — already maintained
- \`skillai-mcp/README.md\` — comprehensive already
- \`docs/setup.md\` and \`docs/development.md\` — not in this round

## Why an MCP server (the README's new section)

> Recruiting teams increasingly want to compose their workflows from chat — *"email Bob's CV and interview pack to recruiter@x.com with a one-paragraph summary."* Rather than build email + scheduling + drive integrations into SkillAi, the MCP server exposes SkillAi's data and actions to MCP-aware clients (claude-desktop primarily). SkillAi stays focused on "rank candidates fast"; orchestration of multi-tool workflows lives in the LLM. Three concrete examples are documented in README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)