### PR TITLE
feat(gdpr): right-to-erasure UI + DSAR export (closes #75)

### DIFF
--- a/src/actions/gdpr.ts
+++ b/src/actions/gdpr.ts
@@ -1,0 +1,276 @@
+'use server'
+
+/**
+ * GDPR actions — admin-only operations for data subject rights compliance.
+ *
+ * Article 17 (Right to Erasure):
+ *   deleteCandidateForGdpr — hard-deletes a candidate and all associated data,
+ *   redacts audit log PII, and removes the CV file from disk.
+ */
+
+import { revalidatePath } from 'next/cache'
+import { eq, and } from 'drizzle-orm'
+import { z } from 'zod'
+import { withTenant } from '@/db'
+import {
+  candidates,
+  scores,
+  notes,
+  candidateEnrichments,
+  cvProfiles,
+  auditLogs,
+  sentEmails,
+  interviewPacks,
+  interviewQuestions,
+  codeChallenges,
+  interviewSlots,
+  interviewTranscripts,
+  transcriptAnalyses,
+  candidateRoleApprovals,
+} from '@/db/schema'
+import { getActionContext } from '@/lib/auth/action-context'
+import { requireRole } from '@/lib/auth/require-role'
+import { writeAuditLog } from '@/lib/audit'
+import { deleteCvFile } from '@/lib/cv/store'
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+const DeleteCandidateGdprSchema = z.object({
+  candidateId: z.string().uuid('candidateId must be a valid UUID'),
+  typedConfirmation: z.string().min(1, 'Confirmation name is required'),
+})
+
+export type DeleteCandidateGdprInput = z.infer<typeof DeleteCandidateGdprSchema>
+
+export type DeleteCandidateGdprResult =
+  | { ok: true }
+  | { ok: false; error: string }
+
+// ---------------------------------------------------------------------------
+// deleteCandidateForGdpr
+// ---------------------------------------------------------------------------
+
+/**
+ * Hard-deletes a candidate and all associated child data as required under
+ * GDPR Article 17 (Right to Erasure).
+ *
+ * - Requires admin role.
+ * - Requires the caller to type the candidate's full name as confirmation.
+ * - Deletes child rows in FK-safe dependency order inside a transaction.
+ * - Redacts (does NOT delete) existing audit_logs rows for this candidate so
+ *   the audit trail is preserved without PII.
+ * - Removes the CV file from disk after the transaction commits.
+ * - Writes a tombstone audit entry.
+ */
+export async function deleteCandidateForGdpr(
+  input: DeleteCandidateGdprInput
+): Promise<DeleteCandidateGdprResult> {
+  // 1. Validate input
+  const parsed = DeleteCandidateGdprSchema.safeParse(input)
+  if (!parsed.success) {
+    return {
+      ok: false,
+      error: parsed.error.issues[0]?.message ?? 'Invalid input',
+    }
+  }
+  const { candidateId, typedConfirmation } = parsed.data
+
+  // 2. Get action context (tenant + user)
+  const ctx = await getActionContext()
+  if (!ctx) {
+    return { ok: false, error: 'Unauthorized' }
+  }
+  const { tenantId, userRole } = ctx
+
+  // 3. Admin-only
+  try {
+    requireRole(userRole, 'admin')
+  } catch {
+    return { ok: false, error: 'Forbidden: admin role required' }
+  }
+
+  // 4. Load candidate to verify existence and get confirmation name + file paths
+  const candidateRow = await withTenant(tenantId, async (tx) => {
+    const [row] = await tx
+      .select({
+        id: candidates.id,
+        firstName: candidates.firstName,
+        lastName: candidates.lastName,
+        filePath: candidates.filePath,
+      })
+      .from(candidates)
+      .where(
+        and(
+          eq(candidates.id, candidateId),
+          eq(candidates.tenantId, tenantId)
+        )
+      )
+      .limit(1)
+    return row ?? null
+  })
+
+  if (!candidateRow) {
+    return { ok: false, error: 'Candidate not found' }
+  }
+
+  // 5. Verify typed confirmation — must match "<firstName> <lastName>" exactly (case-sensitive)
+  const expectedName = `${candidateRow.firstName} ${candidateRow.lastName}`
+  if (typedConfirmation !== expectedName) {
+    return { ok: false, error: 'Confirmation name does not match' }
+  }
+
+  // 6. Capture file path before deletion (used after tx commits)
+  const cvFilePath = candidateRow.filePath ?? null
+
+  // 7. Delete in dependency order inside a single transaction
+  await withTenant(tenantId, async (tx) => {
+    // ---- Grand-children of interview_packs ---------------------------------
+    // Collect pack IDs for this candidate first so we can cascade manually.
+    const packRows = await tx
+      .select({ id: interviewPacks.id })
+      .from(interviewPacks)
+      .where(eq(interviewPacks.candidateId, candidateId))
+
+    const packIds = packRows.map((p) => p.id)
+
+    if (packIds.length > 0) {
+      // interview_questions (FK → pack_id)
+      for (const pid of packIds) {
+        await tx
+          .delete(interviewQuestions)
+          .where(eq(interviewQuestions.packId, pid))
+      }
+      // code_challenges (FK → pack_id)
+      for (const pid of packIds) {
+        await tx
+          .delete(codeChallenges)
+          .where(eq(codeChallenges.packId, pid))
+      }
+    }
+
+    // ---- Grand-children of interview_transcripts ---------------------------
+    const transcriptRows = await tx
+      .select({ id: interviewTranscripts.id })
+      .from(interviewTranscripts)
+      .where(eq(interviewTranscripts.candidateId, candidateId))
+
+    const transcriptIds = transcriptRows.map((t) => t.id)
+
+    if (transcriptIds.length > 0) {
+      // transcript_analyses (FK → transcript_id)
+      for (const tid of transcriptIds) {
+        await tx
+          .delete(transcriptAnalyses)
+          .where(eq(transcriptAnalyses.transcriptId, tid))
+      }
+    }
+
+    // ---- Direct children of candidates (FK → candidate_id) -----------------
+
+    // sent_emails
+    await tx
+      .delete(sentEmails)
+      .where(eq(sentEmails.candidateId, candidateId))
+
+    // interview_transcripts (after their analyses are gone)
+    await tx
+      .delete(interviewTranscripts)
+      .where(eq(interviewTranscripts.candidateId, candidateId))
+
+    // interview_packs (after questions + challenges are gone)
+    await tx
+      .delete(interviewPacks)
+      .where(eq(interviewPacks.candidateId, candidateId))
+
+    // interview_slots
+    await tx
+      .delete(interviewSlots)
+      .where(eq(interviewSlots.candidateId, candidateId))
+
+    // candidate_role_approvals
+    await tx
+      .delete(candidateRoleApprovals)
+      .where(eq(candidateRoleApprovals.candidateId, candidateId))
+
+    // notes (only where candidate_id matches — notes may reference other entities)
+    await tx
+      .delete(notes)
+      .where(eq(notes.candidateId, candidateId))
+
+    // cv_profiles
+    await tx
+      .delete(cvProfiles)
+      .where(eq(cvProfiles.candidateId, candidateId))
+
+    // candidate_enrichments
+    await tx
+      .delete(candidateEnrichments)
+      .where(eq(candidateEnrichments.candidateId, candidateId))
+
+    // scores
+    await tx
+      .delete(scores)
+      .where(eq(scores.candidateId, candidateId))
+
+    // ---- Redact audit_log rows — RETAIN rows but strip PII -----------------
+    await tx
+      .update(auditLogs)
+      .set({
+        entityLabel: '[redacted-gdpr]',
+        metadata: {
+          redacted_gdpr: true,
+          redacted_at: new Date().toISOString(),
+        },
+      })
+      .where(
+        and(
+          eq(auditLogs.entityType, 'candidate'),
+          eq(auditLogs.entityId, candidateId)
+        )
+      )
+
+    // ---- Delete the candidate row itself (last) ----------------------------
+    await tx
+      .delete(candidates)
+      .where(
+        and(
+          eq(candidates.id, candidateId),
+          eq(candidates.tenantId, tenantId)
+        )
+      )
+  })
+
+  // 8. Delete CV file from disk after transaction commits (best-effort)
+  if (cvFilePath) {
+    try {
+      await deleteCvFile(cvFilePath)
+    } catch (err) {
+      // File deletion failure is non-fatal — the DB record is already gone.
+      // Log for ops visibility but do not fail the action.
+      console.error('[gdpr] Failed to delete CV file:', cvFilePath, err)
+    }
+  }
+
+  // TODO: if synechronCvData was stored as a separate file path, delete it here.
+  // Currently synechronCvData is stored as JSONB on the candidate row (which is
+  // now deleted), so no additional file deletion is needed.
+
+  // 9. Write tombstone audit entry
+  writeAuditLog(tenantId, {
+    action: 'candidate.deleted_gdpr',
+    entityType: 'candidate',
+    entityId: candidateId,
+    entityLabel: '[deleted-gdpr]',
+    metadata: {
+      deletedAt: new Date().toISOString(),
+      deletedBy: ctx.userId,
+    },
+  }).catch(() => {})
+
+  // 10. Invalidate candidate list cache
+  revalidatePath('/dashboard/candidates')
+
+  return { ok: true }
+}

--- a/src/app/(dashboard)/dashboard/candidates/[candidateId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/candidates/[candidateId]/page.tsx
@@ -38,6 +38,7 @@ import { SendEmailButton } from '@/components/candidates/send-email-button'
 import { EmailHistory } from '@/components/candidates/email-history'
 import { listEmailTemplates } from '@/actions/email-templates'
 import { listSentEmailsForCandidate } from '@/actions/emails'
+import { GdprActionsPanel } from '@/components/candidates/gdpr-actions-panel'
 
 type Props = { params: Promise<{ candidateId: string }>; searchParams: Promise<{ roleId?: string }> }
 
@@ -627,6 +628,14 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
 
       {/* Email history — hidden for hiring managers (EmailHistory handles null-guard internally) */}
       <EmailHistory sentEmails={sentEmailRows} audience={audience} />
+
+      {/* GDPR actions — admin only */}
+      {userRole === 'admin' && (
+        <GdprActionsPanel
+          candidateId={candidateId}
+          candidateName={`${candidate.firstName} ${candidate.lastName}`}
+        />
+      )}
     </div>
   )
 }

--- a/src/app/api/export/dsar/[candidateId]/route.ts
+++ b/src/app/api/export/dsar/[candidateId]/route.ts
@@ -1,0 +1,88 @@
+/**
+ * GET /api/export/dsar/[candidateId]
+ *
+ * Admin-only. Generates and streams a GDPR Article 15 Subject Access Request
+ * (DSAR) ZIP archive containing all data held for the given candidate.
+ *
+ * Authentication: Auth.js v5 session cookie (same as every other route).
+ * Authorization: admin role only — non-admins receive 403.
+ */
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { buildDsarZip } from '@/lib/gdpr/dsar-builder'
+import { writeAuditLog } from '@/lib/audit'
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ candidateId: string }> }
+) {
+  // 1. Auth
+  const session = await auth()
+  if (!session?.user?.tenantId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  // 2. Admin-only
+  if (session.user.role !== 'admin') {
+    return NextResponse.json(
+      { error: 'Forbidden: admin role required' },
+      { status: 403 }
+    )
+  }
+
+  const tenantId = session.user.tenantId
+  const { candidateId } = await params
+
+  try {
+    // 3. Build the ZIP stream
+    const archive = await buildDsarZip(candidateId, tenantId)
+
+    // 4. Non-fatal audit log (fire-and-forget)
+    writeAuditLog(tenantId, {
+      action: 'candidate.dsar_exported',
+      entityType: 'candidate',
+      entityId: candidateId,
+      entityLabel: candidateId,
+      metadata: {
+        exportedAt: new Date().toISOString(),
+        exportedBy: session.user.id,
+      },
+    }).catch(() => {})
+
+    // 5. Wrap archiver in a ReadableStream for the Response body
+    const date = new Date().toISOString().slice(0, 10)
+    const filename = `skillai-dsar-${candidateId}-${date}.zip`
+
+    const stream = new ReadableStream({
+      start(controller) {
+        archive.on('data', (chunk: Buffer) => {
+          controller.enqueue(chunk)
+        })
+        archive.on('end', () => {
+          controller.close()
+        })
+        archive.on('error', (err: Error) => {
+          console.error('[dsar] stream error:', err)
+          controller.error(err)
+        })
+      },
+    })
+
+    return new NextResponse(stream, {
+      headers: {
+        'Content-Type': 'application/zip',
+        'Content-Disposition': `attachment; filename="${filename}"`,
+      },
+    })
+  } catch (err) {
+    console.error('[dsar] export failed:', err instanceof Error ? err.stack : err)
+    return NextResponse.json(
+      {
+        error: 'DSAR export failed',
+        detail: err instanceof Error ? err.message : 'unknown',
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/src/components/candidates/gdpr-actions-panel.tsx
+++ b/src/components/candidates/gdpr-actions-panel.tsx
@@ -1,0 +1,234 @@
+'use client'
+
+/**
+ * GdprActionsPanel — Admin-only GDPR controls on the candidate detail page.
+ *
+ * - "Export all data (GDPR)" triggers a DSAR ZIP download (Article 15).
+ * - "Delete candidate (GDPR)" opens a confirmation modal and performs a
+ *   hard-delete when the admin types the candidate's full name (Article 17).
+ *
+ * Both actions are gated to admin role on the server; this component is only
+ * rendered by the page when session.user.role === 'admin'.
+ */
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { DownloadIcon, Trash2Icon, XIcon, ShieldIcon } from 'lucide-react'
+import { deleteCandidateForGdpr } from '@/actions/gdpr'
+
+type Props = {
+  candidateId: string
+  candidateName: string
+}
+
+export function GdprActionsPanel({ candidateId, candidateName }: Props) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+
+  // Modal state
+  const [modalOpen, setModalOpen] = useState(false)
+  const [typedName, setTypedName] = useState('')
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+  const [deleteSuccess, setDeleteSuccess] = useState(false)
+
+  const canDelete = typedName === candidateName
+
+  function openModal() {
+    setTypedName('')
+    setDeleteError(null)
+    setDeleteSuccess(false)
+    setModalOpen(true)
+  }
+
+  function closeModal() {
+    if (isPending) return // Don't allow closing while deletion is in-flight
+    setModalOpen(false)
+    setTypedName('')
+    setDeleteError(null)
+  }
+
+  function handleConfirmDelete() {
+    if (!canDelete || isPending) return
+
+    startTransition(async () => {
+      setDeleteError(null)
+      const result = await deleteCandidateForGdpr({ candidateId, typedConfirmation: typedName })
+      if (result.ok) {
+        setDeleteSuccess(true)
+        // Brief pause so the user can read the success message before navigation
+        setTimeout(() => {
+          router.push('/dashboard/candidates')
+        }, 1500)
+      } else {
+        setDeleteError(result.error)
+      }
+    })
+  }
+
+  return (
+    <>
+      {/* Panel card */}
+      <div className="bg-zinc-900 rounded-xl border border-red-900/50 p-6 mb-6">
+        <div className="flex items-center gap-2 mb-4">
+          <ShieldIcon className="h-4 w-4 text-red-400" />
+          <h2 className="font-semibold text-red-400">GDPR Actions (Admin only)</h2>
+        </div>
+
+        <p className="text-xs text-zinc-500 mb-5">
+          These actions are irreversible and are provided to fulfil data subject rights
+          under the General Data Protection Regulation (GDPR).
+        </p>
+
+        <div className="flex flex-wrap gap-3">
+          {/* Article 15 — DSAR export */}
+          <a
+            href={`/api/export/dsar/${candidateId}`}
+            download
+            className="inline-flex items-center gap-1.5 rounded-md border border-zinc-700
+                       bg-zinc-800 text-zinc-300 text-xs font-medium px-3 py-1.5
+                       hover:bg-zinc-700 transition-colors"
+          >
+            <DownloadIcon className="h-3.5 w-3.5" />
+            Export all data (GDPR)
+          </a>
+
+          {/* Article 17 — Right to erasure */}
+          <button
+            type="button"
+            onClick={openModal}
+            disabled={isPending}
+            className="inline-flex items-center gap-1.5 rounded-md border border-red-800
+                       bg-red-950 text-red-400 text-xs font-medium px-3 py-1.5
+                       hover:bg-red-900 transition-colors
+                       disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <Trash2Icon className="h-3.5 w-3.5" />
+            Delete candidate (GDPR)
+          </button>
+        </div>
+      </div>
+
+      {/* Confirmation modal */}
+      {modalOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+          {/* Backdrop */}
+          <div
+            className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+            onClick={closeModal}
+            aria-hidden="true"
+          />
+
+          {/* Dialog */}
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="gdpr-delete-title"
+            className="relative z-10 w-full max-w-md bg-zinc-900 border border-red-900
+                       rounded-xl shadow-2xl p-6"
+          >
+            {/* Header */}
+            <div className="flex items-start justify-between mb-4">
+              <h3
+                id="gdpr-delete-title"
+                className="font-semibold text-red-400 text-base"
+              >
+                Permanently delete candidate?
+              </h3>
+              <button
+                type="button"
+                onClick={closeModal}
+                disabled={isPending}
+                className="text-zinc-500 hover:text-zinc-300 ml-4 shrink-0 disabled:opacity-50"
+                aria-label="Close dialog"
+              >
+                <XIcon className="h-4 w-4" />
+              </button>
+            </div>
+
+            {/* Description */}
+            <div className="text-sm text-zinc-400 space-y-2 mb-5">
+              <p>
+                This will <strong className="text-zinc-200">permanently and irreversibly</strong> delete
+                this candidate and all associated data including scores, notes, interview packs,
+                transcripts, and the uploaded CV file.
+              </p>
+              <p>
+                Audit log entries will be{' '}
+                <strong className="text-zinc-200">retained</strong> but personal
+                identifiers will be redacted to comply with GDPR Article 17 while
+                preserving the system audit trail.
+              </p>
+              <p className="text-red-400 font-medium">This action cannot be undone.</p>
+            </div>
+
+            {/* Typed confirmation input */}
+            <div className="mb-5">
+              <label
+                htmlFor="gdpr-confirm-name"
+                className="block text-xs text-zinc-400 mb-1.5"
+              >
+                Type the candidate&apos;s full name to confirm:{' '}
+                <span className="font-semibold text-zinc-200">{candidateName}</span>
+              </label>
+              <input
+                id="gdpr-confirm-name"
+                type="text"
+                value={typedName}
+                onChange={(e) => {
+                  setTypedName(e.target.value)
+                  setDeleteError(null)
+                }}
+                disabled={isPending || deleteSuccess}
+                placeholder={candidateName}
+                autoComplete="off"
+                className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2
+                           text-sm text-zinc-100 placeholder-zinc-600
+                           focus:border-red-700 focus:outline-none focus:ring-1 focus:ring-red-700
+                           disabled:opacity-50"
+              />
+            </div>
+
+            {/* Error message */}
+            {deleteError && (
+              <p className="text-sm text-red-400 mb-4">{deleteError}</p>
+            )}
+
+            {/* Success message */}
+            {deleteSuccess && (
+              <p className="text-sm text-emerald-400 mb-4">
+                Candidate deleted. Redirecting...
+              </p>
+            )}
+
+            {/* Actions */}
+            <div className="flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={closeModal}
+                disabled={isPending}
+                className="rounded-md border border-zinc-700 bg-zinc-800 text-zinc-300
+                           text-sm font-medium px-4 py-2
+                           hover:bg-zinc-700 transition-colors
+                           disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleConfirmDelete}
+                disabled={!canDelete || isPending || deleteSuccess}
+                className="inline-flex items-center gap-1.5 rounded-md border border-red-700
+                           bg-red-900 text-red-200 text-sm font-medium px-4 py-2
+                           hover:bg-red-800 transition-colors
+                           disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                <Trash2Icon className="h-3.5 w-3.5" />
+                {isPending ? 'Deleting...' : 'Permanently delete'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -39,6 +39,8 @@ export type AuditAction =
   | 'candidate.email_sent'
   | 'email_template.created' | 'email_template.updated' | 'email_template.deleted'
   | 'settings.smtp_updated'
+  | 'candidate.deleted_gdpr'
+  | 'candidate.dsar_exported'
 
 type AuditEntry = {
   action: AuditAction

--- a/src/lib/gdpr/cover-letter.ts
+++ b/src/lib/gdpr/cover-letter.ts
@@ -1,0 +1,84 @@
+/**
+ * GDPR Article 15 DSAR cover letter generator.
+ *
+ * Pure function — no I/O, no DB access. Returns a plain ASCII README.txt
+ * body that is bundled into every DSAR ZIP export.
+ */
+
+type CoverLetterParams = {
+  candidateName: string
+  candidateId: string
+  exportDate: string   // ISO-8601 timestamp
+  files: string[]      // list of filenames that were included in the archive
+}
+
+export function getDsarCoverLetter({
+  candidateName,
+  candidateId,
+  exportDate,
+  files,
+}: CoverLetterParams): string {
+  const fileDescriptions: Record<string, string> = {
+    'candidate.json': 'Your candidate record including parsed CV text, contact details, status, agency assignment, and day rate',
+    'scores.json': 'All AI scoring runs against any role this candidate was evaluated for, including per-dimension scores and AI reasoning',
+    'notes.json': 'Recruiter notes associated with this candidate profile',
+    'enrichment.json': 'Web intelligence data gathered about this candidate (e.g. GitHub profile, public web mentions)',
+    'cv-profile.json': 'Structured CV profile extracted by AI from the uploaded CV document',
+    'audit-log.json': 'Audit trail of system events related to this candidate (uploads, status changes, logins that accessed this record)',
+    'sent-emails.json': 'Record of emails sent to this candidate via the platform',
+    'interview-packs.json': 'AI-generated interview question packs and code challenges created for this candidate',
+    'interview-slots.json': 'Interview scheduling slots booked for this candidate',
+    'interview-transcripts.json': 'Interview transcript files uploaded and any AI analysis results',
+    'approvals.json': 'Hiring manager approval decisions recorded for this candidate',
+    'synechron-cv.json': 'Structured CV data extracted in Synechron format',
+  }
+
+  // File index — one line per file included in the archive
+  const fileIndex = files
+    .filter((f) => f !== 'README.txt')
+    .map((f) => {
+      const desc = fileDescriptions[f] ?? 'Associated data file'
+      return `  - ${f}: ${desc}`
+    })
+    .join('\n')
+
+  return [
+    'GDPR Article 15 -- Right of Access -- Subject Access Request Export',
+    '====================================================================',
+    '',
+    'This archive was generated in response to a Subject Access Request (SAR) under',
+    'Article 15 of the General Data Protection Regulation (GDPR). It contains all',
+    'personal data held about the data subject in the SkillAI recruiting platform.',
+    '',
+    'DATA SUBJECT INFORMATION',
+    '------------------------',
+    `  Name       : ${candidateName}`,
+    `  Record ID  : ${candidateId}`,
+    `  Export date: ${exportDate}`,
+    '',
+    'FILES IN THIS ARCHIVE',
+    '---------------------',
+    fileIndex,
+    '',
+    'YOUR RIGHTS',
+    '-----------',
+    'Under GDPR you have the right to:',
+    '  - Rectification (Article 16): correct inaccurate personal data',
+    '  - Erasure (Article 17): request deletion of your personal data',
+    '  - Restriction of processing (Article 18)',
+    '  - Data portability (Article 20)',
+    '  - Object to processing (Article 21)',
+    '',
+    'CONTACT',
+    '-------',
+    'For questions about this export, to exercise any of the above rights, or to',
+    'raise a concern about how your data is processed, please contact:',
+    '  privacy@your-organisation.example',
+    '',
+    'You also have the right to lodge a complaint with your national data protection',
+    'supervisory authority.',
+    '',
+    '====================================================================',
+    'End of cover letter.',
+  ].join('\n')
+}

--- a/src/lib/gdpr/dsar-builder.ts
+++ b/src/lib/gdpr/dsar-builder.ts
@@ -1,0 +1,303 @@
+/**
+ * GDPR Article 15 DSAR ZIP builder.
+ *
+ * Gathers all data held for a candidate and streams it as a ZIP archive.
+ * The caller (API route) receives the archiver stream and pipes it to the
+ * Response body.
+ *
+ * No PII is modified here — this is a read-only export.
+ */
+
+import path from 'path'
+import fs from 'fs'
+import archiver from 'archiver'
+import type { Archiver } from 'archiver'
+import { eq } from 'drizzle-orm'
+import { withTenant } from '@/db'
+import {
+  candidates,
+  scores,
+  notes,
+  candidateEnrichments,
+  cvProfiles,
+  auditLogs,
+  sentEmails,
+  interviewPacks,
+  interviewQuestions,
+  codeChallenges,
+  interviewSlots,
+  interviewTranscripts,
+  transcriptAnalyses,
+  candidateRoleApprovals,
+} from '@/db/schema'
+import { getDsarCoverLetter } from './cover-letter'
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Resolve a DB-stored `/uploads/...` path to an absolute filesystem path. */
+function resolveUploadPath(filePath: string): string {
+  const relative = filePath.startsWith('/') ? filePath.slice(1) : filePath
+  return path.join(process.cwd(), relative)
+}
+
+/** Extract the file extension from a DB filePath, e.g. ".pdf". */
+function extensionOf(filePath: string): string {
+  return path.extname(filePath).toLowerCase() || '.bin'
+}
+
+// ---------------------------------------------------------------------------
+// buildDsarZip
+// ---------------------------------------------------------------------------
+
+/**
+ * Assembles a ZIP containing all data held for a candidate.
+ *
+ * Returns the archiver stream. The caller MUST consume the stream promptly;
+ * `archive.finalize()` is called internally before this function returns.
+ */
+export async function buildDsarZip(
+  candidateId: string,
+  tenantId: string
+): Promise<Archiver> {
+  const archive = archiver('zip', { zlib: { level: 9 } })
+
+  // Track errors — bubble them so the API route can return a 500
+  archive.on('warning', (err) => {
+    if (err.code !== 'ENOENT') console.error('[dsar] archiver warning:', err)
+  })
+
+  // Gather all data inside a single RLS-scoped transaction
+  const data = await withTenant(tenantId, async (tx) => {
+    // 1. Candidate row
+    const [candidate] = await tx
+      .select()
+      .from(candidates)
+      .where(eq(candidates.id, candidateId))
+      .limit(1)
+
+    if (!candidate) return null
+
+    // 2. All remaining queries in parallel — they all depend only on candidateId
+    const [
+      scoreRows,
+      noteRows,
+      enrichmentRows,
+      cvProfileRows,
+      auditRows,
+      sentEmailRows,
+      interviewSlotRows,
+      approvalRows,
+    ] = await Promise.all([
+      tx.select().from(scores).where(eq(scores.candidateId, candidateId)),
+      tx.select().from(notes).where(eq(notes.candidateId, candidateId)),
+      tx.select().from(candidateEnrichments).where(eq(candidateEnrichments.candidateId, candidateId)),
+      tx.select().from(cvProfiles).where(eq(cvProfiles.candidateId, candidateId)),
+      tx.select().from(auditLogs).where(eq(auditLogs.entityId, candidateId)),
+      tx.select().from(sentEmails).where(eq(sentEmails.candidateId, candidateId)),
+      tx.select().from(interviewSlots).where(eq(interviewSlots.candidateId, candidateId)),
+      tx.select().from(candidateRoleApprovals).where(eq(candidateRoleApprovals.candidateId, candidateId)),
+    ])
+
+    // 3. Interview packs + child tables (questions, challenges, transcripts)
+    const packRows = await tx
+      .select()
+      .from(interviewPacks)
+      .where(eq(interviewPacks.candidateId, candidateId))
+
+    const packIds = packRows.map((p) => p.id)
+
+    const [questionRows, challengeRows, transcriptRows] = await Promise.all([
+      packIds.length > 0
+        ? tx.select().from(interviewQuestions).where(
+            // Drizzle inArray requires at least one value
+            eq(interviewQuestions.packId, packIds[0]!)
+          ).then(async (first) => {
+            // Fetch questions for remaining packs if any
+            if (packIds.length === 1) return first
+            const rest = await Promise.all(
+              packIds.slice(1).map((pid) =>
+                tx.select().from(interviewQuestions).where(eq(interviewQuestions.packId, pid))
+              )
+            )
+            return [...first, ...rest.flat()]
+          })
+        : Promise.resolve([]),
+      packIds.length > 0
+        ? tx.select().from(codeChallenges).where(eq(codeChallenges.packId, packIds[0]!)).then(async (first) => {
+            if (packIds.length === 1) return first
+            const rest = await Promise.all(
+              packIds.slice(1).map((pid) =>
+                tx.select().from(codeChallenges).where(eq(codeChallenges.packId, pid))
+              )
+            )
+            return [...first, ...rest.flat()]
+          })
+        : Promise.resolve([]),
+      tx.select().from(interviewTranscripts).where(eq(interviewTranscripts.candidateId, candidateId)),
+    ])
+
+    // 4. Transcript analyses (child of transcripts)
+    const transcriptIds = transcriptRows.map((t) => t.id)
+    const analysisRows = await (transcriptIds.length > 0
+      ? Promise.all(
+          transcriptIds.map((tid) =>
+            tx.select().from(transcriptAnalyses).where(eq(transcriptAnalyses.transcriptId, tid))
+          )
+        ).then((nested) => nested.flat())
+      : Promise.resolve([]))
+
+    return {
+      candidate,
+      scoreRows,
+      noteRows,
+      enrichmentRows,
+      cvProfileRows,
+      auditRows,
+      sentEmailRows,
+      interviewSlotRows,
+      approvalRows,
+      packRows,
+      questionRows,
+      challengeRows,
+      transcriptRows,
+      analysisRows,
+    }
+  })
+
+  if (!data) {
+    // Return an empty archive with a note rather than throwing — the API
+    // route will receive an empty ZIP which it can handle gracefully.
+    archive.append('Candidate not found or access denied.', { name: 'ERROR.txt' })
+    archive.finalize()
+    return archive
+  }
+
+  const {
+    candidate,
+    scoreRows,
+    noteRows,
+    enrichmentRows,
+    cvProfileRows,
+    auditRows,
+    sentEmailRows,
+    interviewSlotRows,
+    approvalRows,
+    packRows,
+    questionRows,
+    challengeRows,
+    transcriptRows,
+    analysisRows,
+  } = data
+
+  const includedFiles: string[] = []
+
+  // ---------------------------------------------------------------------------
+  // Helper: append a JSON entry
+  // ---------------------------------------------------------------------------
+  function appendJson(name: string, payload: unknown) {
+    archive.append(JSON.stringify(payload, null, 2), { name })
+    includedFiles.push(name)
+  }
+
+  // 1. candidate.json
+  appendJson('candidate.json', candidate)
+
+  // 2. scores.json
+  if (scoreRows.length > 0) {
+    appendJson('scores.json', scoreRows)
+  }
+
+  // 3. notes.json
+  if (noteRows.length > 0) {
+    appendJson('notes.json', noteRows)
+  }
+
+  // 4. enrichment.json
+  if (enrichmentRows.length > 0) {
+    appendJson('enrichment.json', enrichmentRows[0])
+  }
+
+  // 5. cv-profile.json
+  if (cvProfileRows.length > 0) {
+    appendJson('cv-profile.json', cvProfileRows[0])
+  }
+
+  // 6. audit-log.json
+  if (auditRows.length > 0) {
+    appendJson('audit-log.json', auditRows)
+  }
+
+  // 7. sent-emails.json
+  if (sentEmailRows.length > 0) {
+    appendJson('sent-emails.json', sentEmailRows)
+  }
+
+  // 8. interview-packs.json (combined: packs + questions + challenges)
+  if (packRows.length > 0) {
+    const combined = packRows.map((p) => ({
+      ...p,
+      questions: questionRows.filter((q) => q.packId === p.id),
+      codeChallenge: challengeRows.find((c) => c.packId === p.id) ?? null,
+    }))
+    appendJson('interview-packs.json', combined)
+  }
+
+  // 9. interview-slots.json
+  if (interviewSlotRows.length > 0) {
+    appendJson('interview-slots.json', interviewSlotRows)
+  }
+
+  // 10. interview-transcripts.json (combined: transcripts + analyses)
+  if (transcriptRows.length > 0) {
+    const combined = transcriptRows.map((t) => ({
+      ...t,
+      analysis: analysisRows.find((a) => a.transcriptId === t.id) ?? null,
+    }))
+    appendJson('interview-transcripts.json', combined)
+  }
+
+  // 11. approvals.json
+  if (approvalRows.length > 0) {
+    appendJson('approvals.json', approvalRows)
+  }
+
+  // 12. Synechron CV — stored as JSONB on the candidate row
+  if (candidate.synechronCvData) {
+    appendJson('synechron-cv.json', candidate.synechronCvData)
+    includedFiles.push('synechron-cv.json')
+  }
+
+  // 13. CV file — read from disk if path is set
+  if (candidate.filePath) {
+    const absPath = resolveUploadPath(candidate.filePath)
+    const ext = extensionOf(candidate.filePath)
+    const cvFileName = `cv${ext}`
+
+    try {
+      if (fs.existsSync(absPath)) {
+        archive.file(absPath, { name: cvFileName })
+        includedFiles.push(cvFileName)
+      }
+    } catch {
+      // CV file unreadable — omit from archive, do not fail the export
+    }
+  }
+
+  // 14. README.txt cover letter
+  const exportDate = new Date().toISOString()
+  const candidateName = `${candidate.firstName} ${candidate.lastName}`.trim()
+  const coverLetter = getDsarCoverLetter({
+    candidateName,
+    candidateId,
+    exportDate,
+    files: [...includedFiles, 'README.txt'],
+  })
+  archive.append(coverLetter, { name: 'README.txt' })
+
+  // Finalize — must be called after all entries are queued
+  archive.finalize()
+
+  return archive
+}

--- a/tests/unit/actions/gdpr.test.ts
+++ b/tests/unit/actions/gdpr.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Unit tests for src/actions/gdpr.ts — deleteCandidateForGdpr
+ *
+ * Mocks:
+ *   - @/db (withTenant) — intercepts all DB calls
+ *   - @/lib/auth/action-context (getActionContext) — provides synthetic context
+ *   - @/lib/audit (writeAuditLog) — spied to verify tombstone write
+ *   - @/lib/cv/store (deleteCvFile) — spied to verify file deletion
+ *   - next/cache (revalidatePath) — silenced
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TENANT_ID = 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa'
+const CANDIDATE_ID = 'bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb'
+const USER_ID = 'cccccccc-cccc-4ccc-accc-cccccccccccc'
+
+const CANDIDATE_ROW = {
+  id: CANDIDATE_ID,
+  tenantId: TENANT_ID,
+  firstName: 'Jane',
+  lastName: 'Doe',
+  filePath: '/uploads/tenant1/some-cv.pdf',
+}
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// DB mocks — we capture individual operations so we can assert call order/args
+const mockDeleteChain = { where: vi.fn().mockResolvedValue(undefined) }
+const mockUpdateChain = { set: vi.fn() }
+const mockSetChain = { where: vi.fn().mockResolvedValue(undefined) }
+mockUpdateChain.set.mockReturnValue(mockSetChain)
+
+/**
+ * makeSelectChain — returns a Drizzle-compatible query builder mock.
+ *
+ * The chain supports:
+ *   tx.select().from(t).where(w).limit(n) → Promise<rows>
+ *   await tx.select().from(t).where(w)    → rows  (via PromiseLike.then)
+ */
+function makeSelectChain(rows: unknown[]) {
+  const chain: Record<string, unknown> = {}
+  // Make the chain itself a PromiseLike so direct `await` resolves to rows
+  chain.then = (
+    resolve: (v: unknown) => unknown,
+    reject?: (e: unknown) => unknown
+  ) => Promise.resolve(rows).then(resolve, reject)
+  chain.catch = (reject: (e: unknown) => unknown) =>
+    Promise.resolve(rows).catch(reject)
+  chain.from = vi.fn(() => chain)
+  chain.where = vi.fn(() => chain)
+  chain.limit = vi.fn(() => Promise.resolve(rows))
+  return chain
+}
+
+let selectCallCount = 0
+const mockTx = {
+  select: vi.fn(() => {
+    selectCallCount++
+    // First select call: existence check → returns the candidate row
+    if (selectCallCount === 1) return makeSelectChain([CANDIDATE_ROW])
+    // Subsequent selects (packs, transcripts): return empty arrays so no child
+    // deletes are attempted
+    return makeSelectChain([])
+  }),
+  delete: vi.fn(() => mockDeleteChain),
+  update: vi.fn(() => mockUpdateChain),
+}
+
+vi.mock('@/db', () => ({
+  withTenant: vi.fn(async (_tenantId: string, fn: (tx: unknown) => Promise<unknown>) => fn(mockTx)),
+}))
+
+vi.mock('@/db/schema', () => ({
+  candidates: {},
+  scores: {},
+  notes: {},
+  candidateEnrichments: {},
+  cvProfiles: {},
+  auditLogs: {},
+  sentEmails: {},
+  interviewPacks: {},
+  interviewQuestions: {},
+  codeChallenges: {},
+  interviewSlots: {},
+  interviewTranscripts: {},
+  transcriptAnalyses: {},
+  candidateRoleApprovals: {},
+}))
+
+// Drizzle eq/and — just pass through for our simple assertions
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn(() => ({ type: 'eq' })),
+  and: vi.fn((...args: unknown[]) => ({ type: 'and', args })),
+}))
+
+const mockGetActionContext = vi.fn()
+vi.mock('@/lib/auth/action-context', () => ({
+  getActionContext: mockGetActionContext,
+}))
+
+const mockWriteAuditLog = vi.fn().mockResolvedValue(undefined)
+vi.mock('@/lib/audit', () => ({
+  writeAuditLog: mockWriteAuditLog,
+}))
+
+const mockDeleteCvFile = vi.fn().mockResolvedValue(undefined)
+vi.mock('@/lib/cv/store', () => ({
+  deleteCvFile: mockDeleteCvFile,
+}))
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function adminContext() {
+  return { tenantId: TENANT_ID, userId: USER_ID, userRole: 'admin' as const }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('deleteCandidateForGdpr', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    selectCallCount = 0
+
+    // Re-wire delete/update chains after clearAllMocks() resets them
+    mockDeleteChain.where.mockResolvedValue(undefined)
+    mockUpdateChain.set.mockReturnValue(mockSetChain)
+    mockSetChain.where.mockResolvedValue(undefined)
+
+    // Default: admin context
+    mockGetActionContext.mockResolvedValue(adminContext())
+
+    // Rebuild the select mock with a fresh counter closure
+    let localCount = 0
+    mockTx.select = vi.fn(() => {
+      localCount++
+      if (localCount === 1) return makeSelectChain([CANDIDATE_ROW])
+      return makeSelectChain([])
+    })
+  })
+
+  // ── Authorization checks ──────────────────────────────────────────────────
+
+  it('returns error when no action context (unauthenticated)', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { deleteCandidateForGdpr } = await import('@/actions/gdpr')
+
+    const result = await deleteCandidateForGdpr({
+      candidateId: CANDIDATE_ID,
+      typedConfirmation: 'Jane Doe',
+    })
+
+    expect(result.ok).toBe(false)
+    expect((result as { ok: false; error: string }).error).toMatch(/unauthorized/i)
+  })
+
+  it('returns error when role is recruiter (not admin)', async () => {
+    mockGetActionContext.mockResolvedValue({
+      tenantId: TENANT_ID,
+      userId: USER_ID,
+      userRole: 'recruiter' as const,
+    })
+    const { deleteCandidateForGdpr } = await import('@/actions/gdpr')
+
+    const result = await deleteCandidateForGdpr({
+      candidateId: CANDIDATE_ID,
+      typedConfirmation: 'Jane Doe',
+    })
+
+    expect(result.ok).toBe(false)
+    expect((result as { ok: false; error: string }).error).toMatch(/forbidden/i)
+  })
+
+  it('returns error when role is viewer (not admin)', async () => {
+    mockGetActionContext.mockResolvedValue({
+      tenantId: TENANT_ID,
+      userId: USER_ID,
+      userRole: 'viewer' as const,
+    })
+    const { deleteCandidateForGdpr } = await import('@/actions/gdpr')
+
+    const result = await deleteCandidateForGdpr({
+      candidateId: CANDIDATE_ID,
+      typedConfirmation: 'Jane Doe',
+    })
+
+    expect(result.ok).toBe(false)
+    expect((result as { ok: false; error: string }).error).toMatch(/forbidden/i)
+  })
+
+  // ── Input validation ──────────────────────────────────────────────────────
+
+  it('returns error when candidateId is not a valid UUID', async () => {
+    const { deleteCandidateForGdpr } = await import('@/actions/gdpr')
+
+    const result = await deleteCandidateForGdpr({
+      candidateId: 'not-a-uuid',
+      typedConfirmation: 'Jane Doe',
+    })
+
+    expect(result.ok).toBe(false)
+    expect((result as { ok: false; error: string }).error).toContain('UUID')
+  })
+
+  it('returns error when typedConfirmation is empty', async () => {
+    const { deleteCandidateForGdpr } = await import('@/actions/gdpr')
+
+    const result = await deleteCandidateForGdpr({
+      candidateId: CANDIDATE_ID,
+      typedConfirmation: '',
+    })
+
+    expect(result.ok).toBe(false)
+  })
+
+  // ── Confirmation name mismatch ────────────────────────────────────────────
+
+  it('returns error when typed name does not match candidate name', async () => {
+    const { deleteCandidateForGdpr } = await import('@/actions/gdpr')
+
+    const result = await deleteCandidateForGdpr({
+      candidateId: CANDIDATE_ID,
+      typedConfirmation: 'Wrong Name',
+    })
+
+    expect(result.ok).toBe(false)
+    expect((result as { ok: false; error: string }).error).toMatch(/confirmation name does not match/i)
+  })
+
+  it('returns error when typed name has wrong case (case-sensitive)', async () => {
+    const { deleteCandidateForGdpr } = await import('@/actions/gdpr')
+
+    const result = await deleteCandidateForGdpr({
+      candidateId: CANDIDATE_ID,
+      typedConfirmation: 'jane doe', // lowercase
+    })
+
+    expect(result.ok).toBe(false)
+    expect((result as { ok: false; error: string }).error).toMatch(/confirmation name does not match/i)
+  })
+
+  // ── Happy path ────────────────────────────────────────────────────────────
+
+  it('succeeds when admin provides the exact candidate name', async () => {
+    const { deleteCandidateForGdpr } = await import('@/actions/gdpr')
+
+    const result = await deleteCandidateForGdpr({
+      candidateId: CANDIDATE_ID,
+      typedConfirmation: 'Jane Doe',
+    })
+
+    expect(result.ok).toBe(true)
+  })
+
+  it('calls tx.delete for candidates (last delete in chain)', async () => {
+    const { deleteCandidateForGdpr } = await import('@/actions/gdpr')
+
+    await deleteCandidateForGdpr({
+      candidateId: CANDIDATE_ID,
+      typedConfirmation: 'Jane Doe',
+    })
+
+    // tx.delete must have been called at least once (for candidates row)
+    expect(mockTx.delete).toHaveBeenCalled()
+  })
+
+  it('calls tx.update(auditLogs) with redaction values', async () => {
+    const { deleteCandidateForGdpr } = await import('@/actions/gdpr')
+
+    await deleteCandidateForGdpr({
+      candidateId: CANDIDATE_ID,
+      typedConfirmation: 'Jane Doe',
+    })
+
+    // tx.update should have been called with auditLogs-shaped table
+    expect(mockTx.update).toHaveBeenCalled()
+
+    // mockUpdateChain.set should have been called with redaction payload
+    const setCall = mockUpdateChain.set.mock.calls[0]?.[0] as Record<string, unknown> | undefined
+    expect(setCall).toBeDefined()
+    expect(setCall?.entityLabel).toBe('[redacted-gdpr]')
+    expect((setCall?.metadata as Record<string, unknown>)?.redacted_gdpr).toBe(true)
+  })
+
+  it('calls deleteCvFile with the candidate filePath', async () => {
+    const { deleteCandidateForGdpr } = await import('@/actions/gdpr')
+
+    await deleteCandidateForGdpr({
+      candidateId: CANDIDATE_ID,
+      typedConfirmation: 'Jane Doe',
+    })
+
+    expect(mockDeleteCvFile).toHaveBeenCalledWith(CANDIDATE_ROW.filePath)
+  })
+
+  it('writes a tombstone audit log entry with correct action', async () => {
+    const { deleteCandidateForGdpr } = await import('@/actions/gdpr')
+
+    await deleteCandidateForGdpr({
+      candidateId: CANDIDATE_ID,
+      typedConfirmation: 'Jane Doe',
+    })
+
+    // writeAuditLog is fire-and-forget (.catch()), so it may be async;
+    // we wait a tick to allow the promise to schedule
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(mockWriteAuditLog).toHaveBeenCalledWith(
+      TENANT_ID,
+      expect.objectContaining({
+        action: 'candidate.deleted_gdpr',
+        entityType: 'candidate',
+        entityId: CANDIDATE_ID,
+        entityLabel: '[deleted-gdpr]',
+      })
+    )
+  })
+
+  it('does not call deleteCvFile when candidate has no filePath', async () => {
+    // Override select to return a candidate with no filePath
+    let noFileCount = 0
+    mockTx.select = vi.fn(() => {
+      noFileCount++
+      if (noFileCount === 1) {
+        return makeSelectChain([{ ...CANDIDATE_ROW, filePath: null }])
+      }
+      return makeSelectChain([])
+    })
+
+    const { deleteCandidateForGdpr } = await import('@/actions/gdpr')
+
+    await deleteCandidateForGdpr({
+      candidateId: CANDIDATE_ID,
+      typedConfirmation: 'Jane Doe',
+    })
+
+    expect(mockDeleteCvFile).not.toHaveBeenCalled()
+  })
+
+  it('returns error when candidate is not found', async () => {
+    // Override select so the candidate query returns empty
+    mockTx.select = vi.fn(() => makeSelectChain([]))
+
+    const { deleteCandidateForGdpr } = await import('@/actions/gdpr')
+
+    const result = await deleteCandidateForGdpr({
+      candidateId: CANDIDATE_ID,
+      typedConfirmation: 'Jane Doe',
+    })
+
+    expect(result.ok).toBe(false)
+    expect((result as { ok: false; error: string }).error).toMatch(/not found/i)
+  })
+})

--- a/tests/unit/lib/gdpr/dsar-builder.test.ts
+++ b/tests/unit/lib/gdpr/dsar-builder.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Unit tests for src/lib/gdpr/dsar-builder.ts
+ *
+ * Strategy:
+ *   - Mock @/db (withTenant) to return synthetic fixture data
+ *   - Use the real `archiver` module so stream/zip behaviour is verified
+ *   - Collect the archive stream into a Buffer to inspect zip entry names
+ *   - Test the cover-letter module independently (not mocked in that suite)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Mock } from 'vitest'
+import { Readable } from 'stream'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CANDIDATE_ID = 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa'
+const TENANT_ID = 'bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb'
+
+const mockCandidate = {
+  id: CANDIDATE_ID,
+  tenantId: TENANT_ID,
+  firstName: 'Jane',
+  lastName: 'Doe',
+  email: 'jane.doe@example.com',
+  phone: null,
+  cvText: 'CV text here',
+  cvTextFormatted: null,
+  filePath: null,
+  fileType: 'pdf',
+  status: 'new',
+  synechronCvData: null,
+  synechronCandidateId: null,
+  createdAt: new Date('2025-01-01'),
+}
+
+// ---------------------------------------------------------------------------
+// DB layer mock
+//
+// Drizzle queries are awaitable builders (PromiseLike). The select chain ends
+// either with .limit(n) OR is awaited directly (without .limit). We need
+// both patterns to resolve to an array.
+//
+// Pattern: the chain object is both chainable AND a Promise (via .then).
+// ---------------------------------------------------------------------------
+
+let mockTx: Record<string, Mock>
+
+function makeChain(rows: unknown[]): Record<string, unknown> {
+  const chain: Record<string, unknown> = {}
+  // Make the chain a PromiseLike so `await chain` yields `rows`
+  chain.then = (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
+    Promise.resolve(rows).then(resolve, reject)
+  chain.catch = (reject: (e: unknown) => unknown) => Promise.resolve(rows).catch(reject)
+  chain.from = vi.fn(() => chain)
+  chain.where = vi.fn(() => chain)
+  chain.limit = vi.fn(() => Promise.resolve(rows))
+  return chain
+}
+
+vi.mock('@/db', () => ({
+  withTenant: vi.fn(async (_tenantId: string, fn: (tx: unknown) => Promise<unknown>) => fn(mockTx)),
+}))
+
+vi.mock('@/db/schema', () => ({
+  candidates: {},
+  scores: {},
+  notes: {},
+  candidateEnrichments: {},
+  cvProfiles: {},
+  auditLogs: {},
+  sentEmails: {},
+  interviewPacks: {},
+  interviewQuestions: {},
+  codeChallenges: {},
+  interviewSlots: {},
+  interviewTranscripts: {},
+  transcriptAnalyses: {},
+  candidateRoleApprovals: {},
+}))
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn(() => ({ type: 'eq' })),
+  and: vi.fn((...args: unknown[]) => ({ type: 'and', args })),
+}))
+
+// Mock cover-letter so the README content is deterministic
+vi.mock('@/lib/gdpr/cover-letter', () => ({
+  getDsarCoverLetter: vi.fn(() => 'GDPR Article 15 -- Right of Access -- Subject Access Request Export\nREADME cover letter content'),
+}))
+
+// ---------------------------------------------------------------------------
+// Test helper: collect a Readable stream into a Buffer
+// ---------------------------------------------------------------------------
+
+async function collectStream(readable: Readable | NodeJS.ReadableStream): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = []
+    ;(readable as Readable).on('data', (chunk: Buffer) => chunks.push(chunk))
+    ;(readable as Readable).on('end', () => resolve(Buffer.concat(chunks)))
+    ;(readable as Readable).on('error', reject)
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('buildDsarZip', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    let selectCallCount = 0
+
+    mockTx = {
+      select: vi.fn(() => {
+        selectCallCount++
+        // Call 1: candidate lookup → returns candidate row
+        if (selectCallCount === 1) return makeChain([mockCandidate])
+        // All other selects (scores, notes, enrichments, cvProfiles, auditLogs,
+        // sentEmails, interviewSlots, approvals, interviewPacks, transcripts) → []
+        return makeChain([])
+      }),
+    }
+
+    selectCallCount = 0
+  })
+
+  it('returns a readable stream', async () => {
+    const { buildDsarZip } = await import('@/lib/gdpr/dsar-builder')
+    const archive = await buildDsarZip(CANDIDATE_ID, TENANT_ID)
+    expect(archive).toBeDefined()
+    expect(typeof archive.pipe).toBe('function')
+  })
+
+  it('stream produces a non-empty buffer with ZIP magic bytes', async () => {
+    const { buildDsarZip } = await import('@/lib/gdpr/dsar-builder')
+    const archive = await buildDsarZip(CANDIDATE_ID, TENANT_ID)
+    const buffer = await collectStream(archive)
+
+    // ZIP local file header magic: PK\x03\x04
+    expect(buffer.length).toBeGreaterThan(4)
+    expect(buffer[0]).toBe(0x50) // 'P'
+    expect(buffer[1]).toBe(0x4b) // 'K'
+  })
+
+  it('ZIP contains candidate.json', async () => {
+    const { buildDsarZip } = await import('@/lib/gdpr/dsar-builder')
+    const archive = await buildDsarZip(CANDIDATE_ID, TENANT_ID)
+    const buffer = await collectStream(archive)
+
+    // Scan the raw ZIP buffer for the filename bytes
+    expect(buffer.includes(Buffer.from('candidate.json'))).toBe(true)
+  })
+
+  it('ZIP contains README.txt', async () => {
+    const { buildDsarZip } = await import('@/lib/gdpr/dsar-builder')
+    const archive = await buildDsarZip(CANDIDATE_ID, TENANT_ID)
+    const buffer = await collectStream(archive)
+
+    expect(buffer.includes(Buffer.from('README.txt'))).toBe(true)
+  })
+
+  it('calls getDsarCoverLetter with correct candidate details', async () => {
+    // The cover-letter module is mocked. Verify the builder calls it once
+    // with the candidate name and ID so we know README.txt will contain
+    // accurate data subject information.
+    const coverLetterModule = await import('@/lib/gdpr/cover-letter')
+    const { buildDsarZip } = await import('@/lib/gdpr/dsar-builder')
+
+    const archive = await buildDsarZip(CANDIDATE_ID, TENANT_ID)
+    // Drain the archive so all work completes
+    await collectStream(archive)
+
+    const spy = coverLetterModule.getDsarCoverLetter as ReturnType<typeof vi.fn>
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        candidateId: CANDIDATE_ID,
+      })
+    )
+  })
+
+  it('returns a readable stream even when candidate is not found', async () => {
+    // Override mockTx to return empty on all selects (candidate not found)
+    mockTx.select = vi.fn(() => makeChain([]))
+
+    const { buildDsarZip } = await import('@/lib/gdpr/dsar-builder')
+    const archive = await buildDsarZip(CANDIDATE_ID, TENANT_ID)
+
+    expect(typeof archive.pipe).toBe('function')
+
+    const buffer = await collectStream(archive)
+    // Should produce a ZIP with ERROR.txt
+    expect(buffer.includes(Buffer.from('ERROR.txt'))).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cover letter tests
+//
+// The cover-letter module is mocked above for the buildDsarZip tests. Here we
+// test the actual implementation directly by importing it and calling it with
+// concrete inputs — the assertions only check the return VALUE (a string), so
+// the module mock does not interfere because we bypass the module registry by
+// importing the function inline and calling it via its real implementation.
+//
+// We work around the module mock by re-importing the actual function via a
+// dynamic path that resolves to the same source file but forces a fresh module
+// evaluation. In practice, since vi.mock is hoisted, we simply import from the
+// module (which returns the mock), but for these tests we call getDsarCoverLetter
+// directly from the real source using a jest-style `actual` import.
+// ---------------------------------------------------------------------------
+
+describe('getDsarCoverLetter (real implementation)', () => {
+  // Import the real function directly — bypasses the vi.mock by using
+  // importOriginal (vitest pattern).
+  let getDsarCoverLetterReal: typeof import('@/lib/gdpr/cover-letter')['getDsarCoverLetter']
+
+  beforeEach(async () => {
+    const mod = await vi.importActual<typeof import('@/lib/gdpr/cover-letter')>(
+      '@/lib/gdpr/cover-letter'
+    )
+    getDsarCoverLetterReal = mod.getDsarCoverLetter
+  })
+  it('contains GDPR Article 15 header', () => {
+    const text = getDsarCoverLetterReal({
+      candidateName: 'John Smith',
+      candidateId: '123',
+      exportDate: '2025-04-28T10:00:00.000Z',
+      files: ['candidate.json', 'scores.json', 'README.txt'],
+    })
+    expect(text).toContain('GDPR Article 15')
+    expect(text).toContain('Right of Access')
+  })
+
+  it('includes candidate name and ID in the cover letter', () => {
+    const text = getDsarCoverLetterReal({
+      candidateName: 'Alice Baker',
+      candidateId: 'cand-999',
+      exportDate: '2025-04-28T10:00:00.000Z',
+      files: ['candidate.json'],
+    })
+    expect(text).toContain('Alice Baker')
+    expect(text).toContain('cand-999')
+  })
+
+  it('lists provided files in the file index', () => {
+    const text = getDsarCoverLetterReal({
+      candidateName: 'Test User',
+      candidateId: 'id-1',
+      exportDate: '2025-01-01T00:00:00.000Z',
+      files: ['candidate.json', 'scores.json', 'README.txt'],
+    })
+    expect(text).toContain('candidate.json')
+    expect(text).toContain('scores.json')
+  })
+
+  it('does not include README.txt as a listed file item (it is the cover letter itself)', () => {
+    const text = getDsarCoverLetterReal({
+      candidateName: 'Test',
+      candidateId: 'id-1',
+      exportDate: '2025-01-01T00:00:00.000Z',
+      files: ['candidate.json', 'README.txt'],
+    })
+    // README.txt should not appear as a bullet in the file index
+    const lines = text.split('\n')
+    const readmeIndexLines = lines.filter((l) => l.trim().startsWith('- README.txt'))
+    expect(readmeIndexLines.length).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #75. Adds the admin-only GDPR compliance surface that the recruiter team needs to honour data-subject requests:

- **Article 17 — Right to Erasure**: typed-name confirmation modal → hard-delete in FK-safe order across 13 tables → audit log rows retained but PII redacted (`entityLabel = '[redacted-gdpr]'`, metadata replaced with `{redacted_gdpr: true, redacted_at}`) → CV file removed from disk → tombstone audit row written.
- **Article 15 — Right of Access (DSAR)**: streams a single ZIP containing `candidate.json`, `scores.json`, `notes.json`, `cv-profile.json`, `enrichment.json`, `audit-log.json`, `sent-emails.json`, `interview-packs.json`, `interview-slots.json`, `interview-transcripts.json`, `approvals.json`, the original CV file, plus a `README.txt` cover letter explaining each file under GDPR Article 15.

Both actions are admin-gated at every layer (server action, API route, and UI panel render) and audit-logged.

## Design notes

- **Explicit transactional deletes, not DB cascade.** Avoids a schema migration and keeps the order auditable in code (sent_emails → transcript_analyses → interview_transcripts → interview_questions/code_challenges → interview_packs → interview_slots → candidate_role_approvals → notes → cv_profiles → candidate_enrichments → scores → candidates).
- **Audit redaction, not audit deletion.** GDPR allows retention of records for legal accountability when the personal data is removed — we redact `entityLabel` and replace metadata with a redaction marker, so the action history (who did what, when) survives.
- **Soft signal for synechron CV file.** Currently stored as JSONB on the candidate row, so it's removed atomically with the candidate delete — TODO comment left in case we ever externalise it.
- **DSAR ZIP streamed via archiver** (already in package.json), wrapped in a `ReadableStream` for the Next.js Response body. No staging to disk.

## Files

- `src/actions/gdpr.ts` (NEW, 276 lines) — `deleteCandidateForGdpr`
- `src/lib/gdpr/cover-letter.ts` (NEW, 84 lines) — README.txt body
- `src/lib/gdpr/dsar-builder.ts` (NEW, 303 lines) — ZIP stream builder
- `src/app/api/export/dsar/[candidateId]/route.ts` (NEW, 88 lines) — admin-only GET
- `src/components/candidates/gdpr-actions-panel.tsx` (NEW, 234 lines) — UI panel + typed-name modal
- `src/lib/audit.ts` — 2 new actions: `candidate.deleted_gdpr`, `candidate.dsar_exported`
- `src/app/(dashboard)/dashboard/candidates/[candidateId]/page.tsx` — render panel when `userRole === 'admin'`
- 24 new unit tests across `tests/unit/actions/gdpr.test.ts` + `tests/unit/lib/gdpr/dsar-builder.test.ts`

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] New GDPR tests: 24 passed (14 action + 10 dsar/cover-letter)
- [x] Full vitest suite: 336 passed (no regressions; pre-existing failures unrelated)
- [ ] Post-merge manual smoke:
  - [ ] Admin sees the GDPR panel; recruiter / viewer / hiring_manager do not
  - [ ] Type wrong name → delete button stays disabled
  - [ ] Type correct name → candidate vanishes from list, all child rows gone, audit rows redacted, CV file removed from `/app/uploads`
  - [ ] DSAR export downloads a ZIP that opens cleanly and contains README.txt + JSON files + CV
  - [ ] Audit log shows `candidate.deleted_gdpr` and `candidate.dsar_exported` with the actor's user id

## Pre-merge

- [x] pg_dump backup taken: `backups/skillai-pre-gdpr-20260428T161006Z.sql` (9.3M)

🤖 Generated with [Claude Code](https://claude.com/claude-code)