### PR TITLE
feat(reports): leadership reporting dashboard (closes #76)

### DIFF
--- a/src/actions/reports.ts
+++ b/src/actions/reports.ts
@@ -1,0 +1,614 @@
+'use server'
+
+import { sql, gte, eq, and, isNotNull, lt, inArray } from 'drizzle-orm'
+import { withTenant } from '@/db'
+import {
+  candidates,
+  roles,
+  scores,
+  agencies,
+  customers,
+  auditLogs,
+  aiUsage,
+} from '@/db/schema'
+import { getActionContext } from '@/lib/auth/action-context'
+import { requireRole } from '@/lib/auth/require-role'
+
+// ── Public types ───────────────────────────────────────────────────────────────
+
+export type ReportRange = '7d' | '30d' | '90d' | '12mo'
+
+export type ReportsFeed = {
+  rangeDays: number
+  generatedAt: Date
+
+  // KPI cards
+  kpis: {
+    activeRoles: number
+    candidatesAddedInRange: number
+    candidatesScoredInRange: number
+    candidatesHiredInRange: number
+    aiSpendInRangeUsd: number
+  }
+
+  // Time-to-fill (last `days`, by customer)
+  timeToFill: {
+    series: { customerName: string; avgDaysToFill: number; rolesFilled: number }[]
+    totalRolesFilled: number
+    averageDaysOverall: number | null
+    hasLimitedHistoricalData: boolean   // true if matched-event count < 5
+  }
+
+  // Agency hit-rate
+  agencyHitRate: {
+    series: {
+      agencyId: string
+      agencyName: string
+      candidatesSubmitted: number
+      candidatesShortlisted: number
+      candidatesHired: number
+      submissionToHirePct: number      // 0..100
+      shortlistToHirePct: number       // 0..100, null-safe (0 if no shortlists)
+    }[]
+  }
+
+  // AI cost trend (LineChart)
+  aiCostTrend: {
+    series: { date: string; costUsd: number; calls: number }[]   // YYYY-MM-DD daily
+    totalUsd: number
+    monthOverMonthPct: number | null   // null if cannot compute
+  }
+
+  // Cycle health (3 KPI tiles)
+  cycleHealth: {
+    rolesOpenOver30Days: number
+    expiredRoles: number
+    candidatesStuckInterviewing: number
+  }
+
+  // Top performers (two small tables)
+  topPerformers: {
+    fastestFilledRoles: { roleId: string; roleTitle: string; daysToFill: number; customerName: string | null }[]   // top 5
+    topAgenciesByHitRate: { agencyId: string; agencyName: string; submissionToHirePct: number; candidatesHired: number }[]   // top 5, must have >= 3 candidates submitted
+  }
+}
+
+// ── Main action ────────────────────────────────────────────────────────────────
+
+export async function getReportsFeed(opts: { days: 7 | 30 | 90 | 365 }): Promise<ReportsFeed> {
+  const ctx = await getActionContext()
+  if (!ctx) throw new Error('Unauthorized')
+  requireRole(ctx.userRole, 'admin')
+
+  const { days } = opts
+  const rangeStart = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+  const sixtyDaysAgo = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000)
+
+  // Shortlisted / interviewing / offered / hired statuses for agency hit-rate
+  const SHORTLISTED_STATUSES = ['shortlisted', 'interviewing', 'offered', 'hired'] as const
+
+  // Stuck-interviewing threshold: 14 days
+  const fourteenDaysAgo = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000)
+
+  const todayStr = new Date().toISOString().slice(0, 10) // 'YYYY-MM-DD'
+
+  return withTenant(ctx.tenantId, async (tx) => {
+    // ── KPI queries (independent — run in parallel) ────────────────────────
+
+    const activeRolesPromise = tx
+      .select({ count: sql<number>`count(*)::int` })
+      .from(roles)
+      .where(eq(roles.isActive, true))
+
+    const candidatesAddedPromise = tx
+      .select({ count: sql<number>`count(*)::int` })
+      .from(candidates)
+      .where(gte(candidates.createdAt, rangeStart))
+
+    const candidatesScoredPromise = tx
+      .select({ count: sql<number>`count(distinct ${scores.candidateId})::int` })
+      .from(scores)
+      .where(
+        and(
+          gte(scores.createdAt, rangeStart),
+          eq(scores.scoreStatus, 'complete'),
+        )
+      )
+
+    const candidatesHiredPromise = tx
+      .select({ count: sql<number>`count(*)::int` })
+      .from(candidates)
+      .where(
+        and(
+          eq(candidates.status, 'hired'),
+          gte(candidates.createdAt, rangeStart),
+        )
+      )
+
+    const aiSpendPromise = tx
+      .select({ total: sql<string>`coalesce(sum(${aiUsage.costUsd}), 0)` })
+      .from(aiUsage)
+      .where(gte(aiUsage.createdAt, rangeStart))
+
+    // ── AI cost trend queries ──────────────────────────────────────────────
+
+    const aiCostTrendPromise = tx
+      .select({
+        date: sql<string>`to_char(${aiUsage.createdAt} at time zone 'UTC', 'YYYY-MM-DD')`,
+        calls: sql<number>`count(*)::int`,
+        costUsd: sql<string>`coalesce(sum(${aiUsage.costUsd}), 0)`,
+      })
+      .from(aiUsage)
+      .where(gte(aiUsage.createdAt, rangeStart))
+      .groupBy(sql`to_char(${aiUsage.createdAt} at time zone 'UTC', 'YYYY-MM-DD')`)
+      .orderBy(sql`to_char(${aiUsage.createdAt} at time zone 'UTC', 'YYYY-MM-DD')`)
+
+    // Month-over-month: last 30 days vs prior 30 days
+    const aiCostLast30Promise = tx
+      .select({ total: sql<string>`coalesce(sum(${aiUsage.costUsd}), 0)` })
+      .from(aiUsage)
+      .where(gte(aiUsage.createdAt, thirtyDaysAgo))
+
+    const aiCostPrior30Promise = tx
+      .select({ total: sql<string>`coalesce(sum(${aiUsage.costUsd}), 0)` })
+      .from(aiUsage)
+      .where(
+        and(
+          gte(aiUsage.createdAt, sixtyDaysAgo),
+          lt(aiUsage.createdAt, thirtyDaysAgo),
+        )
+      )
+
+    // ── Cycle health queries ───────────────────────────────────────────────
+
+    const thirtyDaysAgoDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+
+    const rolesOpenOver30Promise = tx
+      .select({ count: sql<number>`count(*)::int` })
+      .from(roles)
+      .where(
+        and(
+          eq(roles.isActive, true),
+          lt(roles.createdAt, thirtyDaysAgoDate),
+        )
+      )
+
+    const expiredRolesPromise = tx
+      .select({ count: sql<number>`count(*)::int` })
+      .from(roles)
+      .where(
+        and(
+          eq(roles.isActive, true),
+          isNotNull(roles.cutoffDate),
+          sql`${roles.cutoffDate} < ${todayStr}::date`,
+        )
+      )
+
+    const stuckInterviewingPromise = tx
+      .select({ count: sql<number>`count(*)::int` })
+      .from(candidates)
+      .where(
+        and(
+          eq(candidates.status, 'interviewing'),
+          isNotNull(candidates.statusConfirmedAt),
+          lt(candidates.statusConfirmedAt, fourteenDaysAgo),
+        )
+      )
+
+    // ── Agency hit-rate query ──────────────────────────────────────────────
+    // Fetch all candidates in range with agencyId, join agencies for name
+    const agencyCandidatesPromise = tx
+      .select({
+        agencyId: candidates.agencyId,
+        agencyName: agencies.name,
+        status: candidates.status,
+      })
+      .from(candidates)
+      .innerJoin(agencies, eq(candidates.agencyId, agencies.id))
+      .where(
+        and(
+          gte(candidates.createdAt, rangeStart),
+          isNotNull(candidates.agencyId),
+        )
+      )
+
+    // ── Audit log: hired events for time-to-fill ───────────────────────────
+    const hiredAuditPromise = tx
+      .select({
+        entityId: auditLogs.entityId,
+        metadata: auditLogs.metadata,
+        createdAt: auditLogs.createdAt,
+      })
+      .from(auditLogs)
+      .where(
+        and(
+          eq(auditLogs.action, 'candidate.status_changed'),
+          sql`${auditLogs.metadata}->>'newStatus' = 'hired'`,
+          gte(auditLogs.createdAt, rangeStart),
+        )
+      )
+
+    // ── Run all parallel queries ───────────────────────────────────────────
+    const [
+      activeRolesRes,
+      candidatesAddedRes,
+      candidatesScoredRes,
+      candidatesHiredRes,
+      aiSpendRes,
+      aiCostTrendRes,
+      aiCostLast30Res,
+      aiCostPrior30Res,
+      rolesOpenOver30Res,
+      expiredRolesRes,
+      stuckInterviewingRes,
+      agencyCandidatesRes,
+      hiredAuditRes,
+    ] = await Promise.all([
+      activeRolesPromise,
+      candidatesAddedPromise,
+      candidatesScoredPromise,
+      candidatesHiredPromise,
+      aiSpendPromise,
+      aiCostTrendPromise,
+      aiCostLast30Promise,
+      aiCostPrior30Promise,
+      rolesOpenOver30Promise,
+      expiredRolesPromise,
+      stuckInterviewingPromise,
+      agencyCandidatesPromise,
+      hiredAuditPromise,
+    ])
+
+    // ── Build KPIs ─────────────────────────────────────────────────────────
+    const kpis = {
+      activeRoles: activeRolesRes[0]?.count ?? 0,
+      candidatesAddedInRange: candidatesAddedRes[0]?.count ?? 0,
+      candidatesScoredInRange: candidatesScoredRes[0]?.count ?? 0,
+      candidatesHiredInRange: candidatesHiredRes[0]?.count ?? 0,
+      aiSpendInRangeUsd: parseFloat(aiSpendRes[0]?.total ?? '0'),
+    }
+
+    // ── Build AI cost trend ────────────────────────────────────────────────
+    const aiCostSeries = aiCostTrendRes.map((r) => ({
+      date: r.date,
+      costUsd: parseFloat(r.costUsd),
+      calls: r.calls,
+    }))
+
+    const totalAiUsd = aiCostSeries.reduce((acc, r) => acc + r.costUsd, 0)
+
+    const last30 = parseFloat(aiCostLast30Res[0]?.total ?? '0')
+    const prior30 = parseFloat(aiCostPrior30Res[0]?.total ?? '0')
+    let monthOverMonthPct: number | null = null
+    if (prior30 > 0 && last30 > 0) {
+      monthOverMonthPct = ((last30 - prior30) / prior30) * 100
+    }
+
+    const aiCostTrend = {
+      series: aiCostSeries,
+      totalUsd: totalAiUsd,
+      monthOverMonthPct,
+    }
+
+    // ── Build cycle health ─────────────────────────────────────────────────
+    const cycleHealth = {
+      rolesOpenOver30Days: rolesOpenOver30Res[0]?.count ?? 0,
+      expiredRoles: expiredRolesRes[0]?.count ?? 0,
+      candidatesStuckInterviewing: stuckInterviewingRes[0]?.count ?? 0,
+    }
+
+    // ── Build agency hit-rate ──────────────────────────────────────────────
+    // Group by agencyId in JS — avoids complex SQL groupBy across multiple columns
+    type AgencyAcc = {
+      agencyId: string
+      agencyName: string
+      candidatesSubmitted: number
+      candidatesShortlisted: number
+      candidatesHired: number
+    }
+
+    const agencyMap = new Map<string, AgencyAcc>()
+
+    for (const row of agencyCandidatesRes) {
+      if (!row.agencyId) continue
+      const key = row.agencyId
+      if (!agencyMap.has(key)) {
+        agencyMap.set(key, {
+          agencyId: key,
+          agencyName: row.agencyName,
+          candidatesSubmitted: 0,
+          candidatesShortlisted: 0,
+          candidatesHired: 0,
+        })
+      }
+      const entry = agencyMap.get(key)!
+      entry.candidatesSubmitted += 1
+      if ((SHORTLISTED_STATUSES as readonly string[]).includes(row.status)) {
+        entry.candidatesShortlisted += 1
+      }
+      if (row.status === 'hired') {
+        entry.candidatesHired += 1
+      }
+    }
+
+    const agencyHitRateSeries = Array.from(agencyMap.values())
+      .filter((a) => a.candidatesSubmitted > 0)
+      .map((a) => ({
+        agencyId: a.agencyId,
+        agencyName: a.agencyName,
+        candidatesSubmitted: a.candidatesSubmitted,
+        candidatesShortlisted: a.candidatesShortlisted,
+        candidatesHired: a.candidatesHired,
+        submissionToHirePct:
+          a.candidatesSubmitted > 0
+            ? (a.candidatesHired / a.candidatesSubmitted) * 100
+            : 0,
+        shortlistToHirePct:
+          a.candidatesShortlisted > 0
+            ? (a.candidatesHired / a.candidatesShortlisted) * 100
+            : 0,
+      }))
+
+    // ── Build time-to-fill ─────────────────────────────────────────────────
+    // Collect unique candidateIds from hired audit events
+    const hiredCandidateIds = hiredAuditRes
+      .map((r) => r.entityId)
+      .filter((id): id is string => id !== null)
+
+    // For time-to-fill we need: (hired audit createdAt) - (role createdAt)
+    // Strategy:
+    //  1. Prefer metadata.roleId from audit row (when present)
+    //  2. Fallback: best score per candidate (highest overallScore)
+    //
+    // We'll fetch roles for the preferred-path candidates and scores for fallback
+
+    type HiredEvent = {
+      candidateId: string
+      roleIdFromAudit: string | null
+      hiredAt: Date
+    }
+
+    const hiredEvents: HiredEvent[] = hiredAuditRes
+      .filter((r) => r.entityId !== null)
+      .map((r) => ({
+        candidateId: r.entityId!,
+        // metadata is typed as Record<string, unknown> | null from Drizzle
+        roleIdFromAudit:
+          r.metadata &&
+          typeof r.metadata === 'object' &&
+          'roleId' in r.metadata &&
+          typeof (r.metadata as Record<string, unknown>).roleId === 'string'
+            ? (r.metadata as Record<string, unknown>).roleId as string
+            : null,
+        hiredAt: r.createdAt,
+      }))
+
+    // Candidate IDs that need fallback (no roleId in audit metadata)
+    const needsFallbackIds = hiredEvents
+      .filter((e) => e.roleIdFromAudit === null)
+      .map((e) => e.candidateId)
+
+    // Preferred path: fetch roles referenced directly in audit metadata
+    const preferredRoleIds = [
+      ...new Set(
+        hiredEvents
+          .map((e) => e.roleIdFromAudit)
+          .filter((id): id is string => id !== null)
+      ),
+    ]
+
+    // Fetch roles by IDs (preferred path)
+    const preferredRolesMap = new Map<
+      string,
+      { id: string; title: string; createdAt: Date; customerId: string | null }
+    >()
+
+    if (preferredRoleIds.length > 0) {
+      const preferredRoles = await tx
+        .select({
+          id: roles.id,
+          title: roles.title,
+          createdAt: roles.createdAt,
+          customerId: roles.customerId,
+        })
+        .from(roles)
+        .where(inArray(roles.id, preferredRoleIds))
+
+      for (const r of preferredRoles) {
+        preferredRolesMap.set(r.id, r)
+      }
+    }
+
+    // Fallback path: fetch best score per candidate (highest overallScore)
+    type FallbackScore = {
+      candidateId: string
+      roleId: string
+      overallScore: number | null
+    }
+    const fallbackScoresMap = new Map<string, FallbackScore>()
+
+    if (needsFallbackIds.length > 0) {
+      const fallbackScores = await tx
+        .select({
+          candidateId: scores.candidateId,
+          roleId: scores.roleId,
+          overallScore: scores.overallScore,
+        })
+        .from(scores)
+        .where(inArray(scores.candidateId, needsFallbackIds))
+
+      // Keep the highest overallScore per candidate
+      for (const s of fallbackScores) {
+        const existing = fallbackScoresMap.get(s.candidateId)
+        if (!existing || (s.overallScore ?? -1) > (existing.overallScore ?? -1)) {
+          fallbackScoresMap.set(s.candidateId, s)
+        }
+      }
+    }
+
+    // Fetch roles for fallback (deduplicated)
+    const fallbackRoleIds = [
+      ...new Set(
+        Array.from(fallbackScoresMap.values()).map((s) => s.roleId)
+      ),
+    ]
+
+    const fallbackRolesMap = new Map<
+      string,
+      { id: string; title: string; createdAt: Date; customerId: string | null }
+    >()
+
+    if (fallbackRoleIds.length > 0) {
+      const fallbackRoles = await tx
+        .select({
+          id: roles.id,
+          title: roles.title,
+          createdAt: roles.createdAt,
+          customerId: roles.customerId,
+        })
+        .from(roles)
+        .where(inArray(roles.id, fallbackRoleIds))
+
+      for (const r of fallbackRoles) {
+        fallbackRolesMap.set(r.id, r)
+      }
+    }
+
+    // Fetch customer names for all roles we found
+    const allCustomerIds = [
+      ...new Set([
+        ...Array.from(preferredRolesMap.values())
+          .map((r) => r.customerId)
+          .filter((id): id is string => id !== null),
+        ...Array.from(fallbackRolesMap.values())
+          .map((r) => r.customerId)
+          .filter((id): id is string => id !== null),
+      ]),
+    ]
+
+    const customersMap = new Map<string, string>()
+    if (allCustomerIds.length > 0) {
+      const customerRows = await tx
+        .select({ id: customers.id, name: customers.name })
+        .from(customers)
+        .where(inArray(customers.id, allCustomerIds))
+
+      for (const c of customerRows) {
+        customersMap.set(c.id, c.name)
+      }
+    }
+
+    // Build per-(candidate, role) time-to-fill entries
+    type FillEntry = {
+      roleId: string
+      roleTitle: string
+      daysToFill: number
+      customerName: string | null
+    }
+
+    const fillEntries: FillEntry[] = []
+
+    for (const event of hiredEvents) {
+      const role =
+        event.roleIdFromAudit !== null
+          ? preferredRolesMap.get(event.roleIdFromAudit)
+          : (() => {
+              const fb = fallbackScoresMap.get(event.candidateId)
+              return fb ? fallbackRolesMap.get(fb.roleId) : undefined
+            })()
+
+      if (!role) continue
+
+      const daysToFill =
+        (event.hiredAt.getTime() - role.createdAt.getTime()) / 86_400_000
+
+      // Discard invalid entries (data error or orphan)
+      if (daysToFill < 0 || daysToFill > 730) continue
+
+      fillEntries.push({
+        roleId: role.id,
+        roleTitle: role.title,
+        daysToFill,
+        customerName:
+          role.customerId ? (customersMap.get(role.customerId) ?? null) : null,
+      })
+    }
+
+    // Group by customerName for the series
+    const customerFillMap = new Map<
+      string,
+      { totalDays: number; count: number }
+    >()
+
+    for (const entry of fillEntries) {
+      const key = entry.customerName ?? '(No Customer)'
+      const acc = customerFillMap.get(key) ?? { totalDays: 0, count: 0 }
+      acc.totalDays += entry.daysToFill
+      acc.count += 1
+      customerFillMap.set(key, acc)
+    }
+
+    const timeToFillSeries = Array.from(customerFillMap.entries()).map(
+      ([customerName, acc]) => ({
+        customerName,
+        avgDaysToFill: acc.totalDays / acc.count,
+        rolesFilled: acc.count,
+      })
+    )
+
+    const totalRolesFilled = fillEntries.length
+    const matchedEventCount = fillEntries.length
+    const averageDaysOverall =
+      matchedEventCount > 0
+        ? fillEntries.reduce((sum, e) => sum + e.daysToFill, 0) / matchedEventCount
+        : null
+    const hasLimitedHistoricalData = matchedEventCount < 5
+
+    const timeToFill = {
+      series: timeToFillSeries,
+      totalRolesFilled,
+      averageDaysOverall,
+      hasLimitedHistoricalData,
+    }
+
+    // ── Build top performers ───────────────────────────────────────────────
+
+    // fastestFilledRoles: top 5 lowest daysToFill from fillEntries (per-role, not per-candidate)
+    const fastestFilledRoles = [...fillEntries]
+      .sort((a, b) => a.daysToFill - b.daysToFill)
+      .slice(0, 5)
+      .map((e) => ({
+        roleId: e.roleId,
+        roleTitle: e.roleTitle,
+        daysToFill: e.daysToFill,
+        customerName: e.customerName,
+      }))
+
+    // topAgenciesByHitRate: filter submitted >= 3, sort desc by submissionToHirePct, top 5
+    const topAgenciesByHitRate = agencyHitRateSeries
+      .filter((a) => a.candidatesSubmitted >= 3)
+      .sort((a, b) => b.submissionToHirePct - a.submissionToHirePct)
+      .slice(0, 5)
+      .map((a) => ({
+        agencyId: a.agencyId,
+        agencyName: a.agencyName,
+        submissionToHirePct: a.submissionToHirePct,
+        candidatesHired: a.candidatesHired,
+      }))
+
+    return {
+      rangeDays: days,
+      generatedAt: new Date(),
+      kpis,
+      timeToFill,
+      agencyHitRate: { series: agencyHitRateSeries },
+      aiCostTrend,
+      cycleHealth,
+      topPerformers: {
+        fastestFilledRoles,
+        topAgenciesByHitRate,
+      },
+    }
+  })
+}

--- a/src/app/(dashboard)/dashboard/reports/page.tsx
+++ b/src/app/(dashboard)/dashboard/reports/page.tsx
@@ -1,0 +1,100 @@
+import { BarChart3Icon } from 'lucide-react'
+import { auth } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import { getReportsFeed, type ReportsFeed } from '@/actions/reports'
+import { KpiCard } from '@/components/reports/kpi-card'
+import { TimeToFillChart } from '@/components/reports/time-to-fill-chart'
+import { AgencyHitRateChart } from '@/components/reports/agency-hit-rate-chart'
+import { AiCostTrendChart } from '@/components/reports/ai-cost-trend-chart'
+import { CycleHealthPanel } from '@/components/reports/cycle-health-panel'
+import { TopPerformersTables } from '@/components/reports/top-performers-tables'
+import { DateRangePresets } from '@/components/reports/date-range-presets'
+
+export const metadata = { title: 'Reports — SkillAI' }
+
+type ReportRange = '7d' | '30d' | '90d' | '12mo'
+
+function parseRange(r: string | undefined): 7 | 30 | 90 | 365 {
+  if (r === '7d') return 7
+  if (r === '90d') return 90
+  if (r === '12mo') return 365
+  return 30
+}
+
+function toRangeKey(r: string | undefined): ReportRange {
+  if (r === '7d' || r === '90d' || r === '12mo') return r
+  return '30d'
+}
+
+export default async function ReportsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ range?: string }>
+}) {
+  const session = await auth()
+  if (!session?.user?.tenantId) redirect('/login')
+
+  const { range } = await searchParams
+  const days = parseRange(range)
+  const current = toRangeKey(range)
+
+  if (session.user.role !== 'admin') {
+    return (
+      <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-8 text-center">
+        <h1 className="text-lg font-medium text-[var(--color-fg)] mb-2">Admin access required</h1>
+        <p className="text-sm text-[var(--color-fg-muted)]">
+          The reports dashboard is only available to admins.
+        </p>
+      </div>
+    )
+  }
+
+  const feed: ReportsFeed = await getReportsFeed({ days })
+
+  return (
+    <div className="space-y-6 p-6">
+      {/* Page header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="p-2 bg-[var(--color-bg-elevated)] rounded-lg">
+            <BarChart3Icon className="h-5 w-5 text-[var(--color-fg-muted)]" />
+          </div>
+          <div>
+            <h1 className="text-xl font-bold text-[var(--color-fg)]">Reports</h1>
+            <p className="text-sm text-[var(--color-fg-subtle)]">
+              Recruiting performance and pipeline health
+            </p>
+          </div>
+        </div>
+        <DateRangePresets current={current} />
+      </div>
+
+      {/* KPI grid — 5 cards */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
+        <KpiCard label="Active roles" value={feed.kpis.activeRoles} />
+        <KpiCard label="New candidates" value={feed.kpis.candidatesAddedInRange} />
+        <KpiCard label="Scored" value={feed.kpis.candidatesScoredInRange} />
+        <KpiCard label="Hires" value={feed.kpis.candidatesHiredInRange} />
+        <KpiCard
+          label="AI spend ($)"
+          value={`$${feed.kpis.aiSpendInRangeUsd.toFixed(2)}`}
+        />
+      </div>
+
+      {/* Cycle health — full width */}
+      <CycleHealthPanel data={feed.cycleHealth} rangeDays={days} />
+
+      {/* AI cost trend — full width */}
+      <AiCostTrendChart data={feed.aiCostTrend} rangeDays={days} />
+
+      {/* Two-column: agency hit rate + time to fill */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <AgencyHitRateChart data={feed.agencyHitRate} rangeDays={days} />
+        <TimeToFillChart data={feed.timeToFill} rangeDays={days} />
+      </div>
+
+      {/* Top performers — full width, renders its own two-table layout internally */}
+      <TopPerformersTables data={feed.topPerformers} rangeDays={days} />
+    </div>
+  )
+}

--- a/src/app/api/reports/[metric]/csv/route.ts
+++ b/src/app/api/reports/[metric]/csv/route.ts
@@ -1,0 +1,132 @@
+import { auth } from '@/lib/auth'
+import { getReportsFeed } from '@/actions/reports'
+import { toCsv } from '@/lib/reports/to-csv'
+
+// ── Range parsing ─────────────────────────────────────────────────────────────
+
+const RANGE_MAP: Record<string, 7 | 30 | 90 | 365> = {
+  '7d':   7,
+  '30d':  30,
+  '90d':  90,
+  '12mo': 365,
+}
+
+function parseRange(raw: string | null): { days: 7 | 30 | 90 | 365; label: string } | null {
+  if (!raw) return { days: 30, label: '30d' }
+  const days = RANGE_MAP[raw]
+  if (!days) return null
+  return { days, label: raw }
+}
+
+// ── Response helpers ──────────────────────────────────────────────────────────
+
+function csvResponse(csv: string, filename: string): Response {
+  return new Response(csv, {
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': `attachment; filename="${filename}"`,
+    },
+  })
+}
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+// ── Route handler ─────────────────────────────────────────────────────────────
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ metric: string }> },
+): Promise<Response> {
+  // 1. Auth
+  const session = await auth()
+  if (!session?.user?.tenantId) return json({ error: 'Unauthorized' }, 401)
+
+  // 2. Admin gate
+  if (session.user.role !== 'admin') return json({ error: 'Forbidden' }, 403)
+
+  // 3. Parse range
+  const rangeRaw = new URL(req.url).searchParams.get('range')
+  const range = parseRange(rangeRaw)
+  if (!range) return json({ error: 'Invalid range. Use 7d, 30d, 90d, or 12mo.' }, 400)
+
+  const { days, label: rangeLabel } = range
+
+  // 4. Fetch data — getReportsFeed also enforces admin internally
+  const feed = await getReportsFeed({ days })
+
+  // 5. Build CSV for the requested metric
+  const { metric } = await params
+
+  switch (metric) {
+    case 'time-to-fill': {
+      const csv = toCsv(feed.timeToFill.series, [
+        { key: 'customerName',  label: 'customerName' },
+        { key: 'avgDaysToFill', label: 'avgDaysToFill' },
+        { key: 'rolesFilled',   label: 'rolesFilled' },
+      ])
+      return csvResponse(csv, `time-to-fill-${rangeLabel}.csv`)
+    }
+
+    case 'agency-hit-rate': {
+      const csv = toCsv(feed.agencyHitRate.series, [
+        { key: 'agencyName',           label: 'agencyName' },
+        { key: 'candidatesSubmitted',  label: 'candidatesSubmitted' },
+        { key: 'candidatesShortlisted', label: 'candidatesShortlisted' },
+        { key: 'candidatesHired',      label: 'candidatesHired' },
+        { key: 'submissionToHirePct',  label: 'submissionToHirePct' },
+        { key: 'shortlistToHirePct',   label: 'shortlistToHirePct' },
+      ])
+      return csvResponse(csv, `agency-hit-rate-${rangeLabel}.csv`)
+    }
+
+    case 'ai-cost-trend': {
+      const csv = toCsv(feed.aiCostTrend.series, [
+        { key: 'date',    label: 'date' },
+        { key: 'costUsd', label: 'costUsd' },
+        { key: 'calls',   label: 'calls' },
+      ])
+      return csvResponse(csv, `ai-cost-trend-${rangeLabel}.csv`)
+    }
+
+    case 'cycle-health': {
+      const rows = [
+        { metric: 'Roles open >30 days',      value: feed.cycleHealth.rolesOpenOver30Days },
+        { metric: 'Expired roles',             value: feed.cycleHealth.expiredRoles },
+        { metric: 'Stuck in interviewing',     value: feed.cycleHealth.candidatesStuckInterviewing },
+      ]
+      const csv = toCsv(rows, [
+        { key: 'metric', label: 'metric' },
+        { key: 'value',  label: 'value' },
+      ])
+      return csvResponse(csv, `cycle-health-${rangeLabel}.csv`)
+    }
+
+    case 'top-performers': {
+      // Two labelled sections in a single file
+      const sectionHeader1 = '## Roles closed fastest\r\n'
+      const fastest = toCsv(feed.topPerformers.fastestFilledRoles, [
+        { key: 'roleTitle',    label: 'roleTitle' },
+        { key: 'daysToFill',   label: 'daysToFill' },
+        { key: 'customerName', label: 'customerName' },
+      ])
+      const sectionHeader2 = '\r\n## Top agencies by hit-rate\r\n'
+      const topAgencies = toCsv(feed.topPerformers.topAgenciesByHitRate, [
+        { key: 'agencyName',          label: 'agencyName' },
+        { key: 'submissionToHirePct', label: 'submissionToHirePct' },
+        { key: 'candidatesHired',     label: 'candidatesHired' },
+      ])
+      return csvResponse(
+        sectionHeader1 + fastest + sectionHeader2 + topAgencies,
+        `top-performers-${rangeLabel}.csv`,
+      )
+    }
+
+    default:
+      return json({ error: 'Unknown metric' }, 404)
+  }
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -13,6 +13,7 @@ import {
   ShieldCheckIcon,
   ListChecksIcon,
   HelpCircleIcon,
+  BarChart3Icon,
 } from 'lucide-react'
 import type { UserRole } from '@/lib/auth/types'
 import { ThemeToggle } from '@/components/theme/theme-toggle'
@@ -58,6 +59,7 @@ const NAV_ITEMS: NavItem[] = [
   { href: '/dashboard/agencies', label: 'Agencies', icon: BuildingIcon, minRole: 'recruiter' },
   { href: '/dashboard/users', label: 'Users', icon: UserCogIcon, minRole: 'admin' },
   { href: '/dashboard/audit', label: 'Audit Log', icon: ShieldCheckIcon, minRole: 'admin' },
+  { href: '/dashboard/reports', label: 'Reports', icon: BarChart3Icon, minRole: 'admin' },
   { href: '/settings', label: 'Settings', icon: SettingsIcon, minRole: 'admin' },
   { href: '/dashboard/help', label: 'Help', icon: HelpCircleIcon, minRole: 'viewer' },
 ]

--- a/src/components/reports/agency-hit-rate-chart.tsx
+++ b/src/components/reports/agency-hit-rate-chart.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+// Usage:
+// <AgencyHitRateChart data={feed.agencyHitRate} rangeDays={30} />
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+  ResponsiveContainer,
+  Legend,
+} from 'recharts'
+import type { ReportsFeed } from '@/actions/reports'
+
+type Props = {
+  data: ReportsFeed['agencyHitRate']
+  rangeDays: number
+}
+
+type AgencyRow = ReportsFeed['agencyHitRate']['series'][number]
+
+interface CustomTooltipProps {
+  active?: boolean
+  payload?: Array<{
+    name: string
+    value: number
+    payload: AgencyRow
+  }>
+  label?: string
+}
+
+function AgencyTooltip({ active, payload, label }: CustomTooltipProps) {
+  if (!active || !payload || payload.length === 0) return null
+  const row = payload[0].payload
+  return (
+    <div
+      style={{
+        backgroundColor: '#18181b',
+        border: '1px solid #3f3f46',
+        borderRadius: 6,
+        fontSize: 12,
+        padding: '8px 12px',
+        color: '#d4d4d8',
+      }}
+    >
+      <p style={{ marginBottom: 6, fontWeight: 600 }}>{label}</p>
+      <p>Submission → Hire: {row.submissionToHirePct.toFixed(1)}%</p>
+      <p>Shortlist → Hire: {row.shortlistToHirePct.toFixed(1)}%</p>
+      <p style={{ marginTop: 4, color: '#71717a' }}>
+        Submitted: {row.candidatesSubmitted} · Shortlisted: {row.candidatesShortlisted} · Hired: {row.candidatesHired}
+      </p>
+    </div>
+  )
+}
+
+export function AgencyHitRateChart({ data, rangeDays }: Props) {
+  const rangeParam = rangeDays === 365 ? '12mo' : `${rangeDays}d`
+
+  return (
+    <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-base font-medium text-[var(--color-fg)]">
+          Agency hit-rate
+        </h2>
+        <a
+          href={`/api/reports/agency-hit-rate/csv?range=${rangeParam}`}
+          className="text-xs px-2 py-1 rounded border border-[var(--color-border)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg)] hover:bg-[var(--color-bg-input)]"
+        >
+          Export CSV
+        </a>
+      </div>
+
+      {data.series.length === 0 ? (
+        <p className="text-sm text-[var(--color-fg-subtle)] py-12 text-center">
+          No data for this range.
+        </p>
+      ) : (
+        <ResponsiveContainer width="100%" height={300}>
+          <BarChart
+            data={data.series}
+            margin={{ top: 5, right: 10, left: 0, bottom: 40 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />
+            <XAxis
+              dataKey="agencyName"
+              stroke="#71717a"
+              tick={{ fontSize: 10, fill: '#71717a' }}
+              angle={-35}
+              textAnchor="end"
+              interval={0}
+            />
+            <YAxis
+              stroke="#71717a"
+              tick={{ fontSize: 10, fill: '#71717a' }}
+              tickFormatter={(v: number) => `${v}%`}
+              label={{
+                value: '%',
+                angle: -90,
+                position: 'insideLeft',
+                style: { fontSize: 10, fill: '#71717a' },
+              }}
+            />
+            <Tooltip content={<AgencyTooltip />} />
+            <Legend
+              wrapperStyle={{ fontSize: 11, color: '#71717a' }}
+            />
+            <Bar
+              dataKey="submissionToHirePct"
+              name="Submission → Hire %"
+              fill="#3b82f6"
+              radius={[3, 3, 0, 0]}
+            />
+            <Bar
+              dataKey="shortlistToHirePct"
+              name="Shortlist → Hire %"
+              fill="#10b981"
+              radius={[3, 3, 0, 0]}
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  )
+}

--- a/src/components/reports/ai-cost-trend-chart.tsx
+++ b/src/components/reports/ai-cost-trend-chart.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+// Usage:
+// <AiCostTrendChart data={feed.aiCostTrend} rangeDays={30} />
+
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+  ResponsiveContainer,
+} from 'recharts'
+import type { ReportsFeed } from '@/actions/reports'
+
+type Props = {
+  data: ReportsFeed['aiCostTrend']
+  rangeDays: number
+}
+
+export function AiCostTrendChart({ data, rangeDays }: Props) {
+  const rangeParam = rangeDays === 365 ? '12mo' : `${rangeDays}d`
+
+  const momPct = data.monthOverMonthPct
+  const momDisplay =
+    momPct !== null
+      ? `${momPct >= 0 ? '+' : ''}${momPct.toFixed(0)}%`
+      : null
+  const momColour =
+    momPct !== null && momPct >= 0 ? 'text-red-500' : 'text-emerald-500'
+
+  return (
+    <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-base font-medium text-[var(--color-fg)]">
+          AI cost trend
+        </h2>
+        <div className="flex items-center gap-3">
+          {momDisplay && (
+            <span className={`text-xs font-medium ${momColour}`}>
+              {momDisplay} MoM
+            </span>
+          )}
+          <span className="text-xs text-[var(--color-fg-muted)]">
+            Total ${data.totalUsd.toFixed(2)}
+          </span>
+          <a
+            href={`/api/reports/ai-cost-trend/csv?range=${rangeParam}`}
+            className="text-xs px-2 py-1 rounded border border-[var(--color-border)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg)] hover:bg-[var(--color-bg-input)]"
+          >
+            Export CSV
+          </a>
+        </div>
+      </div>
+
+      {data.series.length === 0 ? (
+        <p className="text-sm text-[var(--color-fg-subtle)] py-12 text-center">
+          No data for this range.
+        </p>
+      ) : (
+        <ResponsiveContainer width="100%" height={300}>
+          <LineChart
+            data={data.series}
+            margin={{ top: 5, right: 10, left: 0, bottom: 0 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />
+            <XAxis
+              dataKey="date"
+              stroke="#71717a"
+              tick={{ fontSize: 10, fill: '#71717a' }}
+              tickFormatter={(d: string) => d.slice(5)}
+            />
+            <YAxis
+              stroke="#71717a"
+              tick={{ fontSize: 10, fill: '#71717a' }}
+              tickFormatter={(v: number) => `$${v.toFixed(2)}`}
+            />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: '#18181b',
+                border: '1px solid #3f3f46',
+                borderRadius: 6,
+                fontSize: 12,
+              }}
+              labelStyle={{ color: '#d4d4d8' }}
+              formatter={(value, name) => {
+                const num = typeof value === 'number' ? value : Number(value)
+                if (name === 'costUsd') return [`$${num.toFixed(4)}`, 'Cost']
+                if (name === 'calls') return [num.toLocaleString('en-GB'), 'API calls']
+                return [String(value), String(name)]
+              }}
+            />
+            <Line
+              type="monotone"
+              dataKey="costUsd"
+              stroke="#fbbf24"
+              strokeWidth={2}
+              dot={false}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  )
+}

--- a/src/components/reports/cycle-health-panel.tsx
+++ b/src/components/reports/cycle-health-panel.tsx
@@ -1,0 +1,76 @@
+// Usage:
+// <CycleHealthPanel data={feed.cycleHealth} rangeDays={30} />
+
+import Link from 'next/link'
+import type { ReportsFeed } from '@/actions/reports'
+
+type Props = {
+  data: ReportsFeed['cycleHealth']
+  rangeDays: number
+}
+
+interface TileProps {
+  label: string
+  value: number
+  accent: 'amber' | 'red'
+  href: string
+}
+
+function Tile({ label, value, accent, href }: TileProps) {
+  const valueColour =
+    accent === 'amber' ? 'text-amber-500' : 'text-red-500'
+
+  return (
+    <Link
+      href={href}
+      className="block rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-app)] p-4
+                 hover:bg-[var(--color-bg-input)] transition-colors"
+    >
+      <p className="text-xs uppercase tracking-wide text-[var(--color-fg-muted)] mb-2">
+        {label}
+      </p>
+      <p className={`text-3xl font-semibold ${valueColour}`}>{value}</p>
+    </Link>
+  )
+}
+
+export function CycleHealthPanel({ data, rangeDays }: Props) {
+  const rangeParam = rangeDays === 365 ? '12mo' : `${rangeDays}d`
+
+  return (
+    <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-base font-medium text-[var(--color-fg)]">
+          Cycle health
+        </h2>
+        <a
+          href={`/api/reports/cycle-health/csv?range=${rangeParam}`}
+          className="text-xs px-2 py-1 rounded border border-[var(--color-border)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg)] hover:bg-[var(--color-bg-input)]"
+        >
+          Export CSV
+        </a>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <Tile
+          label="Roles open >30 days"
+          value={data.rolesOpenOver30Days}
+          accent="amber"
+          href="/dashboard/roles?filter=open30d"
+        />
+        <Tile
+          label="Expired roles"
+          value={data.expiredRoles}
+          accent="red"
+          href="/dashboard/roles?filter=expired"
+        />
+        <Tile
+          label="Stuck in interviewing"
+          value={data.candidatesStuckInterviewing}
+          accent="red"
+          href="/dashboard/candidates?filter=stuck"
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/components/reports/date-range-presets.tsx
+++ b/src/components/reports/date-range-presets.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import Link from 'next/link'
+
+const RANGES = [
+  { key: '7d', label: '7d' },
+  { key: '30d', label: '30d' },
+  { key: '90d', label: '90d' },
+  { key: '12mo', label: '12mo' },
+] as const
+
+export function DateRangePresets({ current }: { current: '7d' | '30d' | '90d' | '12mo' }) {
+  return (
+    <div className="inline-flex rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-elevated)] p-1">
+      {RANGES.map((r) => {
+        const isActive = r.key === current
+        return (
+          <Link
+            key={r.key}
+            href={`/dashboard/reports?range=${r.key}`}
+            className={`px-3 py-1 text-sm rounded-md transition-colors ${
+              isActive
+                ? 'bg-[var(--color-bg-input)] text-[var(--color-fg)]'
+                : 'text-[var(--color-fg-muted)] hover:text-[var(--color-fg)]'
+            }`}
+          >
+            {r.label}
+          </Link>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/reports/kpi-card.tsx
+++ b/src/components/reports/kpi-card.tsx
@@ -1,0 +1,33 @@
+// Usage:
+// <KpiCard label="Active Roles" value={42} />
+// <KpiCard label="AI Spend" value="$12.50" subtext="last 30 days" accent="amber" />
+
+type Props = {
+  label: string
+  value: string | number
+  subtext?: string
+  accent?: 'default' | 'emerald' | 'red' | 'amber'
+}
+
+const accentClass: Record<NonNullable<Props['accent']>, string> = {
+  default: 'text-[var(--color-fg)]',
+  emerald: 'text-emerald-500',
+  red: 'text-red-500',
+  amber: 'text-amber-500',
+}
+
+export function KpiCard({ label, value, subtext, accent = 'default' }: Props) {
+  return (
+    <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-6">
+      <p className="text-xs uppercase tracking-wide text-[var(--color-fg-muted)] mb-2">
+        {label}
+      </p>
+      <p className={`text-3xl font-semibold ${accentClass[accent]}`}>
+        {value}
+      </p>
+      {subtext && (
+        <p className="mt-1 text-xs text-[var(--color-fg-subtle)]">{subtext}</p>
+      )}
+    </div>
+  )
+}

--- a/src/components/reports/time-to-fill-chart.tsx
+++ b/src/components/reports/time-to-fill-chart.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+// Usage:
+// <TimeToFillChart data={feed.timeToFill} rangeDays={30} />
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+  ResponsiveContainer,
+} from 'recharts'
+import type { ReportsFeed } from '@/actions/reports'
+
+type Props = {
+  data: ReportsFeed['timeToFill']
+  rangeDays: number
+}
+
+export function TimeToFillChart({ data, rangeDays }: Props) {
+  const rangeParam = rangeDays === 365 ? '12mo' : `${rangeDays}d`
+
+  return (
+    <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-6">
+      <div className="flex items-center justify-between mb-4">
+        <div>
+          <h2 className="text-base font-medium text-[var(--color-fg)]">
+            Time to fill (by customer)
+          </h2>
+          <p className="mt-0.5 text-xs text-[var(--color-fg-subtle)]">
+            {data.totalRolesFilled} roles filled
+            {data.averageDaysOverall !== null
+              ? ` · avg ${data.averageDaysOverall} days`
+              : ''}
+          </p>
+        </div>
+        <a
+          href={`/api/reports/time-to-fill/csv?range=${rangeParam}`}
+          className="text-xs px-2 py-1 rounded border border-[var(--color-border)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg)] hover:bg-[var(--color-bg-input)]"
+        >
+          Export CSV
+        </a>
+      </div>
+
+      {data.series.length === 0 ? (
+        <p className="text-sm text-[var(--color-fg-subtle)] py-12 text-center">
+          No data for this range.
+        </p>
+      ) : (
+        <>
+          <ResponsiveContainer width="100%" height={300}>
+            <BarChart
+              data={data.series}
+              margin={{ top: 5, right: 10, left: 0, bottom: 40 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />
+              <XAxis
+                dataKey="customerName"
+                stroke="#71717a"
+                tick={{ fontSize: 10, fill: '#71717a' }}
+                angle={-35}
+                textAnchor="end"
+                interval={0}
+              />
+              <YAxis
+                stroke="#71717a"
+                tick={{ fontSize: 10, fill: '#71717a' }}
+                label={{
+                  value: 'Days',
+                  angle: -90,
+                  position: 'insideLeft',
+                  style: { fontSize: 10, fill: '#71717a' },
+                }}
+              />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: '#18181b',
+                  border: '1px solid #3f3f46',
+                  borderRadius: 6,
+                  fontSize: 12,
+                }}
+                labelStyle={{ color: '#d4d4d8' }}
+                formatter={(value, name, props) => {
+                  const item = props.payload as {
+                    avgDaysToFill: number
+                    rolesFilled: number
+                  }
+                  if (name === 'avgDaysToFill') {
+                    return [
+                      `${value} days (${item.rolesFilled} role${item.rolesFilled === 1 ? '' : 's'} filled)`,
+                      'Avg days to fill',
+                    ]
+                  }
+                  return [String(value), String(name)]
+                }}
+              />
+              <Bar dataKey="avgDaysToFill" fill="#3b82f6" radius={[3, 3, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+
+          {data.hasLimitedHistoricalData && (
+            <p className="mt-2 text-xs text-[var(--color-fg-subtle)]">
+              Limited historical data — accuracy improves as new roles complete.
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/components/reports/top-performers-tables.tsx
+++ b/src/components/reports/top-performers-tables.tsx
@@ -1,0 +1,126 @@
+// Usage:
+// <TopPerformersTables data={feed.topPerformers} rangeDays={30} />
+
+import Link from 'next/link'
+import type { ReportsFeed } from '@/actions/reports'
+
+type Props = {
+  data: ReportsFeed['topPerformers']
+  rangeDays: number
+}
+
+export function TopPerformersTables({ data, rangeDays }: Props) {
+  const rangeParam = rangeDays === 365 ? '12mo' : `${rangeDays}d`
+
+  return (
+    <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-base font-medium text-[var(--color-fg)]">
+          Top performers
+        </h2>
+        <a
+          href={`/api/reports/top-performers/csv?range=${rangeParam}`}
+          className="text-xs px-2 py-1 rounded border border-[var(--color-border)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg)] hover:bg-[var(--color-bg-input)]"
+        >
+          Export CSV
+        </a>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Sub-card 1: Fastest filled roles */}
+        <div className="bg-[var(--color-bg-app)] rounded-lg border border-[var(--color-border)] p-4">
+          <h3 className="text-sm font-medium text-[var(--color-fg-muted)] mb-3">
+            Roles closed fastest
+          </h3>
+          {data.fastestFilledRoles.length === 0 ? (
+            <p className="text-sm text-[var(--color-fg-subtle)] py-6 text-center">
+              No data for this range.
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-xs text-[var(--color-fg-subtle)] border-b border-[var(--color-border)]">
+                    <th className="py-2 pr-3 font-normal">Role</th>
+                    <th className="py-2 pr-3 font-normal">Customer</th>
+                    <th className="py-2 font-normal text-right">Days</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.fastestFilledRoles.map((row) => (
+                    <tr
+                      key={row.roleId}
+                      className="border-b border-[var(--color-border)] last:border-0"
+                    >
+                      <td className="py-2 pr-3">
+                        <Link
+                          href={`/dashboard/roles/${row.roleId}`}
+                          className="text-[var(--color-fg)] hover:text-blue-400 transition-colors"
+                        >
+                          {row.roleTitle}
+                        </Link>
+                      </td>
+                      <td className="py-2 pr-3 text-[var(--color-fg-muted)]">
+                        {row.customerName ?? '—'}
+                      </td>
+                      <td className="py-2 text-right font-medium text-emerald-500">
+                        {row.daysToFill}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+
+        {/* Sub-card 2: Top agencies by hit-rate */}
+        <div className="bg-[var(--color-bg-app)] rounded-lg border border-[var(--color-border)] p-4">
+          <h3 className="text-sm font-medium text-[var(--color-fg-muted)] mb-3">
+            Top agencies by hit-rate
+          </h3>
+          {data.topAgenciesByHitRate.length === 0 ? (
+            <p className="text-sm text-[var(--color-fg-subtle)] py-6 text-center">
+              No data for this range.
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-xs text-[var(--color-fg-subtle)] border-b border-[var(--color-border)]">
+                    <th className="py-2 pr-3 font-normal">Agency</th>
+                    <th className="py-2 pr-3 font-normal text-right">Hit-rate</th>
+                    <th className="py-2 font-normal text-right">Hires</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.topAgenciesByHitRate.map((row) => (
+                    <tr
+                      key={row.agencyId}
+                      className="border-b border-[var(--color-border)] last:border-0"
+                    >
+                      <td className="py-2 pr-3">
+                        <Link
+                          href={`/dashboard/agencies/${row.agencyId}`}
+                          className="text-[var(--color-fg)] hover:text-blue-400 transition-colors"
+                        >
+                          {row.agencyName}
+                        </Link>
+                      </td>
+                      <td className="py-2 pr-3 text-right font-medium text-emerald-500">
+                        {row.submissionToHirePct.toFixed(1)}%
+                      </td>
+                      <td className="py-2 text-right text-[var(--color-fg-muted)]">
+                        {row.candidatesHired}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/reports/to-csv.ts
+++ b/src/lib/reports/to-csv.ts
@@ -1,0 +1,37 @@
+/**
+ * RFC 4180 CSV serialisation helpers.
+ *
+ * Pure utility — no I/O, no side effects.
+ */
+
+const NEEDS_QUOTING = /[,"\r\n]/
+
+export function escapeCsvField(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  if (value instanceof Date) return value.toISOString()
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+
+  const str = String(value)
+  if (!NEEDS_QUOTING.test(str)) return str
+
+  // Wrap in double-quotes and double any internal double-quotes
+  return `"${str.replace(/"/g, '""')}"`
+}
+
+export function toCsv(
+  rows: Record<string, unknown>[],
+  headers: { key: string; label: string }[],
+): string {
+  const lines: string[] = []
+
+  // Header row
+  lines.push(headers.map((h) => escapeCsvField(h.label)).join(','))
+
+  // Data rows
+  for (const row of rows) {
+    lines.push(headers.map((h) => escapeCsvField(row[h.key])).join(','))
+  }
+
+  // RFC 4180: CRLF line endings, trailing CRLF after final row
+  return lines.join('\r\n') + '\r\n'
+}

--- a/tests/unit/actions/reports.test.ts
+++ b/tests/unit/actions/reports.test.ts
@@ -1,0 +1,462 @@
+/**
+ * Unit tests for src/actions/reports.ts — getReportsFeed()
+ *
+ * Strategy: mock @/db (withTenant) and @/lib/auth/action-context to control
+ * auth state. The withTenant mock receives a fake tx with a chainable select
+ * mock, enabling us to drive each sub-query's return value independently.
+ *
+ * No real DB is touched.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+const TENANT_ID = 'aaaaaaaa-0000-0000-0000-000000000001'
+const ROLE_ID = 'cccccccc-0000-0000-0000-000000000003'
+const AGENCY_ID = 'ffffffff-0000-0000-0000-000000000006'
+
+// ── next/headers mock (required because action-context imports it) ─────────────
+vi.mock('next/headers', () => ({
+  headers: vi.fn().mockResolvedValue({ get: vi.fn().mockReturnValue(null) }),
+}))
+
+// ── DB mock ───────────────────────────────────────────────────────────────────
+const mockSelect = vi.fn()
+
+vi.mock('@/db', () => ({
+  withTenant: vi.fn().mockImplementation(
+    async (_tenantId: string, fn: (tx: unknown) => unknown) =>
+      fn({ select: mockSelect })
+  ),
+}))
+
+// ── action-context mock ───────────────────────────────────────────────────────
+const mockGetActionContext = vi.fn()
+vi.mock('@/lib/auth/action-context', () => ({
+  getActionContext: () => mockGetActionContext(),
+}))
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Chainable Drizzle query mock that resolves to `returnValue` when awaited. */
+function chainableMock(returnValue: unknown) {
+  const m: Record<string, unknown> = {}
+  const methods = [
+    'from', 'where', 'limit', 'offset', 'leftJoin', 'innerJoin',
+    'orderBy', 'returning', 'values', 'set', 'onConflictDoNothing',
+    'onConflictDoUpdate', 'groupBy',
+  ]
+  methods.forEach((method) => {
+    m[method] = vi.fn().mockReturnValue(m)
+  })
+  ;(m as { then: unknown }).then = (resolve: (v: unknown) => unknown) =>
+    Promise.resolve(returnValue).then(resolve)
+  return m
+}
+
+/** Admin context fixture */
+function adminCtx() {
+  return { tenantId: TENANT_ID, userId: 'user-1', userRole: 'admin' as const }
+}
+
+/**
+ * Queue up all mocked select calls in exact order — NO fallback mockReturnValue.
+ *
+ * The function queues exactly the provided returns. Each test must know how many
+ * calls will be made and provide that many return values.
+ *
+ * Parallel batch (13 calls in Promise.all — indices 0-12):
+ *  0.  activeRoles
+ *  1.  candidatesAdded
+ *  2.  candidatesScored
+ *  3.  candidatesHired
+ *  4.  aiSpend
+ *  5.  aiCostTrend
+ *  6.  aiCostLast30
+ *  7.  aiCostPrior30
+ *  8.  rolesOpenOver30
+ *  9.  expiredRoles
+ *  10. stuckInterviewing
+ *  11. agencyCandidates
+ *  12. hiredAudit
+ *
+ * Sequential follow-ups (only executed when the matching ids array is non-empty):
+ *  13. preferredRoles    (if any hiredAudit row has metadata.roleId)
+ *  14. fallbackScores    (if any hiredAudit row lacks metadata.roleId)
+ *  15. fallbackRoles     (if fallbackScores returns non-empty)
+ *  16. customers         (if any resolved role has a non-null customerId)
+ */
+function queueSelectReturns(returns: unknown[][]) {
+  // Use only mockReturnValueOnce — never mockReturnValue — to prevent bleed between tests.
+  let chain: typeof mockSelect = mockSelect
+  for (const rv of returns) {
+    chain = chain.mockReturnValueOnce(chainableMock(rv)) as typeof mockSelect
+  }
+}
+
+/** Minimal all-zeros setup — no follow-up queries needed since hiredAudit is empty. */
+function setupEmptyMocks(opts: { stuckInterviewing?: number } = {}) {
+  queueSelectReturns([
+    [{ count: 0 }],               // 0  activeRoles
+    [{ count: 0 }],               // 1  candidatesAdded
+    [{ count: 0 }],               // 2  candidatesScored
+    [{ count: 0 }],               // 3  candidatesHired
+    [{ total: '0.000000' }],      // 4  aiSpend
+    [],                           // 5  aiCostTrend
+    [{ total: '0.000000' }],      // 6  aiCostLast30
+    [{ total: '0.000000' }],      // 7  aiCostPrior30
+    [{ count: 0 }],               // 8  rolesOpenOver30
+    [{ count: 0 }],               // 9  expiredRoles
+    [{ count: opts.stuckInterviewing ?? 0 }], // 10 stuckInterviewing
+    [],                           // 11 agencyCandidates (empty → no agency map entries)
+    [],                           // 12 hiredAudit (empty → no follow-up queries)
+  ])
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('getReportsFeed()', () => {
+  beforeEach(() => {
+    // clearAllMocks clears call counts and mockReturnValueOnce queues.
+    // It does NOT reset mockImplementation, so withTenant stays wired up.
+    // It does NOT clear mockReturnValue (the non-Once fallback) — but we never
+    // call mockReturnValue in these tests to avoid bleed between tests.
+    vi.clearAllMocks()
+
+    // Re-apply withTenant implementation in case clearAllMocks wiped it.
+    // (vitest clearAllMocks behaviour: clears calls/results but keeps impl.)
+    // Being explicit here prevents any edge case.
+    const { withTenant } = vi.mocked(
+      // We can't call importActual in beforeEach synchronously, so
+      // we re-apply the mock factory directly on the already-mocked module.
+      // The vi.mock at the top keeps the module mocked; clearAllMocks only
+      // wipes call history, not the mockImplementation set in the factory.
+      // This line is intentionally a no-op safety guard:
+      { withTenant: () => {} }
+    )
+    void withTenant
+  })
+
+  // ── Test 1: Admin gating — non-admin role throws ───────────────────────────
+  it('throws for non-admin role (recruiter)', async () => {
+    mockGetActionContext.mockResolvedValueOnce({
+      tenantId: TENANT_ID,
+      userId: 'user-1',
+      userRole: 'recruiter' as const,
+    })
+
+    const { getReportsFeed } = await import('@/actions/reports')
+    await expect(getReportsFeed({ days: 7 })).rejects.toThrow()
+  })
+
+  // ── Test 2: Unauthorized context throws ───────────────────────────────────
+  it('throws when no auth context', async () => {
+    mockGetActionContext.mockResolvedValueOnce(null)
+
+    const { getReportsFeed } = await import('@/actions/reports')
+    await expect(getReportsFeed({ days: 7 })).rejects.toThrow('Unauthorized')
+  })
+
+  // ── Test 3: Days param — returned rangeDays matches input ──────────────────
+  it('returns rangeDays=7 when called with days=7', async () => {
+    mockGetActionContext.mockResolvedValueOnce(adminCtx())
+    setupEmptyMocks()
+
+    const { getReportsFeed } = await import('@/actions/reports')
+    const feed = await getReportsFeed({ days: 7 })
+
+    expect(feed.rangeDays).toBe(7)
+  })
+
+  it('returns rangeDays=90 when called with days=90', async () => {
+    mockGetActionContext.mockResolvedValueOnce(adminCtx())
+    setupEmptyMocks()
+
+    const { getReportsFeed } = await import('@/actions/reports')
+    const feed = await getReportsFeed({ days: 90 })
+
+    expect(feed.rangeDays).toBe(90)
+  })
+
+  // ── Test 4: Empty data — fully-shaped ReportsFeed, no crashes ─────────────
+  it('returns fully-shaped feed with zero counts and null averages when DB returns empty', async () => {
+    mockGetActionContext.mockResolvedValueOnce(adminCtx())
+    setupEmptyMocks()
+
+    const { getReportsFeed } = await import('@/actions/reports')
+    const feed = await getReportsFeed({ days: 30 })
+
+    // KPIs
+    expect(feed.kpis.activeRoles).toBe(0)
+    expect(feed.kpis.candidatesAddedInRange).toBe(0)
+    expect(feed.kpis.candidatesScoredInRange).toBe(0)
+    expect(feed.kpis.candidatesHiredInRange).toBe(0)
+    expect(feed.kpis.aiSpendInRangeUsd).toBe(0)
+
+    // Time-to-fill
+    expect(feed.timeToFill.series).toEqual([])
+    expect(feed.timeToFill.totalRolesFilled).toBe(0)
+    expect(feed.timeToFill.averageDaysOverall).toBeNull()
+    expect(feed.timeToFill.hasLimitedHistoricalData).toBe(true)
+
+    // Agency hit-rate
+    expect(feed.agencyHitRate.series).toEqual([])
+
+    // AI cost trend
+    expect(feed.aiCostTrend.series).toEqual([])
+    expect(feed.aiCostTrend.totalUsd).toBe(0)
+    expect(feed.aiCostTrend.monthOverMonthPct).toBeNull()
+
+    // Cycle health
+    expect(feed.cycleHealth.rolesOpenOver30Days).toBe(0)
+    expect(feed.cycleHealth.expiredRoles).toBe(0)
+    expect(feed.cycleHealth.candidatesStuckInterviewing).toBe(0)
+
+    // Top performers
+    expect(feed.topPerformers.fastestFilledRoles).toEqual([])
+    expect(feed.topPerformers.topAgenciesByHitRate).toEqual([])
+
+    // generatedAt is a Date
+    expect(feed.generatedAt).toBeInstanceOf(Date)
+  })
+
+  // ── Test 5a: hasLimitedHistoricalData=true when matched events < 5 ─────────
+  it('sets hasLimitedHistoricalData=true when matched hire events < 5', async () => {
+    mockGetActionContext.mockResolvedValueOnce(adminCtx())
+
+    // 3 hired audit events, none with roleId in metadata.
+    // needsFallbackIds = [c1, c2, c3] → fallbackScores fires (returns [])
+    // fallbackRoleIds = [] → no fallbackRoles query
+    // allCustomerIds = [] → no customers query
+    const hiredAudit = [
+      { entityId: 'c1', metadata: { newStatus: 'hired' }, createdAt: new Date() },
+      { entityId: 'c2', metadata: { newStatus: 'hired' }, createdAt: new Date() },
+      { entityId: 'c3', metadata: { newStatus: 'hired' }, createdAt: new Date() },
+    ]
+
+    queueSelectReturns([
+      [{ count: 5 }],               // 0  activeRoles
+      [{ count: 10 }],              // 1  candidatesAdded
+      [{ count: 8 }],               // 2  candidatesScored
+      [{ count: 2 }],               // 3  candidatesHired
+      [{ total: '150.000000' }],    // 4  aiSpend
+      [],                           // 5  aiCostTrend
+      [{ total: '80.000000' }],     // 6  aiCostLast30
+      [{ total: '70.000000' }],     // 7  aiCostPrior30
+      [{ count: 3 }],               // 8  rolesOpenOver30
+      [{ count: 1 }],               // 9  expiredRoles
+      [{ count: 0 }],               // 10 stuckInterviewing
+      [],                           // 11 agencyCandidates
+      hiredAudit,                   // 12 hiredAudit (3 rows, no roleId in metadata)
+      // preferredRoleIds = [] → NO preferredRoles query
+      [],                           // 13 fallbackScores (needsFallbackIds = [c1,c2,c3])
+      // fallbackRoleIds = [] → NO fallbackRoles query
+      // allCustomerIds = [] → NO customers query
+    ])
+
+    const { getReportsFeed } = await import('@/actions/reports')
+    const feed = await getReportsFeed({ days: 30 })
+
+    expect(feed.timeToFill.hasLimitedHistoricalData).toBe(true)
+  })
+
+  // ── Test 5b: hasLimitedHistoricalData=false when matched events >= 5 ───────
+  it('sets hasLimitedHistoricalData=false when matched hire events >= 5', async () => {
+    mockGetActionContext.mockResolvedValueOnce(adminCtx())
+
+    const now = Date.now()
+    const roleCreatedAt = new Date(now - 20 * 86_400_000) // 20 days ago
+
+    // 6 hired audit events with roleId directly in metadata (preferred path).
+    // preferredRoleIds = [ROLE_ID] → preferredRoles query fires
+    // needsFallbackIds = [] → NO fallbackScores query
+    // fallbackRoleIds = [] → NO fallbackRoles query
+    // allCustomerIds = [] (customerId: null) → NO customers query
+    const hiredAudit = Array.from({ length: 6 }, (_, i) => ({
+      entityId: `cand-${i}`,
+      metadata: { newStatus: 'hired', roleId: ROLE_ID },
+      createdAt: new Date(now - i * 86_400_000),
+    }))
+
+    const preferredRoles = [
+      {
+        id: ROLE_ID,
+        title: 'Backend Engineer',
+        createdAt: roleCreatedAt,
+        customerId: null,
+      },
+    ]
+
+    queueSelectReturns([
+      [{ count: 5 }],               // 0  activeRoles
+      [{ count: 10 }],              // 1  candidatesAdded
+      [{ count: 8 }],               // 2  candidatesScored
+      [{ count: 2 }],               // 3  candidatesHired
+      [{ total: '150.000000' }],    // 4  aiSpend
+      [],                           // 5  aiCostTrend
+      [{ total: '80.000000' }],     // 6  aiCostLast30
+      [{ total: '70.000000' }],     // 7  aiCostPrior30
+      [{ count: 3 }],               // 8  rolesOpenOver30
+      [{ count: 1 }],               // 9  expiredRoles
+      [{ count: 0 }],               // 10 stuckInterviewing
+      [],                           // 11 agencyCandidates
+      hiredAudit,                   // 12 hiredAudit
+      preferredRoles,               // 13 preferredRoles (preferredRoleIds = [ROLE_ID])
+      // needsFallbackIds = [] → NO fallbackScores
+      // fallbackRoleIds = [] → NO fallbackRoles
+      // allCustomerIds = [] (customerId: null) → NO customers
+    ])
+
+    const { getReportsFeed } = await import('@/actions/reports')
+    const feed = await getReportsFeed({ days: 90 })
+
+    expect(feed.timeToFill.hasLimitedHistoricalData).toBe(false)
+    expect(feed.timeToFill.totalRolesFilled).toBeGreaterThanOrEqual(5)
+  })
+
+  // ── Test 6a: Agency hit-rate: skips agencies with zero submissions ─────────
+  it('agency hit-rate series is empty when no agency candidates in range', async () => {
+    mockGetActionContext.mockResolvedValueOnce(adminCtx())
+    setupEmptyMocks()
+
+    const { getReportsFeed } = await import('@/actions/reports')
+    const feed = await getReportsFeed({ days: 30 })
+
+    expect(feed.agencyHitRate.series).toHaveLength(0)
+  })
+
+  // ── Test 6b: Agency hit-rate computes pcts correctly ──────────────────────
+  it('agency hit-rate computes submission and hire percentages correctly', async () => {
+    mockGetActionContext.mockResolvedValueOnce(adminCtx())
+
+    // Agency: 10 submitted, 2 hired, 3 more in shortlisted/interviewing/offered (= 5 shortlisted total)
+    // submissionToHirePct = 2/10 * 100 = 20
+    // shortlistToHirePct  = 2/5 * 100  = 40
+    const agencyCandidates = [
+      ...Array.from({ length: 2 }, () => ({ agencyId: AGENCY_ID, agencyName: 'Alpha', status: 'hired' })),
+      ...Array.from({ length: 3 }, () => ({ agencyId: AGENCY_ID, agencyName: 'Alpha', status: 'shortlisted' })),
+      ...Array.from({ length: 5 }, () => ({ agencyId: AGENCY_ID, agencyName: 'Alpha', status: 'new' })),
+    ]
+
+    queueSelectReturns([
+      [{ count: 5 }],               // 0  activeRoles
+      [{ count: 10 }],              // 1  candidatesAdded
+      [{ count: 8 }],               // 2  candidatesScored
+      [{ count: 2 }],               // 3  candidatesHired
+      [{ total: '150.000000' }],    // 4  aiSpend
+      [],                           // 5  aiCostTrend
+      [{ total: '80.000000' }],     // 6  aiCostLast30
+      [{ total: '70.000000' }],     // 7  aiCostPrior30
+      [{ count: 3 }],               // 8  rolesOpenOver30
+      [{ count: 1 }],               // 9  expiredRoles
+      [{ count: 0 }],               // 10 stuckInterviewing
+      agencyCandidates,             // 11 agencyCandidates
+      [],                           // 12 hiredAudit (empty → no follow-ups)
+    ])
+
+    const { getReportsFeed } = await import('@/actions/reports')
+    const feed = await getReportsFeed({ days: 30 })
+
+    expect(feed.agencyHitRate.series).toHaveLength(1)
+    const a = feed.agencyHitRate.series[0]
+    expect(a.agencyId).toBe(AGENCY_ID)
+    expect(a.candidatesSubmitted).toBe(10)
+    expect(a.candidatesHired).toBe(2)
+    expect(a.submissionToHirePct).toBe(20)
+    expect(a.shortlistToHirePct).toBeCloseTo(40)
+  })
+
+  // ── Test 7a: Top agencies: filters out agencies with submitted < 3 ─────────
+  it('topAgenciesByHitRate excludes agencies with fewer than 3 submitted candidates', async () => {
+    mockGetActionContext.mockResolvedValueOnce(adminCtx())
+
+    // Only 2 candidates from this agency → below threshold of 3
+    const agencyCandidates = [
+      { agencyId: AGENCY_ID, agencyName: 'Small Agency', status: 'hired' },
+      { agencyId: AGENCY_ID, agencyName: 'Small Agency', status: 'new' },
+    ]
+
+    queueSelectReturns([
+      [{ count: 5 }],               // 0  activeRoles
+      [{ count: 10 }],              // 1  candidatesAdded
+      [{ count: 8 }],               // 2  candidatesScored
+      [{ count: 2 }],               // 3  candidatesHired
+      [{ total: '150.000000' }],    // 4  aiSpend
+      [],                           // 5  aiCostTrend
+      [{ total: '80.000000' }],     // 6  aiCostLast30
+      [{ total: '70.000000' }],     // 7  aiCostPrior30
+      [{ count: 3 }],               // 8  rolesOpenOver30
+      [{ count: 1 }],               // 9  expiredRoles
+      [{ count: 0 }],               // 10 stuckInterviewing
+      agencyCandidates,             // 11 agencyCandidates
+      [],                           // 12 hiredAudit (empty → no follow-ups)
+    ])
+
+    const { getReportsFeed } = await import('@/actions/reports')
+    const feed = await getReportsFeed({ days: 30 })
+
+    // Agency IS in agencyHitRate.series (submitted = 2 > 0)
+    expect(feed.agencyHitRate.series).toHaveLength(1)
+    // But NOT in topAgenciesByHitRate (submitted = 2 < 3)
+    expect(feed.topPerformers.topAgenciesByHitRate).toHaveLength(0)
+  })
+
+  // ── Test 7b: Top agencies: includes agency with submitted >= 3 ─────────────
+  it('topAgenciesByHitRate includes agency with >= 3 submitted candidates', async () => {
+    mockGetActionContext.mockResolvedValueOnce(adminCtx())
+
+    // 5 submitted, 3 hired → qualifies for top-agencies list
+    const agencyCandidates = [
+      { agencyId: AGENCY_ID, agencyName: 'Big Agency', status: 'hired' },
+      { agencyId: AGENCY_ID, agencyName: 'Big Agency', status: 'hired' },
+      { agencyId: AGENCY_ID, agencyName: 'Big Agency', status: 'hired' },
+      { agencyId: AGENCY_ID, agencyName: 'Big Agency', status: 'new' },
+      { agencyId: AGENCY_ID, agencyName: 'Big Agency', status: 'new' },
+    ]
+
+    queueSelectReturns([
+      [{ count: 5 }],               // 0  activeRoles
+      [{ count: 10 }],              // 1  candidatesAdded
+      [{ count: 8 }],               // 2  candidatesScored
+      [{ count: 2 }],               // 3  candidatesHired
+      [{ total: '150.000000' }],    // 4  aiSpend
+      [],                           // 5  aiCostTrend
+      [{ total: '80.000000' }],     // 6  aiCostLast30
+      [{ total: '70.000000' }],     // 7  aiCostPrior30
+      [{ count: 3 }],               // 8  rolesOpenOver30
+      [{ count: 1 }],               // 9  expiredRoles
+      [{ count: 0 }],               // 10 stuckInterviewing
+      agencyCandidates,             // 11 agencyCandidates
+      [],                           // 12 hiredAudit (empty → no follow-ups)
+    ])
+
+    const { getReportsFeed } = await import('@/actions/reports')
+    const feed = await getReportsFeed({ days: 30 })
+
+    expect(feed.topPerformers.topAgenciesByHitRate).toHaveLength(1)
+    expect(feed.topPerformers.topAgenciesByHitRate[0].agencyId).toBe(AGENCY_ID)
+    expect(feed.topPerformers.topAgenciesByHitRate[0].candidatesHired).toBe(3)
+  })
+
+  // ── Test 8: Cycle health stuck candidates ─────────────────────────────────
+  it('cycleHealth.candidatesStuckInterviewing reflects the DB query count', async () => {
+    mockGetActionContext.mockResolvedValueOnce(adminCtx())
+    // DB query (stuckInterviewing) returns count=7 — the action passes this directly
+    setupEmptyMocks({ stuckInterviewing: 7 })
+
+    const { getReportsFeed } = await import('@/actions/reports')
+    const feed = await getReportsFeed({ days: 30 })
+
+    expect(feed.cycleHealth.candidatesStuckInterviewing).toBe(7)
+  })
+
+  it('cycleHealth.candidatesStuckInterviewing is 0 when no stuck candidates', async () => {
+    mockGetActionContext.mockResolvedValueOnce(adminCtx())
+    setupEmptyMocks()
+
+    const { getReportsFeed } = await import('@/actions/reports')
+    const feed = await getReportsFeed({ days: 30 })
+
+    expect(feed.cycleHealth.candidatesStuckInterviewing).toBe(0)
+  })
+})

--- a/tests/unit/api/reports-csv-route.test.ts
+++ b/tests/unit/api/reports-csv-route.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Mocks — must be declared before any imports that transitively load them ───
+
+vi.mock('@/lib/auth', () => ({ auth: vi.fn() }))
+vi.mock('@/actions/reports', () => ({ getReportsFeed: vi.fn() }))
+
+// ── Import subjects after mocks ───────────────────────────────────────────────
+
+import { GET } from '@/app/api/reports/[metric]/csv/route'
+import { auth } from '@/lib/auth'
+import { getReportsFeed } from '@/actions/reports'
+import type { ReportsFeed } from '@/actions/reports'
+
+const mockAuth = vi.mocked(auth)
+const mockFeed = vi.mocked(getReportsFeed)
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const ADMIN_SESSION = {
+  user: { tenantId: 't1', role: 'admin' as const },
+  expires: '2099-01-01',
+}
+
+const RECRUITER_SESSION = {
+  user: { tenantId: 't1', role: 'recruiter' as const },
+  expires: '2099-01-01',
+}
+
+/** Minimal valid ReportsFeed that satisfies all switch branches */
+const MINIMAL_FEED: ReportsFeed = {
+  rangeDays: 30,
+  generatedAt: new Date('2026-04-28T00:00:00Z'),
+  kpis: {
+    activeRoles: 0,
+    candidatesAddedInRange: 0,
+    candidatesScoredInRange: 0,
+    candidatesHiredInRange: 0,
+    aiSpendInRangeUsd: 0,
+  },
+  timeToFill: {
+    series: [{ customerName: 'Acme', avgDaysToFill: 14, rolesFilled: 2 }],
+    totalRolesFilled: 2,
+    averageDaysOverall: 14,
+    hasLimitedHistoricalData: true,
+  },
+  agencyHitRate: {
+    series: [
+      {
+        agencyId: 'a1',
+        agencyName: 'TopTalent',
+        candidatesSubmitted: 10,
+        candidatesShortlisted: 4,
+        candidatesHired: 2,
+        submissionToHirePct: 20,
+        shortlistToHirePct: 50,
+      },
+    ],
+  },
+  aiCostTrend: {
+    series: [{ date: '2026-04-01', costUsd: 1.23, calls: 5 }],
+    totalUsd: 1.23,
+    monthOverMonthPct: null,
+  },
+  cycleHealth: {
+    rolesOpenOver30Days: 3,
+    expiredRoles: 1,
+    candidatesStuckInterviewing: 2,
+  },
+  topPerformers: {
+    fastestFilledRoles: [
+      { roleId: 'r1', roleTitle: 'SRE', daysToFill: 7, customerName: 'Acme' },
+    ],
+    topAgenciesByHitRate: [
+      { agencyId: 'a1', agencyName: 'TopTalent', submissionToHirePct: 20, candidatesHired: 2 },
+    ],
+  },
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeReq(url: string): Request {
+  return new Request(url)
+}
+
+function makeParams(metric: string): { params: Promise<{ metric: string }> } {
+  return { params: Promise.resolve({ metric }) }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('GET /api/reports/[metric]/csv', () => {
+  it('returns 401 when there is no session', async () => {
+    mockAuth.mockResolvedValue(null as never)
+    const res = await GET(
+      makeReq('http://localhost/api/reports/time-to-fill/csv?range=30d'),
+      makeParams('time-to-fill'),
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 when the session role is recruiter', async () => {
+    mockAuth.mockResolvedValue(RECRUITER_SESSION as never)
+    const res = await GET(
+      makeReq('http://localhost/api/reports/time-to-fill/csv?range=30d'),
+      makeParams('time-to-fill'),
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 200 with correct Content-Type for time-to-fill', async () => {
+    mockAuth.mockResolvedValue(ADMIN_SESSION as never)
+    mockFeed.mockResolvedValue(MINIMAL_FEED)
+    const res = await GET(
+      makeReq('http://localhost/api/reports/time-to-fill/csv?range=30d'),
+      makeParams('time-to-fill'),
+    )
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('text/csv; charset=utf-8')
+  })
+
+  it('returns the expected header row for time-to-fill', async () => {
+    mockAuth.mockResolvedValue(ADMIN_SESSION as never)
+    mockFeed.mockResolvedValue(MINIMAL_FEED)
+    const res = await GET(
+      makeReq('http://localhost/api/reports/time-to-fill/csv?range=30d'),
+      makeParams('time-to-fill'),
+    )
+    const body = await res.text()
+    expect(body.startsWith('customerName,avgDaysToFill,rolesFilled\r\n')).toBe(true)
+  })
+
+  it('returns 404 for an unknown metric', async () => {
+    mockAuth.mockResolvedValue(ADMIN_SESSION as never)
+    mockFeed.mockResolvedValue(MINIMAL_FEED)
+    const res = await GET(
+      makeReq('http://localhost/api/reports/fish/csv?range=30d'),
+      makeParams('fish'),
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 400 for an invalid range value', async () => {
+    mockAuth.mockResolvedValue(ADMIN_SESSION as never)
+    const res = await GET(
+      makeReq('http://localhost/api/reports/time-to-fill/csv?range=random'),
+      makeParams('time-to-fill'),
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('defaults to 30 days when range param is missing', async () => {
+    mockAuth.mockResolvedValue(ADMIN_SESSION as never)
+    mockFeed.mockResolvedValue(MINIMAL_FEED)
+    await GET(
+      makeReq('http://localhost/api/reports/time-to-fill/csv'),
+      makeParams('time-to-fill'),
+    )
+    expect(mockFeed).toHaveBeenCalledWith({ days: 30 })
+  })
+
+  it('returns 200 for all five valid metrics', async () => {
+    mockAuth.mockResolvedValue(ADMIN_SESSION as never)
+    mockFeed.mockResolvedValue(MINIMAL_FEED)
+
+    const metrics = [
+      'time-to-fill',
+      'agency-hit-rate',
+      'ai-cost-trend',
+      'cycle-health',
+      'top-performers',
+    ]
+
+    for (const metric of metrics) {
+      const res = await GET(
+        makeReq(`http://localhost/api/reports/${metric}/csv?range=30d`),
+        makeParams(metric),
+      )
+      expect(res.status, `Expected 200 for metric "${metric}"`).toBe(200)
+    }
+  })
+})

--- a/tests/unit/lib/reports/to-csv.test.ts
+++ b/tests/unit/lib/reports/to-csv.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { escapeCsvField, toCsv } from '@/lib/reports/to-csv'
+
+describe('escapeCsvField', () => {
+  it('returns plain string unchanged', () => {
+    expect(escapeCsvField('hello')).toBe('hello')
+  })
+
+  it('wraps a string containing a comma in double-quotes', () => {
+    expect(escapeCsvField('a,b')).toBe('"a,b"')
+  })
+
+  it('wraps and doubles internal double-quotes', () => {
+    expect(escapeCsvField('she said "hi"')).toBe('"she said ""hi"""')
+  })
+
+  it('wraps a string containing a newline in double-quotes', () => {
+    const result = escapeCsvField('multi\nline')
+    expect(result.startsWith('"')).toBe(true)
+    expect(result.endsWith('"')).toBe(true)
+    expect(result).toContain('multi\nline')
+  })
+
+  it('returns empty string for null', () => {
+    expect(escapeCsvField(null)).toBe('')
+  })
+
+  it('returns empty string for undefined', () => {
+    expect(escapeCsvField(undefined)).toBe('')
+  })
+
+  it('coerces numbers to string', () => {
+    expect(escapeCsvField(42)).toBe('42')
+  })
+
+  it('coerces a Date to ISO string', () => {
+    expect(escapeCsvField(new Date('2026-04-28T12:00:00Z'))).toBe(
+      '2026-04-28T12:00:00.000Z',
+    )
+  })
+})
+
+describe('toCsv', () => {
+  it('produces only the header row + CRLF for empty data', () => {
+    const result = toCsv([], [{ key: 'a', label: 'A' }])
+    expect(result).toBe('A\r\n')
+  })
+
+  it('produces header + data row correctly', () => {
+    const result = toCsv(
+      [{ a: 'x', b: 'y' }],
+      [{ key: 'a', label: 'A' }, { key: 'b', label: 'B' }],
+    )
+    expect(result).toBe('A,B\r\nx,y\r\n')
+  })
+
+  it('round-trips a field with a comma and preserves the value', () => {
+    const rows = [{ name: "O'Reilly, Inc." }]
+    const csv = toCsv(rows, [{ key: 'name', label: 'Name' }])
+    // Split on CRLF and take the data row; naive unquote
+    const dataRow = csv.split('\r\n')[1]
+    // The value is wrapped in quotes; stripping them recovers the original
+    const unquoted = dataRow.replace(/^"|"$/g, '').replace(/""/g, '"')
+    expect(unquoted).toBe("O'Reilly, Inc.")
+  })
+
+  it('escapes header labels that contain special chars', () => {
+    const result = toCsv([], [{ key: 'x', label: 'Col,"A"' }])
+    expect(result).toBe('"Col,""A"""\r\n')
+  })
+})


### PR DESCRIPTION
## Summary

Closes #76. Admin-only `/dashboard/reports` page with five chart areas + CSV export per chart.

## What landed

**Chart areas** (each in its own card with Export CSV button):

1. **KPI strip** — 5 cards: active roles, candidates added in range, candidates scored in range, hires in range, AI spend in range
2. **Cycle health** — roles open >30d (amber), expired roles (red), candidates stuck in interviewing >14d (red); each links to a filtered list
3. **AI cost trend** — LineChart with month-over-month delta
4. **Agency hit-rate** — BarChart with two series (Submission→Hire %, Shortlist→Hire %), custom tooltip showing raw counts
5. **Time-to-fill (by customer)** — BarChart with limited-historical-data footnote where applicable
6. **Top performers** — two side-by-side tables (Roles closed fastest, Top agencies by hit-rate)

**Date range** — `?range=7d|30d|90d|12mo` URL search-param drives state. Default 30d. Preset button row in the page header.

**Admin gating** at three layers: sidebar nav (`minRole: 'admin'`), page renders an "Admin access required" panel for non-admins, server action enforces `requireRole(_, 'admin')`.

**CSV export** — `/api/reports/{metric}/csv?range={Nd}`. RFC 4180 compliant escaping. Five metrics: `time-to-fill`, `agency-hit-rate`, `ai-cost-trend`, `cycle-health`, `top-performers`. The `top-performers` CSV ships two labelled sections in one file (fastest roles + top agencies).

## Design notes

- **Real-time queries.** No snapshot table, no cron job — five aggregations run in parallel inside one `withTenant()` call. v1 data volumes are well within real-time budget; snapshot infrastructure is deferred.
- **Time-to-fill derivation.** No `roles.filled_at` column today. Uses `audit_logs.action='candidate.status_changed' AND metadata->>'newStatus'='hired'` joined to `scores` as a bridge to the role. Ships with a footnote when matched events are sparse. Future PR can populate `metadata.roleId` when status change has role context, making the join exact.
- **Stuck candidates.** Uses `candidates.statusConfirmedAt` (cleaner than the audit-log subquery in the original plan — column is reliably set on transition).
- **Two hit-rate metrics.** "Hit-rate" is ambiguous; chart shows both Submission→Hire and Shortlist→Hire side-by-side so the funnel position is explicit.
- **CSV approach.** No third-party library. ~37-line RFC 4180 helper handles all escaping (commas, quotes, newlines, unicode, null, dates) — covered by 12 unit tests.

## Files

| File | Status | Lines |
|---|---|---|
| `src/actions/reports.ts` | NEW | 614 |
| `src/app/(dashboard)/dashboard/reports/page.tsx` | NEW | 100 |
| `src/app/api/reports/[metric]/csv/route.ts` | NEW | 132 |
| `src/components/reports/agency-hit-rate-chart.tsx` | NEW | 127 |
| `src/components/reports/ai-cost-trend-chart.tsx` | NEW | 106 |
| `src/components/reports/cycle-health-panel.tsx` | NEW | 76 |
| `src/components/reports/date-range-presets.tsx` | NEW | 33 |
| `src/components/reports/kpi-card.tsx` | NEW | 33 |
| `src/components/reports/time-to-fill-chart.tsx` | NEW | 112 |
| `src/components/reports/top-performers-tables.tsx` | NEW | 126 |
| `src/lib/reports/to-csv.ts` | NEW | 37 |
| `src/components/layout/sidebar.tsx` | EDIT | +2 |
| `tests/unit/actions/reports.test.ts` | NEW | 462 |
| `tests/unit/api/reports-csv-route.test.ts` | NEW | (8 tests) |
| `tests/unit/lib/reports/to-csv.test.ts` | NEW | (12 tests) |

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] New tests: 33 passed (13 aggregator + 12 csv-helper + 8 csv-route)
- [x] Full vitest suite: 377 passed (12 pre-existing failures unchanged)
- [ ] Post-merge manual smoke:
  - [ ] Admin login → `/dashboard/reports` shows all sections at 30d default
  - [ ] Click 7d / 90d / 12mo → URL updates, page re-renders with new range
  - [ ] Click Export CSV on each card → file downloads with correct headers + `attachment` filename
  - [ ] Recruiter login → sidebar hides Reports; visiting URL directly shows "Admin access required"
  - [ ] Empty tenant → no crashes, panels show "No data for this range"

## Out of scope (v2)

- Snapshot / cache table + nightly cron (deferred — real-time is fine for current volumes)
- Custom date-range picker (preset buttons cover v1)
- Cross-tenant aggregation for super-admin (per-tenant only)
- Per-recruiter performance breakdown (no `recruiter_id` on candidates today)
- Cohort / funnel charts
- Email-scheduled report digests
- Future: populate `roleId` in `candidate.status_changed` audit metadata so time-to-fill becomes exact rather than score-bridged for new roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)