### PR TITLE
docs: roadmap + 4 new help articles for today's shipped features

### DIFF
--- a/.agent-os/product/roadmap.md
+++ b/.agent-os/product/roadmap.md
@@ -1,8 +1,8 @@
 # Product Roadmap
 
 > Last Updated: 2026-04-28
-> Version: 2.5.0
-> Status: Phases 1–4 shipped; Phase 5 partial (health endpoint now shipped); Hiring Manager persona shipped (Epic #73); in-app help, branding logos, candidate-list cleanup, and light/dark mode v1 shipped; REST API parity, API token system, per-tenant rate limiting, and MCP server (Epic #105) shipped; cross-platform `skillai-mcp` packaging (Epic #115) shipped; GDPR right-to-erasure + DSAR export shipped (#75); daily-active recruiter dashboard shipped (#84); further integrations tracked on GitHub
+> Version: 2.6.0
+> Status: Phases 1–4 shipped; Phase 5 substantially advanced (Epic #72 children #75/#84/#76/#79/#81/#82 all shipped); Hiring Manager persona shipped (Epic #73); in-app help, branding logos, candidate-list cleanup, and light/dark mode v1 shipped; REST API parity, API token system, per-tenant rate limiting, and MCP server (Epic #105) shipped; cross-platform `skillai-mcp` packaging (Epic #115) shipped; GDPR right-to-erasure + DSAR export shipped (#75); daily-active recruiter dashboard shipped (#84); leadership reporting dashboard shipped (#76); calendar 2-way pull-sync shipped (#79); per-tenant Calendar OAuth credentials UI shipped; admin tenant data export (JSON ZIP, optional binaries, per-entity CSVs) shipped (#81 + #82); further integrations tracked on GitHub
 
 ## Phase 1: Foundation & Core MVP ✅ SHIPPED
 
@@ -215,6 +215,46 @@ Features delivered mid-flight, not in the original v1.0.0 plan.
 - [x] **Per-stream caps + parallel queries** — each widget capped at 5 items; all five sub-queries run in parallel inside a single `withTenant()` call. Zero schema changes.
 - [x] **All-empty collapse** — when every stream is empty, the section renders a single "Nothing on your plate today." panel rather than five empty boxes; per-widget empty states hide the widget entirely.
 - [x] **Personalisation model** — hiring-managers see only their `role_managers` rows; recruiters see tenant-wide items (no recruiter-ownership / role-assignment model exists today; introducing one is deferred to a future epic).
+
+### Leadership Reporting Dashboard (Epic #72, PR #132 — closes #76)
+
+- [x] **`/dashboard/reports` admin-only page** — five chart areas + KPI cards. Chart areas: time-to-fill (per customer), agency hit-rate (Submission→Hire and Shortlist→Hire side-by-side), AI cost trend (LineChart with month-over-month delta), cycle health (roles >30d / expired / stuck-in-interviewing), top performers (fastest-filled roles + agencies by hit-rate).
+- [x] **Date-range presets** — `?range=7d|30d|90d|12mo` URL search-param drives state; default 30d; preset button row in the page header.
+- [x] **Per-chart CSV export** — every card has an "Export CSV" button → streams via `/api/reports/{metric}/csv` using a new RFC 4180 helper at `src/lib/reports/to-csv.ts`. Five metrics: time-to-fill, agency-hit-rate, ai-cost-trend, cycle-health, top-performers (the latter ships two labelled sections in one CSV).
+- [x] **Real-time aggregation** — five sub-queries run in parallel inside a single `withTenant()` call; no snapshot/cron infrastructure (deferred). Time-to-fill derived via audit-log + scores join (limited-historical-data footnote when matched events are sparse).
+- [x] **Three-layer admin gate** — sidebar nav `minRole: admin`, page server-component check, server action `requireRole(_, 'admin')`.
+
+### Calendar 2-Way Sync (Epic #72, PR #133 — closes #79)
+
+- [x] **Pull-side sync loop** — `/api/cron/calendar-sync` (Bearer-secret gated via `CRON_SECRET`) polls each connected calendar, compares events to `interview_slots`, applies the diff. Detects reschedules → updates `slot.scheduledAt` + audit `interview_slot.rescheduled_external`; detects cancellations → marks slot cancelled + audit `interview_slot.cancelled_external`. Read-only on calendar side — never modifies / deletes calendar events.
+- [x] **`listGoogleEvents` + `listMicrosoftEvents`** — new helpers mirror the existing auto-refresh-on-401 pattern from outbound event creation. Refreshed accessToken is re-encrypted and persisted back to `calendar_connections`.
+- [x] **Conflict resolution** — if `slot.updatedAt > event.updated`, SkillAi-side edit wins (sync skips that slot for this run). Avoids overwriting recruiter edits made just before sync fires.
+- [x] **Per-connection isolation** — try/catch per connection; one expired refresh token doesn't break the run for other users. Failures captured in the response and audited as `calendar.sync_failed`.
+- [x] **Time window** — `[now − 1d, now + 30d]`. Past events outside window skipped.
+- [x] **External scheduler** — host crontab / GitHub Actions / k8s CronJob calls the endpoint every 15 min; SkillAi has no in-process scheduler.
+
+### Per-Tenant Calendar OAuth Credentials (PR #134 + #135)
+
+- [x] **Documentation** — new help article `settings-oauth-credentials.md` walks tenant admins through Google Cloud Console + Azure Portal app setup with the redirect-URI gotcha called out hard. `docs/setup.md` env-var reference table corrected.
+- [x] **Per-tenant credentials in `tenant_settings`** — five new keys (`google_oauth_client_id`, `google_oauth_client_secret`, `microsoft_oauth_client_id`, `microsoft_oauth_client_secret`, `microsoft_oauth_tenant_id`), all encrypted via AES-256-GCM. Resolution order: tenant_settings → env var → 503. Existing self-hosted single-tenant deployments continue to work via env vars.
+- [x] **Admin-only UI** — new "Calendar OAuth Credentials" card on `/settings`, between "General Settings" and "Default Pack Language". Mirrors the masking + show/hide / Replace pattern of `ApiKeyField`.
+- [x] **Two new audit actions** — `settings.oauth_credentials_updated`, `settings.oauth_credentials_removed`. Audit metadata records `{ provider, field }` only — never the secret value.
+
+### Admin Backups & Data Export (Epic #72, PRs #136 + #137 — closes #81)
+
+- [x] **`/settings` "Backups & Data Export" admin card** — shows last manual export timestamp pulled from audit_logs (action `tenant.exported`); "Download tenant export now" button streams a ZIP with one JSON file per tenant-scoped table (25 tables) + manifest.json. Three-layer admin gate.
+- [x] **60-second rate limit per tenant** — enforced via `MAX(createdAt)` audit-log query; 429 with `Retry-After` header when exceeded.
+- [x] **Optional binary file inclusion (PR #137)** — opt-in checkbox toggles `?files=1`; when set, the ZIP gains a `files/` directory with original CV PDFs, agency / customer logos, and role attachments. Filename gets a `-with-files` suffix. Default off (preserves the JSON-only behaviour for users who don't want a 100MB+ download).
+- [x] **Defence-in-depth path-traversal guard** — every absolute path is checked against `${tenantUploadRoot}/` before any filesystem access; cross-tenant paths skipped + recorded in `manifest.skippedFiles[]` with reason `path-outside-tenant`. Unit test asserts `fs.stat` is NOT invoked for blocked paths.
+- [x] **Missing-file handling** — ENOENT / EACCES → skipped + recorded in `manifest.skippedFiles[]`; export does NOT fail on individual file errors.
+
+### Per-Entity CSV Exports (Epic #72, PR #138 — closes #82)
+
+- [x] **`/settings` "Per-Entity CSV Exports" admin card** — four download buttons: Candidates, Roles, AI Scores, Agencies. Each emits an RFC 4180 CSV scoped to the current tenant via `/api/export/tenant/csv/[entity]`.
+- [x] **Single dynamic route** — typed allow-list `['candidates', 'roles', 'scores', 'agencies']`; unknown entity → 404; non-admin → 403.
+- [x] **Heavy columns excluded** — `cvText` / `cvTextFormatted` / `embedding` / `synechronCvData` from candidates; `description` / `requirements` from roles; reasoning text fields from scores. Full data remains in the JSON tenant export above; CSVs are spreadsheet-friendly.
+- [x] **New audit action** — `tenant.csv_exported` with metadata `{ entity, rowCount }`.
+- [x] **Greenhouse / Lever / Workday formats deferred** — separate issue when there's customer demand.
 
 ---
 

--- a/src/content/help/admin-gdpr-erasure.md
+++ b/src/content/help/admin-gdpr-erasure.md
@@ -1,0 +1,83 @@
+---
+title: "GDPR right-to-erasure (deleting a candidate)"
+category: "Settings & Admin"
+audience: ["admin"]
+order: 55
+lastUpdated: "2026-04-28"
+tags: ["gdpr", "privacy", "compliance", "deletion", "right-to-erasure"]
+---
+
+# GDPR right-to-erasure (deleting a candidate)
+
+Under GDPR Article 17 ("right to erasure"), individuals can request that you delete their personal data. SkillAi provides a hard-delete flow for this purpose, distinct from the soft-archive flow used in routine recruiting. This page covers what gets deleted, what is retained for audit purposes, and how to fulfil a Subject Access Request alongside.
+
+## Where to find it
+
+Open any candidate detail page (admin only). Scroll to the bottom — there is a **GDPR Actions** panel with two buttons:
+
+- **Export all data (DSAR)** — Article 15 right of access
+- **Delete candidate (GDPR)** — Article 17 right to erasure
+
+Both actions require admin role. Recruiters and hiring managers do not see the panel.
+
+## What gets deleted
+
+The candidate row and **all** related data:
+
+- `scores` — every AI scoring result for this candidate
+- `notes` — recruiter notes on the candidate
+- `candidate_enrichments` — AI-enriched profile data
+- `cv_profiles` — structured CV profiles
+- `candidate_role_approvals` — hiring manager approval decisions
+- `sent_emails` — outbound emails to or about the candidate
+- `interview_packs` — generated interview packs
+- `interview_questions` — individual interview questions
+- `code_challenges` — code challenges linked to this candidate
+- `interview_slots` — scheduled interview slots
+- `interview_transcripts` — uploaded interview transcripts
+- `transcript_analyses` — AI analysis results
+
+The CV file on disk is also unlinked. After the operation completes, no part of the candidate's personal data exists in SkillAi.
+
+## What gets RETAINED (with PII redacted)
+
+`audit_logs` rows referencing this candidate are retained. The actor, action, and timestamp survive — this is required for accountability under GDPR Article 5(2) and Article 30 — but the personal data is replaced:
+
+- `entityLabel` becomes `[redacted-gdpr]`
+- `metadata` becomes `{ "redacted_gdpr": true, "redacted_at": "<iso-timestamp>" }`
+
+A tombstone row is also written: `audit_logs.action = 'candidate.deleted_gdpr'` recording who triggered the erasure and when. This proves the deletion happened without re-introducing the very PII you just deleted.
+
+## The typed-name confirmation
+
+Before the delete fires, you must type the candidate's **full name exactly**. The match is case-sensitive and whitespace-sensitive. This is deliberate friction — GDPR erasure is irreversible and the typed-name check prevents an accidental click from destroying data you cannot recover.
+
+## DSAR export (Article 15 — right of access)
+
+The **Export all data (DSAR)** button is a separate, also admin-only action. It generates a single ZIP containing:
+
+- 11 JSON files — one per table referencing this candidate (scores, notes, enrichments, audit log, sent emails, interview packs, code challenges, interview slots, transcripts, analyses, plus the candidate row itself)
+- The original CV file as it was uploaded
+- A `README.txt` cover letter explaining each file in plain language, suitable to forward to the data subject
+
+Use this to fulfil a Subject Access Request. The DSAR export does not delete anything — it is read-only. If the data subject requests both access and erasure, run DSAR first, send them the ZIP, then run the delete.
+
+## What this does NOT do
+
+- **Does not delete data from external systems** — your email server, calendar provider, ATS, or anywhere else you have shared the candidate's data downstream. You must clean those up separately. The DSAR cover letter is a useful checklist for downstream cleanup.
+- **Does not delete the operator-level database backup** (`pg_dump` snapshots). The candidate's data will live on in your backups until those backups expire under your retention policy. GDPR allows reasonable backup retention windows; document yours.
+- **Does not delete derived statistics** — aggregated metrics (e.g. "30 candidates added in March") that no longer reference the individual.
+
+## Audit and accountability
+
+Every GDPR delete and every DSAR export is itself audit-logged with:
+
+- Actor (which admin pressed the button)
+- Timestamp
+- Which candidate ID was affected (kept on the audit row only — the candidate row itself is gone)
+
+Use the audit log to demonstrate compliance to your DPO or to a regulator. The tombstone audit row is the proof you fulfilled the request.
+
+## Related articles
+
+- [Backups and data export](/dashboard/help/settings-backups-data-export) — tenant-wide ZIP export, useful for compliance archival

--- a/src/content/help/calendar-sync-and-reschedules.md
+++ b/src/content/help/calendar-sync-and-reschedules.md
@@ -1,0 +1,76 @@
+---
+title: "Calendar sync — outbound + pull updates"
+category: "Settings & Admin"
+audience: ["admin", "recruiter"]
+order: 65
+lastUpdated: "2026-04-28"
+tags: ["calendar", "google calendar", "outlook", "interviews", "sync"]
+---
+
+# Calendar sync — outbound + pull updates
+
+When a recruiter creates an interview slot in SkillAi with **Sync to calendar** ticked, the event is pushed to the connected Google or Outlook calendar (outbound). A new periodic sync also pulls reschedules and cancellations from the calendar back into SkillAi (pull side), so a meeting moved in your calendar app updates the slot in SkillAi automatically.
+
+## Outbound sync (existing behaviour)
+
+Happens on slot create and slot update. SkillAi calls the Google Calendar or Microsoft Graph API and stores the resulting event ID in `interview_slots.googleEventId` or `interview_slots.microsoftEventId`. Slot deletion in SkillAi triggers event deletion in the calendar.
+
+This has been the behaviour since the calendar OAuth integration shipped. Nothing changes here.
+
+## Pull sync (new in this PR)
+
+A periodic job, every 15 minutes by default, calls the `/api/cron/calendar-sync` endpoint. The endpoint is invoked by an external scheduler — host cron, GitHub Actions, a Kubernetes CronJob, whatever your deployment uses. The sync:
+
+1. Fetches events in the window `[now − 1d, now + 30d]` from each connected calendar.
+2. Compares the events to the matching `interview_slots` rows.
+3. **Reschedule detected** (event start or end timestamp changed) → updates `slot.scheduledAt` and writes an audit row `interview_slot.rescheduled_external`.
+4. **Cancellation detected** (event missing from the response, or `status = 'cancelled'`) → marks the slot `cancelled` and writes an audit row `interview_slot.cancelled_external`.
+
+The audit rows make it obvious which changes came from external calendars rather than from a recruiter editing in SkillAi.
+
+## Conflict resolution
+
+If you edited the slot in SkillAi *after* the calendar event's `updated` timestamp, SkillAi wins for that sync run — the pull sync will not overwrite your change. The next outbound sync (triggered by your edit) will push your version to the calendar, bringing the two sides back into agreement.
+
+This means the rule is simple: **whoever edited last wins**, with SkillAi as the tiebreaker on the same-second edge case.
+
+## What pull sync does NOT do
+
+- **Never modifies or deletes calendar events.** The pull side is read-only against the calendar provider.
+- **Never imports calendar events that weren't created by SkillAi.** A meeting you create directly in Google Calendar or Outlook does not become an interview slot. The sync only touches slots whose `googleEventId` or `microsoftEventId` matches an event in the response.
+- **Never recreates a slot you deleted in SkillAi.** Once a slot is gone from `interview_slots`, the pull sync ignores its calendar event entirely.
+
+## Where to set the cron
+
+The deployment operator is responsible for wiring `/api/cron/calendar-sync` to a scheduler. The endpoint requires an `Authorization` header:
+
+```
+Authorization: Bearer ${CRON_SECRET}
+```
+
+Example invocation:
+
+```
+curl -X POST https://your-deployment.example.com/api/cron/calendar-sync \
+     -H "Authorization: Bearer $CRON_SECRET"
+```
+
+The endpoint returns JSON describing the result of each connection's sync run. Failures per connection are isolated — one tenant's expired refresh token does not stop another tenant's sync from completing. The JSON response surfaces which connections failed and why.
+
+Recommended cadence is every 15 minutes. Faster than that risks bumping into Google's and Microsoft Graph's per-minute quotas; slower than that means rescheduled meetings may not reflect in SkillAi for up to your interval.
+
+## Cross-link to OAuth setup
+
+To use any of this, your tenant first needs Google or Microsoft OAuth credentials configured. See [Calendar OAuth credentials (Google + Microsoft)](/dashboard/help/settings-oauth-credentials) in this same category.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Resolution |
+|---|---|---|
+| Sync returns `401 Unauthorized` | Missing or wrong `CRON_SECRET` in the calling scheduler | Set the env var on both sides; the values must match exactly |
+| One connection's sync reports `invalid_grant` | The user's refresh token has been revoked (e.g. they changed their Google password) | Have the user disconnect and reconnect their calendar from `/settings` |
+| Sync runs but finds no events on a connection that should have some | Wrong `calendar_id` saved on the connection (Google defaults to `primary`); or the user authorised a different account than they expected | Inspect `calendar_connections` for the row; have the user reconnect if needed |
+| Reschedule appears not to have applied | The event was updated within the same second as a SkillAi-side edit; SkillAi won the tiebreaker | Re-run the sync; or edit the slot in SkillAi to match |
+| Hitting Google or Microsoft Graph rate limits | Cron interval is too aggressive, or you have a very large number of connected calendars | Increase the cron interval to 30 minutes; both providers' quotas are well within typical use at 15-minute cadence |
+
+Stale tokens (token close to expiry) refresh automatically when sync runs — you do not need to handle this case manually.

--- a/src/content/help/dashboard-for-you-section.md
+++ b/src/content/help/dashboard-for-you-section.md
@@ -1,0 +1,51 @@
+---
+title: "Your \"For you\" dashboard section"
+category: "Getting Started"
+audience: ["recruiter", "hiring_manager", "admin"]
+order: 25
+lastUpdated: "2026-04-28"
+tags: ["dashboard", "for-you", "daily"]
+---
+
+# Your "For you" dashboard section
+
+At the top of `/dashboard`, the "For you" section surfaces five action streams personalised to you. It is designed to answer **"what should I do right now?"** — not "what is the state of the world?". If a panel is empty, you have nothing waiting in that lane.
+
+## The five widgets
+
+Each widget caps at five items so that the section remains scannable. Click through to the linked entity to act on the item.
+
+### Interviews today + tomorrow
+
+Pending interview slots scheduled in the next 48 hours. Cancelled and completed slots are excluded. Use this to confirm your day's schedule at a glance and click into a slot to see the interview pack and candidate context.
+
+### Candidates awaiting score
+
+Candidates uploaded in the last 7 days whose score is still `pending` or `processing`. If anything has been stuck here for more than a few minutes, the AI scoring job has likely failed — open the candidate and re-run scoring from the role detail page.
+
+### Roles with stale priorities
+
+Roles where the priority keywords were updated more recently than at least one candidate's score on that role. Click into the role to re-score the affected candidates against the updated priorities. Stale priorities mean the ranking you are looking at does not yet reflect what you said matters.
+
+### Expired roles
+
+Roles where `cutoffDate < today` AND `isActive = true`. SkillAi never auto-archives a role on cut-off (see decision DEC-008) — you decide whether to extend the deadline or archive it. The widget exists so expired roles do not silently rot at the bottom of your roles list.
+
+### Awaiting your approval
+
+Renders only if your role is `hiring_manager`. Pending approval decisions across roles assigned to you (`role_managers`). Click through to the role's manager view to approve, reject, or request more info per candidate.
+
+## Empty state
+
+When all five widgets are empty, the section collapses to a single "Nothing on your plate today." panel. That is the goal — an empty "For you" section means you are caught up.
+
+## Per-role scope notes
+
+- **Hiring managers** see only their assigned roles' approval requests, and only the approval widget. Other widgets are tenant-wide and may not be relevant.
+- **Recruiters and admins** see tenant-wide items across all five widgets. There is no per-recruiter ownership model in v1 — every recruiter sees every role.
+
+## Tips
+
+- Refresh the page to pick up new items. Widgets render on every server-side load; there is no client-side polling.
+- The five widgets run their queries in parallel inside one DB transaction, so the section adds milliseconds to the dashboard load — not seconds.
+- If a widget is showing data you do not expect (e.g. a role you thought you archived), check the audit log on that entity — something may have changed it after you last looked.

--- a/src/content/help/dashboard-reports.md
+++ b/src/content/help/dashboard-reports.md
@@ -1,0 +1,83 @@
+---
+title: "Reports dashboard"
+category: "Settings & Admin"
+audience: ["admin"]
+order: 50
+lastUpdated: "2026-04-28"
+tags: ["reports", "analytics", "csv", "time-to-fill", "agency-hit-rate"]
+---
+
+# Reports dashboard
+
+Admin-only `/dashboard/reports` page with five chart areas. Click **Reports** in the sidebar to open it. Use it to answer "how is the recruiting operation actually performing?" — cycle health, AI spend, agency value, time-to-fill.
+
+## Date-range presets
+
+The page is URL-driven, so links are shareable.
+
+```
+?range=7d
+?range=30d
+?range=90d
+?range=12mo
+```
+
+Default is `30d` if no range is specified. Switch ranges from the toggle at the top of the page or by editing the URL directly.
+
+## The five chart areas
+
+### KPI strip
+
+Five at-a-glance numbers across the top: active roles, candidates added (in range), candidates scored, hires, and AI spend. Hovering any value reveals the absolute count and the matching delta versus the previous equivalent period.
+
+### Cycle Health
+
+Three KPI tiles flagging blocked work:
+
+| Tile | Threshold | Tone |
+|---|---|---|
+| Roles open >30 days | `created_at + 30d < today` AND `isActive = true` | Amber |
+| Expired roles | `cutoffDate < today` AND `isActive = true` | Red |
+| Candidates stuck in interviewing >14 days | `status = 'interviewing'` AND last status change >14 days ago | Red |
+
+Each tile links to a filtered list. Some filter routes may not yet exist on this branch — placeholder links are present and will activate as the filter UI ships.
+
+### AI Cost Trend
+
+LineChart of daily AI spend over the selected range, with a month-over-month delta in the header. Source data is the same `ai_usage` table that powers Settings → AI Usage; this view aggregates daily.
+
+### Agency Hit-Rate
+
+BarChart with two series side-by-side per agency:
+
+- **Submission to Hire %** — `hired / total candidates from this agency` × 100
+- **Shortlist to Hire %** — `hired / candidates that reached shortlisted+ from this agency` × 100
+
+Hover any bar for the raw counts. The two series tell different stories: a high submission-to-hire % means the agency sends well-targeted candidates; a high shortlist-to-hire % means the candidates they send through your filter actually land the role.
+
+### Time-to-Fill (by customer)
+
+BarChart of the average days from role creation to the first candidate transitioning to `hired`, grouped by customer.
+
+**Data-quality footnote.** The chart derives the role-hire link from a join between `audit_logs` and `scores`. For older roles where audit metadata didn't include `roleId`, the data is best-effort. The chart shows a "limited historical data" warning when matched events are sparse — treat short bars on old customers with caution.
+
+### Top performers
+
+Two side-by-side tables at the bottom:
+
+- **Roles closed fastest** — top roles by shortest time from creation to first hire.
+- **Agencies by hit-rate** — top agencies by Submission-to-Hire %.
+
+## Per-chart CSV export
+
+Every card has its own **Export CSV** button. The download is focused — you get the rows behind that one chart, not a tenant-wide dump. Use the focused CSVs for spreadsheet analysis or to share a snapshot of one chart with someone who does not have admin access.
+
+For a full tenant snapshot, use **Settings → Backups & Data Export** instead.
+
+## Filtering
+
+Only the date-range preset is available in v1. Per-customer and per-recruiter filters are deferred — they would require additional indexes on `scores` and `audit_logs` to perform well at scale, and are slated for a follow-up PR.
+
+## Performance
+
+All five sub-queries run in parallel inside one DB transaction. There is no nightly snapshot job — every page load is real-time. Expect a 200–800 ms TTFB on a tenant with a few thousand candidates; if you see seconds, the chart queries are likely missing an index — file an issue with the slow chart and your tenant's row counts.


### PR DESCRIPTION
## Summary

Documentation catch-up for today's nine shipped features. Updates the roadmap and adds four new help-tab articles so admins and recruiters can self-serve learning the new features.

## What's in this PR

### Roadmap update
- `.agent-os/product/roadmap.md` — v2.5.0 → v2.6.0
- Status line updated to reflect 6 Epic #72 children all shipped (#75 GDPR, #84 ForYou, #76 Reports, #79 Calendar sync, #81 + #82 Data export)
- Phase 6 gains four new shipped subsections:
  - Leadership Reporting Dashboard (PR #132 / #76)
  - Calendar 2-Way Sync (PR #133 / #79)
  - Per-Tenant Calendar OAuth Credentials (PRs #134 + #135)
  - Admin Backups & Data Export + Per-Entity CSV Exports (PRs #136 + #137 + #138 / #81 + #82)

### Four new help articles in \`src/content/help/\`

| File | Audience | Category | What it covers |
|---|---|---|---|
| \`dashboard-for-you-section.md\` | recruiter / hiring_manager / admin | Getting Started | The five personalised widgets at the top of \`/dashboard\`: pending interviews, awaiting score, stale priorities, expired roles, manager approvals |
| \`dashboard-reports.md\` | admin | Settings & Admin | The \`/dashboard/reports\` page — five chart areas + per-chart CSV export. Includes the time-to-fill data-quality caveat |
| \`admin-gdpr-erasure.md\` | admin | Settings & Admin | The right-to-erasure flow + DSAR export. Explains the audit-redaction-not-deletion distinction (DEC-011) and the typed-name confirmation |
| \`calendar-sync-and-reschedules.md\` | admin / recruiter | Settings & Admin | Documents both the existing outbound sync and the new pull-side \`/api/cron/calendar-sync\` endpoint with its 15-min cadence + conflict-resolution rule |

All front-matter validated against the loader's exact Zod schema (\`src/lib/help/loader.ts\`) in-container.

## Test plan

- [x] Front-matter parses + Zod-validates for all four articles
- [x] Tone + structure match existing help articles (\`settings-api-keys.md\`, \`settings-oauth-credentials.md\`, \`settings-backups-data-export.md\`)
- [ ] Post-merge manual smoke:
  - [ ] Admin login → \`/dashboard/help\` shows all four new articles in the right categories
  - [ ] Recruiter login → only the recruiter-audience articles (\`dashboard-for-you-section\`, \`calendar-sync-and-reschedules\`) appear
  - [ ] Each article renders cleanly (markdown formatting + cross-links)
  - [ ] Search inside the help tab finds all four

## Note about the running container

The help loader caches articles at module-scope. The currently-running dev container won't show the new articles until next process restart — that's expected. Fresh deployments pick them up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)