### PR TITLE
feat(reports): AI spend breakdown dashboard (closes #151)

### DIFF
--- a/src/actions/reports.ts
+++ b/src/actions/reports.ts
@@ -14,6 +14,52 @@ import {
 import { getActionContext } from '@/lib/auth/action-context'
 import { requireRole } from '@/lib/auth/require-role'
 
+// ── AI Spend Detail types ──────────────────────────────────────────────────────
+
+export type AiSpendDetail = {
+  rangeDays: 7 | 30 | 90 | 365
+  kpis: {
+    totalUsd: number
+    totalCalls: number
+    avgCostPerCallUsd: number
+    monthOverMonthPct: number | null
+  }
+  byOperation: Array<{
+    operation: string
+    calls: number
+    totalUsd: number
+    avgCostPerCallUsd: number
+    inputTokens: number
+    outputTokens: number
+    cacheCreationTokens: number
+    cacheReadTokens: number
+    lastCallAt: Date | null
+  }>
+  byModel: Array<{
+    model: string
+    calls: number
+    totalUsd: number
+    sharePct: number
+  }>
+  dailyByOperation: Array<{
+    date: string                       // YYYY-MM-DD UTC
+    operation: string
+    costUsd: number
+  }>
+  latencyByOperation: Array<{
+    operation: string
+    samples: number
+    p50Ms: number | null
+    p95Ms: number | null
+    avgMs: number | null
+    maxMs: number | null
+  }>
+  pricingCoverage: {
+    callsWithZeroCost: number
+    distinctUnknownModels: string[]
+  }
+}
+
 // ── Public types ───────────────────────────────────────────────────────────────
 
 export type ReportRange = '7d' | '30d' | '90d' | '12mo'
@@ -608,6 +654,229 @@ export async function getReportsFeed(opts: { days: 7 | 30 | 90 | 365 }): Promise
       topPerformers: {
         fastestFilledRoles,
         topAgenciesByHitRate,
+      },
+    }
+  })
+}
+
+// ── AI Spend Detail action ─────────────────────────────────────────────────────
+
+export async function getAiSpendDetail(opts: { days: 7 | 30 | 90 | 365 }): Promise<AiSpendDetail> {
+  const ctx = await getActionContext()
+  if (!ctx) throw new Error('Unauthorized')
+  requireRole(ctx.userRole, 'admin')
+
+  const { days } = opts
+  const rangeStart = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+  const sixtyDaysAgo = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000)
+
+  return withTenant(ctx.tenantId, async (tx) => {
+    // ── KPI totals ─────────────────────────────────────────────────────────
+    const kpiPromise = tx
+      .select({
+        totalCalls: sql<number>`count(*)::int`,
+        totalUsd: sql<string>`coalesce(sum(${aiUsage.costUsd}), 0)`,
+      })
+      .from(aiUsage)
+      .where(gte(aiUsage.createdAt, rangeStart))
+
+    // ── Month-over-month: last 30 days vs prior 30 days ────────────────────
+    const momLast30Promise = tx
+      .select({ total: sql<string>`coalesce(sum(${aiUsage.costUsd}), 0)` })
+      .from(aiUsage)
+      .where(gte(aiUsage.createdAt, thirtyDaysAgo))
+
+    const momPrior30Promise = tx
+      .select({ total: sql<string>`coalesce(sum(${aiUsage.costUsd}), 0)` })
+      .from(aiUsage)
+      .where(
+        and(
+          gte(aiUsage.createdAt, sixtyDaysAgo),
+          lt(aiUsage.createdAt, thirtyDaysAgo),
+        )
+      )
+
+    // ── Per-operation breakdown ────────────────────────────────────────────
+    const byOperationPromise = tx
+      .select({
+        operation: aiUsage.operation,
+        calls: sql<number>`count(*)::int`,
+        totalUsd: sql<string>`coalesce(sum(${aiUsage.costUsd}), 0)`,
+        inputTokens: sql<number>`coalesce(sum(${aiUsage.inputTokens}), 0)::int`,
+        outputTokens: sql<number>`coalesce(sum(${aiUsage.outputTokens}), 0)::int`,
+        cacheCreationTokens: sql<number>`coalesce(sum(${aiUsage.cacheCreationTokens}), 0)::int`,
+        cacheReadTokens: sql<number>`coalesce(sum(${aiUsage.cacheReadTokens}), 0)::int`,
+        lastCallAt: sql<Date | null>`max(${aiUsage.createdAt})`,
+      })
+      .from(aiUsage)
+      .where(gte(aiUsage.createdAt, rangeStart))
+      .groupBy(aiUsage.operation)
+      .orderBy(sql`sum(${aiUsage.costUsd}) desc`)
+
+    // ── Per-model breakdown ────────────────────────────────────────────────
+    const byModelPromise = tx
+      .select({
+        model: aiUsage.model,
+        calls: sql<number>`count(*)::int`,
+        totalUsd: sql<string>`coalesce(sum(${aiUsage.costUsd}), 0)`,
+      })
+      .from(aiUsage)
+      .where(gte(aiUsage.createdAt, rangeStart))
+      .groupBy(aiUsage.model)
+      .orderBy(sql`sum(${aiUsage.costUsd}) desc`)
+
+    // ── Daily cost by operation (long format; UI pivots to stacked area) ───
+    const dailyByOperationPromise = tx
+      .select({
+        date: sql<string>`to_char(${aiUsage.createdAt} at time zone 'UTC', 'YYYY-MM-DD')`,
+        operation: aiUsage.operation,
+        costUsd: sql<string>`coalesce(sum(${aiUsage.costUsd}), 0)`,
+      })
+      .from(aiUsage)
+      .where(gte(aiUsage.createdAt, rangeStart))
+      .groupBy(
+        sql`to_char(${aiUsage.createdAt} at time zone 'UTC', 'YYYY-MM-DD')`,
+        aiUsage.operation,
+      )
+      .orderBy(
+        sql`to_char(${aiUsage.createdAt} at time zone 'UTC', 'YYYY-MM-DD')`,
+        aiUsage.operation,
+      )
+
+    // ── Latency percentiles per operation ──────────────────────────────────
+    // COUNT on durationMs so 'samples' only counts rows where latency was recorded.
+    const latencyPromise = tx
+      .select({
+        operation: aiUsage.operation,
+        samples: sql<number>`count(${aiUsage.durationMs})::int`,
+        p50Ms: sql<number | null>`percentile_cont(0.5) WITHIN GROUP (ORDER BY ${aiUsage.durationMs})`,
+        p95Ms: sql<number | null>`percentile_cont(0.95) WITHIN GROUP (ORDER BY ${aiUsage.durationMs})`,
+        avgMs: sql<number | null>`avg(${aiUsage.durationMs})`,
+        maxMs: sql<number | null>`max(${aiUsage.durationMs})`,
+      })
+      .from(aiUsage)
+      .where(
+        and(
+          gte(aiUsage.createdAt, rangeStart),
+          isNotNull(aiUsage.durationMs),
+        )
+      )
+      .groupBy(aiUsage.operation)
+      .orderBy(aiUsage.operation)
+
+    // ── Pricing coverage: calls priced as $0 (unknown model) ───────────────
+    const pricingCoveragePromise = tx
+      .select({
+        callsWithZeroCost: sql<number>`count(*)::int`,
+        unknownModels: sql<string[] | null>`array_agg(DISTINCT ${aiUsage.model}) FILTER (WHERE ${aiUsage.costUsd} = 0)`,
+      })
+      .from(aiUsage)
+      .where(
+        and(
+          gte(aiUsage.createdAt, rangeStart),
+          sql`${aiUsage.costUsd} = 0`,
+        )
+      )
+
+    // ── Run all eight queries in parallel ─────────────────────────────────
+    const [
+      kpiRes,
+      momLast30Res,
+      momPrior30Res,
+      byOperationRes,
+      byModelRes,
+      dailyByOperationRes,
+      latencyRes,
+      pricingCoverageRes,
+    ] = await Promise.all([
+      kpiPromise,
+      momLast30Promise,
+      momPrior30Promise,
+      byOperationPromise,
+      byModelPromise,
+      dailyByOperationPromise,
+      latencyPromise,
+      pricingCoveragePromise,
+    ])
+
+    // ── KPIs ───────────────────────────────────────────────────────────────
+    const totalCalls = kpiRes[0]?.totalCalls ?? 0
+    const totalUsd = Number(kpiRes[0]?.totalUsd ?? '0')
+    const avgCostPerCallUsd = totalCalls > 0 ? totalUsd / totalCalls : 0
+
+    const last30 = Number(momLast30Res[0]?.total ?? '0')
+    const prior30 = Number(momPrior30Res[0]?.total ?? '0')
+    let monthOverMonthPct: number | null = null
+    if (prior30 > 0 && last30 > 0) {
+      monthOverMonthPct = ((last30 - prior30) / prior30) * 100
+    }
+
+    // ── byModel — compute sharePct in TS (avoids SQL window function) ───────
+    // If total is 0, all shares stay 0 to avoid division-by-zero.
+    const byModel = byModelRes.map((r) => {
+      const modelUsd = Number(r.totalUsd)
+      return {
+        model: r.model,
+        calls: r.calls,
+        totalUsd: modelUsd,
+        sharePct: totalUsd > 0 ? Math.round((modelUsd / totalUsd) * 100 * 100) / 100 : 0,
+      }
+    })
+
+    // ── byOperation ────────────────────────────────────────────────────────
+    const byOperation = byOperationRes.map((r) => {
+      const opUsd = Number(r.totalUsd)
+      return {
+        operation: r.operation,
+        calls: r.calls,
+        totalUsd: opUsd,
+        avgCostPerCallUsd: r.calls > 0 ? opUsd / r.calls : 0,
+        inputTokens: r.inputTokens,
+        outputTokens: r.outputTokens,
+        cacheCreationTokens: r.cacheCreationTokens,
+        cacheReadTokens: r.cacheReadTokens,
+        lastCallAt: r.lastCallAt,
+      }
+    })
+
+    // ── dailyByOperation ───────────────────────────────────────────────────
+    const dailyByOperation = dailyByOperationRes.map((r) => ({
+      date: r.date,
+      operation: r.operation,
+      costUsd: Number(r.costUsd),
+    }))
+
+    // ── latencyByOperation ────────────────────────────────────────────────
+    const latencyByOperation = latencyRes.map((r) => ({
+      operation: r.operation,
+      samples: r.samples,
+      p50Ms: r.p50Ms !== null ? Math.round(Number(r.p50Ms)) : null,
+      p95Ms: r.p95Ms !== null ? Math.round(Number(r.p95Ms)) : null,
+      avgMs: r.avgMs !== null ? Math.round(Number(r.avgMs)) : null,
+      maxMs: r.maxMs !== null ? Number(r.maxMs) : null,
+    }))
+
+    // ── pricingCoverage ────────────────────────────────────────────────────
+    // Slice to 5 in TS — keeps the SQL simple and avoids a LIMIT inside array_agg.
+    const callsWithZeroCost = pricingCoverageRes[0]?.callsWithZeroCost ?? 0
+    const distinctUnknownModels = (pricingCoverageRes[0]?.unknownModels ?? []).slice(0, 5)
+
+    return {
+      rangeDays: days,
+      kpis: {
+        totalUsd,
+        totalCalls,
+        avgCostPerCallUsd,
+        monthOverMonthPct,
+      },
+      byOperation,
+      byModel,
+      dailyByOperation,
+      latencyByOperation,
+      pricingCoverage: {
+        callsWithZeroCost,
+        distinctUnknownModels,
       },
     }
   })

--- a/src/app/(dashboard)/dashboard/reports/ai-spend/page.tsx
+++ b/src/app/(dashboard)/dashboard/reports/ai-spend/page.tsx
@@ -1,0 +1,137 @@
+import { SparklesIcon } from 'lucide-react'
+import Link from 'next/link'
+import { auth } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import { getAiSpendDetail } from '@/actions/reports'
+import { KpiCard } from '@/components/reports/kpi-card'
+import { DateRangePresets } from '@/components/reports/date-range-presets'
+import { PricingCoveragePanel } from '@/components/reports/pricing-coverage-panel'
+import { AiSpendByOperationTable } from '@/components/reports/ai-spend-by-operation-table'
+import { AiSpendByModelChart } from '@/components/reports/ai-spend-by-model-chart'
+import { AiLatencyByOperationTable } from '@/components/reports/ai-latency-by-operation-table'
+import { AiDailyStackedChart } from '@/components/reports/ai-daily-stacked-chart'
+
+export const metadata = { title: 'AI Spend — SkillAI' }
+
+type RangeKey = '7d' | '30d' | '90d' | '12mo'
+
+function parseRange(r: string | undefined): 7 | 30 | 90 | 365 {
+  if (r === '7d') return 7
+  if (r === '90d') return 90
+  if (r === '12mo') return 365
+  return 30
+}
+
+function toRangeKey(r: string | undefined): RangeKey {
+  if (r === '7d' || r === '90d' || r === '12mo') return r
+  return '30d'
+}
+
+function fmtUsd(v: number): string {
+  return `$${v.toFixed(2)}`
+}
+
+function fmtMoM(pct: number | null): string {
+  if (pct === null) return '—'
+  return `${pct >= 0 ? '+' : ''}${pct.toFixed(0)}%`
+}
+
+export default async function AiSpendPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ range?: string }>
+}) {
+  const session = await auth()
+  if (!session?.user?.tenantId) redirect('/login')
+
+  if (session.user.role !== 'admin') {
+    return (
+      <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-8 text-center">
+        <h1 className="text-lg font-medium text-[var(--color-fg)] mb-2">Admin access required</h1>
+        <p className="text-sm text-[var(--color-fg-muted)]">
+          The AI spend dashboard is only available to admins.
+        </p>
+      </div>
+    )
+  }
+
+  const { range } = await searchParams
+  const days = parseRange(range)
+  const current = toRangeKey(range)
+
+  const data = await getAiSpendDetail({ days })
+
+  const momAccent =
+    data.kpis.monthOverMonthPct === null
+      ? 'default'
+      : data.kpis.monthOverMonthPct >= 0
+        ? 'red'
+        : 'emerald'
+
+  return (
+    <div className="space-y-6 p-6">
+      {/* Page header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="p-2 bg-[var(--color-bg-elevated)] rounded-lg">
+            <SparklesIcon className="h-5 w-5 text-[var(--color-fg-muted)]" />
+          </div>
+          <div>
+            <div className="flex items-center gap-2">
+              <Link
+                href="/dashboard/reports"
+                className="text-sm text-[var(--color-fg-muted)] hover:text-[var(--color-fg)] transition-colors"
+              >
+                Reports
+              </Link>
+              <span className="text-[var(--color-fg-subtle)] text-sm">/</span>
+              <h1 className="text-xl font-bold text-[var(--color-fg)]">AI Spend</h1>
+            </div>
+            <p className="text-sm text-[var(--color-fg-subtle)]">
+              Token usage and cost breakdown by operation and model
+            </p>
+          </div>
+        </div>
+        <DateRangePresets current={current} basePath="/dashboard/reports/ai-spend" />
+      </div>
+
+      {/* Pricing coverage warning — only shown when there are zero-cost calls */}
+      <PricingCoveragePanel data={data.pricingCoverage} />
+
+      {/* KPI grid — 4 cards */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        <KpiCard
+          label="Total spend"
+          value={fmtUsd(data.kpis.totalUsd)}
+          accent="amber"
+        />
+        <KpiCard
+          label="Total AI calls"
+          value={data.kpis.totalCalls.toLocaleString()}
+        />
+        <KpiCard
+          label="Avg cost / call"
+          value={`$${data.kpis.avgCostPerCallUsd.toFixed(4)}`}
+        />
+        <KpiCard
+          label="Month-over-month"
+          value={fmtMoM(data.kpis.monthOverMonthPct)}
+          accent={momAccent}
+          subtext={data.kpis.monthOverMonthPct === null ? 'insufficient data' : undefined}
+        />
+      </div>
+
+      {/* Per-operation breakdown table — full width */}
+      <AiSpendByOperationTable data={data.byOperation} rangeKey={current} />
+
+      {/* Two-column at lg+: by-model chart + latency table */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <AiSpendByModelChart data={data.byModel} rangeKey={current} />
+        <AiLatencyByOperationTable data={data.latencyByOperation} rangeKey={current} />
+      </div>
+
+      {/* Daily stacked area chart — full width */}
+      <AiDailyStackedChart data={data.dailyByOperation} rangeKey={current} />
+    </div>
+  )
+}

--- a/src/app/api/reports/[metric]/csv/route.ts
+++ b/src/app/api/reports/[metric]/csv/route.ts
@@ -1,5 +1,5 @@
 import { auth } from '@/lib/auth'
-import { getReportsFeed } from '@/actions/reports'
+import { getReportsFeed, getAiSpendDetail } from '@/actions/reports'
 import { toCsv } from '@/lib/reports/to-csv'
 
 // ── Range parsing ─────────────────────────────────────────────────────────────
@@ -56,11 +56,53 @@ export async function GET(
 
   const { days, label: rangeLabel } = range
 
-  // 4. Fetch data — getReportsFeed also enforces admin internally
-  const feed = await getReportsFeed({ days })
-
-  // 5. Build CSV for the requested metric
+  // 4. Dispatch by metric
   const { metric } = await params
+
+  // ── AI-spend metrics use a separate loader to avoid paying for the full
+  //    ReportsFeed query when only spend data is needed.
+  if (metric === 'ai-spend-by-operation') {
+    const detail = await getAiSpendDetail({ days })
+    const csv = toCsv(detail.byOperation, [
+      { key: 'operation',           label: 'Operation' },
+      { key: 'calls',               label: 'Calls' },
+      { key: 'totalUsd',            label: 'Total USD' },
+      { key: 'avgCostPerCallUsd',   label: 'Avg USD per call' },
+      { key: 'inputTokens',         label: 'Input tokens' },
+      { key: 'outputTokens',        label: 'Output tokens' },
+      { key: 'cacheCreationTokens', label: 'Cache creation tokens' },
+      { key: 'cacheReadTokens',     label: 'Cache read tokens' },
+      { key: 'lastCallAt',          label: 'Last call' },
+    ])
+    return csvResponse(csv, `ai-spend-by-operation-${rangeLabel}.csv`)
+  }
+
+  if (metric === 'ai-spend-by-model') {
+    const detail = await getAiSpendDetail({ days })
+    const csv = toCsv(detail.byModel, [
+      { key: 'model',    label: 'Model' },
+      { key: 'calls',    label: 'Calls' },
+      { key: 'totalUsd', label: 'Total USD' },
+      { key: 'sharePct', label: 'Share %' },
+    ])
+    return csvResponse(csv, `ai-spend-by-model-${rangeLabel}.csv`)
+  }
+
+  if (metric === 'ai-latency-by-operation') {
+    const detail = await getAiSpendDetail({ days })
+    const csv = toCsv(detail.latencyByOperation, [
+      { key: 'operation', label: 'Operation' },
+      { key: 'samples',   label: 'Samples' },
+      { key: 'p50Ms',     label: 'p50 ms' },
+      { key: 'p95Ms',     label: 'p95 ms' },
+      { key: 'avgMs',     label: 'Avg ms' },
+      { key: 'maxMs',     label: 'Max ms' },
+    ])
+    return csvResponse(csv, `ai-latency-by-operation-${rangeLabel}.csv`)
+  }
+
+  // ── Remaining metrics come from the full ReportsFeed loader ─────────────
+  const feed = await getReportsFeed({ days })
 
   switch (metric) {
     case 'time-to-fill': {

--- a/src/components/reports/ai-cost-trend-chart.tsx
+++ b/src/components/reports/ai-cost-trend-chart.tsx
@@ -46,6 +46,12 @@ export function AiCostTrendChart({ data, rangeDays }: Props) {
             Total ${data.totalUsd.toFixed(2)}
           </span>
           <a
+            href={`/dashboard/reports/ai-spend?range=${rangeParam}`}
+            className="text-xs px-2 py-1 rounded border border-[var(--color-border)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg)] hover:bg-[var(--color-bg-input)]"
+          >
+            View breakdown →
+          </a>
+          <a
             href={`/api/reports/ai-cost-trend/csv?range=${rangeParam}`}
             className="text-xs px-2 py-1 rounded border border-[var(--color-border)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg)] hover:bg-[var(--color-bg-input)]"
           >

--- a/src/components/reports/ai-daily-stacked-chart.tsx
+++ b/src/components/reports/ai-daily-stacked-chart.tsx
@@ -1,0 +1,199 @@
+'use client'
+
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+  ResponsiveContainer,
+} from 'recharts'
+import type { AiSpendDetail } from '@/actions/reports'
+
+type Props = {
+  data: AiSpendDetail['dailyByOperation']
+  rangeKey: '7d' | '30d' | '90d' | '12mo'
+}
+
+const PALETTE = [
+  '#fbbf24',
+  '#3b82f6',
+  '#10b981',
+  '#a855f7',
+  '#ef4444',
+  '#06b6d4',
+  '#ec4899',
+  '#84cc16',
+  '#94a3b8', // "other" always last
+]
+
+const MAX_OPERATIONS = 8
+
+type WideRow = Record<string, number | string>
+
+interface CustomTooltipProps {
+  active?: boolean
+  payload?: Array<{ name: string; value: number; fill: string }>
+  label?: string
+  operations: string[]
+}
+
+function DailyTooltip({ active, payload, label, operations }: CustomTooltipProps) {
+  if (!active || !payload || payload.length === 0) return null
+
+  // Show operations in consistent order (same as area stacking order), non-zero first
+  const entries = operations
+    .map((op) => {
+      const item = payload.find((p) => p.name === op)
+      return { op, value: item?.value ?? 0, fill: item?.fill ?? '#94a3b8' }
+    })
+    .filter((e) => e.value > 0)
+
+  if (entries.length === 0) return null
+
+  return (
+    <div
+      style={{
+        backgroundColor: '#18181b',
+        border: '1px solid #3f3f46',
+        borderRadius: 6,
+        fontSize: 12,
+        padding: '8px 12px',
+        color: '#d4d4d8',
+        maxWidth: 260,
+      }}
+    >
+      <p style={{ marginBottom: 6, fontWeight: 600 }}>{label}</p>
+      {entries.map(({ op, value, fill }) => (
+        <p key={op} style={{ color: fill, marginBottom: 2 }}>
+          {op}: ${value.toFixed(4)}
+        </p>
+      ))}
+    </div>
+  )
+}
+
+function pivotData(
+  raw: AiSpendDetail['dailyByOperation'],
+  topOps: string[]
+): WideRow[] {
+  // Collect all dates, sorted ascending
+  const dateSet = new Set<string>()
+  for (const row of raw) dateSet.add(row.date)
+  const dates = Array.from(dateSet).sort()
+
+  // Build a lookup: date → operation → costUsd
+  const lookup = new Map<string, Map<string, number>>()
+  for (const row of raw) {
+    if (!lookup.has(row.date)) lookup.set(row.date, new Map())
+    const opKey = topOps.includes(row.operation) ? row.operation : 'other'
+    const existing = lookup.get(row.date)!
+    existing.set(opKey, (existing.get(opKey) ?? 0) + row.costUsd)
+  }
+
+  const allKeys = [...topOps, 'other']
+
+  return dates.map((date) => {
+    const opMap = lookup.get(date) ?? new Map<string, number>()
+    const wide: WideRow = { date: date.slice(5) } // MM-DD display
+    for (const key of allKeys) {
+      wide[key] = opMap.get(key) ?? 0
+    }
+    return wide
+  })
+}
+
+export function AiDailyStackedChart({ data, rangeKey }: Props) {
+  // Determine top-8 operations by total cost across the range
+  const totalsMap = new Map<string, number>()
+  for (const row of data) {
+    totalsMap.set(row.operation, (totalsMap.get(row.operation) ?? 0) + row.costUsd)
+  }
+  const sortedOps = Array.from(totalsMap.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([op]) => op)
+
+  const topOps = sortedOps.slice(0, MAX_OPERATIONS)
+  const hasOther = sortedOps.length > MAX_OPERATIONS
+  const stackKeys = hasOther ? [...topOps, 'other'] : topOps
+
+  const chartData = pivotData(data, topOps)
+
+  return (
+    <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-base font-medium text-[var(--color-fg)]">
+          Daily cost by operation
+        </h2>
+        <a
+          href={`/api/reports/ai-cost-trend/csv?range=${rangeKey}`}
+          className="text-xs px-2 py-1 rounded border border-[var(--color-border)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg)] hover:bg-[var(--color-bg-input)]"
+        >
+          Export CSV
+        </a>
+      </div>
+
+      {chartData.length === 0 ? (
+        <p className="text-sm text-[var(--color-fg-subtle)] py-12 text-center">
+          No data for this range.
+        </p>
+      ) : (
+        <ResponsiveContainer width="100%" height={320}>
+          <AreaChart
+            data={chartData}
+            margin={{ top: 5, right: 10, left: 0, bottom: 0 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />
+            <XAxis
+              dataKey="date"
+              stroke="#71717a"
+              tick={{ fontSize: 10, fill: '#71717a' }}
+            />
+            <YAxis
+              stroke="#71717a"
+              tick={{ fontSize: 10, fill: '#71717a' }}
+              tickFormatter={(v: number) => `$${v.toFixed(2)}`}
+            />
+            <Tooltip
+              content={
+                <DailyTooltip operations={stackKeys} />
+              }
+            />
+            {stackKeys.map((op, index) => {
+              const colour = PALETTE[index % PALETTE.length]
+              return (
+                <Area
+                  key={op}
+                  type="monotone"
+                  dataKey={op}
+                  name={op}
+                  stackId="1"
+                  stroke={colour}
+                  fill={colour}
+                  fillOpacity={0.7}
+                  dot={false}
+                />
+              )
+            })}
+          </AreaChart>
+        </ResponsiveContainer>
+      )}
+
+      {/* Legend — outside Recharts to keep it readable */}
+      {stackKeys.length > 0 && (
+        <div className="mt-4 flex flex-wrap gap-3">
+          {stackKeys.map((op, index) => (
+            <div key={op} className="flex items-center gap-1.5">
+              <span
+                className="inline-block w-3 h-3 rounded-sm flex-shrink-0"
+                style={{ backgroundColor: PALETTE[index % PALETTE.length] }}
+              />
+              <span className="text-xs text-[var(--color-fg-muted)] font-mono">{op}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/reports/ai-latency-by-operation-table.tsx
+++ b/src/components/reports/ai-latency-by-operation-table.tsx
@@ -1,0 +1,85 @@
+import type { AiSpendDetail } from '@/actions/reports'
+
+type Props = {
+  data: AiSpendDetail['latencyByOperation']
+  rangeKey: '7d' | '30d' | '90d' | '12mo'
+}
+
+function fmtMs(value: number | null): string {
+  if (value === null) return '—'
+  return value.toLocaleString()
+}
+
+export function AiLatencyByOperationTable({ data, rangeKey }: Props) {
+  // Operations with all-null latency sink to the bottom
+  const sorted = [...data].sort((a, b) => {
+    if (a.p95Ms === null && b.p95Ms === null) return 0
+    if (a.p95Ms === null) return 1
+    if (b.p95Ms === null) return -1
+    return b.p95Ms - a.p95Ms
+  })
+
+  return (
+    <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-base font-medium text-[var(--color-fg)]">
+          Latency by operation
+        </h2>
+        <a
+          href={`/api/reports/ai-latency-by-operation/csv?range=${rangeKey}`}
+          className="text-xs px-2 py-1 rounded border border-[var(--color-border)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg)] hover:bg-[var(--color-bg-input)]"
+        >
+          Export CSV
+        </a>
+      </div>
+
+      {sorted.length === 0 ? (
+        <p className="text-sm text-[var(--color-fg-subtle)] py-12 text-center">
+          No data for this range.
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-xs text-[var(--color-fg-subtle)] border-b border-[var(--color-border)]">
+                <th className="py-2 pr-3 font-normal">Operation</th>
+                <th className="py-2 pr-3 font-normal text-right">Samples</th>
+                <th className="py-2 pr-3 font-normal text-right">p50 ms</th>
+                <th className="py-2 pr-3 font-normal text-right">p95 ms</th>
+                <th className="py-2 pr-3 font-normal text-right">Avg ms</th>
+                <th className="py-2 font-normal text-right">Max ms</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((row) => (
+                <tr
+                  key={row.operation}
+                  className="border-b border-[var(--color-border)] last:border-0"
+                >
+                  <td className="py-2 pr-3 font-mono text-xs text-[var(--color-fg)]">
+                    {row.operation}
+                  </td>
+                  <td className="py-2 pr-3 text-right text-[var(--color-fg-muted)]">
+                    {row.samples.toLocaleString()}
+                  </td>
+                  <td className="py-2 pr-3 text-right text-[var(--color-fg-muted)]">
+                    {fmtMs(row.p50Ms)}
+                  </td>
+                  <td className="py-2 pr-3 text-right font-medium text-[var(--color-fg)]">
+                    {fmtMs(row.p95Ms)}
+                  </td>
+                  <td className="py-2 pr-3 text-right text-[var(--color-fg-muted)]">
+                    {fmtMs(row.avgMs)}
+                  </td>
+                  <td className="py-2 text-right text-[var(--color-fg-muted)]">
+                    {fmtMs(row.maxMs)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/reports/ai-spend-by-model-chart.tsx
+++ b/src/components/reports/ai-spend-by-model-chart.tsx
@@ -1,0 +1,123 @@
+'use client'
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+  ResponsiveContainer,
+  Cell,
+  LabelList,
+} from 'recharts'
+import type { AiSpendDetail } from '@/actions/reports'
+
+type Props = {
+  data: AiSpendDetail['byModel']
+  rangeKey: '7d' | '30d' | '90d' | '12mo'
+}
+
+type ModelRow = AiSpendDetail['byModel'][number]
+
+const BAR_COLOURS = [
+  '#fbbf24',
+  '#3b82f6',
+  '#10b981',
+  '#a855f7',
+  '#ef4444',
+  '#06b6d4',
+  '#ec4899',
+  '#84cc16',
+  '#94a3b8',
+]
+
+interface CustomTooltipProps {
+  active?: boolean
+  payload?: Array<{ value: number; payload: ModelRow }>
+  label?: string
+}
+
+function ModelTooltip({ active, payload, label }: CustomTooltipProps) {
+  if (!active || !payload || payload.length === 0) return null
+  const row = payload[0].payload
+  return (
+    <div
+      style={{
+        backgroundColor: '#18181b',
+        border: '1px solid #3f3f46',
+        borderRadius: 6,
+        fontSize: 12,
+        padding: '8px 12px',
+        color: '#d4d4d8',
+      }}
+    >
+      <p style={{ marginBottom: 4, fontWeight: 600 }}>{label}</p>
+      <p>Total: ${row.totalUsd.toFixed(4)}</p>
+      <p>Calls: {row.calls.toLocaleString()}</p>
+      <p>Share: {row.sharePct.toFixed(1)}%</p>
+    </div>
+  )
+}
+
+export function AiSpendByModelChart({ data, rangeKey }: Props) {
+  return (
+    <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-base font-medium text-[var(--color-fg)]">
+          By model
+        </h2>
+        <a
+          href={`/api/reports/ai-spend-by-model/csv?range=${rangeKey}`}
+          className="text-xs px-2 py-1 rounded border border-[var(--color-border)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg)] hover:bg-[var(--color-bg-input)]"
+        >
+          Export CSV
+        </a>
+      </div>
+
+      {data.length === 0 ? (
+        <p className="text-sm text-[var(--color-fg-subtle)] py-12 text-center">
+          No data for this range.
+        </p>
+      ) : (
+        <ResponsiveContainer width="100%" height={Math.max(200, data.length * 48)}>
+          <BarChart
+            layout="vertical"
+            data={data}
+            margin={{ top: 5, right: 80, left: 0, bottom: 5 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke="#27272a" horizontal={false} />
+            <XAxis
+              type="number"
+              stroke="#71717a"
+              tick={{ fontSize: 10, fill: '#71717a' }}
+              tickFormatter={(v: number) => `$${v.toFixed(2)}`}
+            />
+            <YAxis
+              type="category"
+              dataKey="model"
+              stroke="#71717a"
+              tick={{ fontSize: 10, fill: '#71717a' }}
+              width={160}
+            />
+            <Tooltip content={<ModelTooltip />} />
+            <Bar dataKey="totalUsd" radius={[0, 3, 3, 0]}>
+              {data.map((entry, index) => (
+                <Cell
+                  key={entry.model}
+                  fill={BAR_COLOURS[index % BAR_COLOURS.length]}
+                />
+              ))}
+              <LabelList
+                dataKey="sharePct"
+                position="right"
+                formatter={(v) => `${typeof v === 'number' ? v.toFixed(1) : v}%`}
+                style={{ fontSize: 10, fill: '#71717a' }}
+              />
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  )
+}

--- a/src/components/reports/ai-spend-by-operation-table.tsx
+++ b/src/components/reports/ai-spend-by-operation-table.tsx
@@ -1,0 +1,99 @@
+import type { AiSpendDetail } from '@/actions/reports'
+
+type Props = {
+  data: AiSpendDetail['byOperation']
+  rangeKey: '7d' | '30d' | '90d' | '12mo'
+}
+
+function timeAgo(date: Date): string {
+  const ms = Date.now() - new Date(date).getTime()
+  const mins = Math.floor(ms / 60_000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 30) return `${days}d ago`
+  const months = Math.floor(days / 30)
+  return `${months}mo ago`
+}
+
+export function AiSpendByOperationTable({ data, rangeKey }: Props) {
+  const sorted = [...data].sort((a, b) => b.totalUsd - a.totalUsd)
+
+  return (
+    <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-base font-medium text-[var(--color-fg)]">
+          By operation
+        </h2>
+        <a
+          href={`/api/reports/ai-spend-by-operation/csv?range=${rangeKey}`}
+          className="text-xs px-2 py-1 rounded border border-[var(--color-border)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg)] hover:bg-[var(--color-bg-input)]"
+        >
+          Export CSV
+        </a>
+      </div>
+
+      {sorted.length === 0 ? (
+        <p className="text-sm text-[var(--color-fg-subtle)] py-12 text-center">
+          No data for this range.
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-xs text-[var(--color-fg-subtle)] border-b border-[var(--color-border)]">
+                <th className="py-2 pr-3 font-normal">Operation</th>
+                <th className="py-2 pr-3 font-normal text-right">Calls</th>
+                <th className="py-2 pr-3 font-normal text-right">Total</th>
+                <th className="py-2 pr-3 font-normal text-right">Avg/call</th>
+                <th className="py-2 pr-3 font-normal text-right">Input tokens</th>
+                <th className="py-2 pr-3 font-normal text-right">Output tokens</th>
+                <th className="py-2 pr-3 font-normal text-right">Cache create</th>
+                <th className="py-2 pr-3 font-normal text-right">Cache read</th>
+                <th className="py-2 font-normal text-right">Last call</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((row) => (
+                <tr
+                  key={row.operation}
+                  className="border-b border-[var(--color-border)] last:border-0"
+                >
+                  <td className="py-2 pr-3 font-mono text-xs text-[var(--color-fg)]">
+                    {row.operation}
+                  </td>
+                  <td className="py-2 pr-3 text-right text-[var(--color-fg-muted)]">
+                    {row.calls.toLocaleString()}
+                  </td>
+                  <td className="py-2 pr-3 text-right font-medium text-[var(--color-fg)]">
+                    ${row.totalUsd.toFixed(2)}
+                  </td>
+                  <td className="py-2 pr-3 text-right text-[var(--color-fg-muted)]">
+                    ${row.avgCostPerCallUsd.toFixed(4)}
+                  </td>
+                  <td className="py-2 pr-3 text-right text-[var(--color-fg-muted)]">
+                    {row.inputTokens.toLocaleString()}
+                  </td>
+                  <td className="py-2 pr-3 text-right text-[var(--color-fg-muted)]">
+                    {row.outputTokens.toLocaleString()}
+                  </td>
+                  <td className="py-2 pr-3 text-right text-[var(--color-fg-muted)]">
+                    {row.cacheCreationTokens.toLocaleString()}
+                  </td>
+                  <td className="py-2 pr-3 text-right text-[var(--color-fg-muted)]">
+                    {row.cacheReadTokens.toLocaleString()}
+                  </td>
+                  <td className="py-2 text-right text-[var(--color-fg-subtle)]">
+                    {row.lastCallAt ? timeAgo(row.lastCallAt) : '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/reports/date-range-presets.tsx
+++ b/src/components/reports/date-range-presets.tsx
@@ -9,7 +9,13 @@ const RANGES = [
   { key: '12mo', label: '12mo' },
 ] as const
 
-export function DateRangePresets({ current }: { current: '7d' | '30d' | '90d' | '12mo' }) {
+export function DateRangePresets({
+  current,
+  basePath = '/dashboard/reports',
+}: {
+  current: '7d' | '30d' | '90d' | '12mo'
+  basePath?: string
+}) {
   return (
     <div className="inline-flex rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-elevated)] p-1">
       {RANGES.map((r) => {
@@ -17,7 +23,7 @@ export function DateRangePresets({ current }: { current: '7d' | '30d' | '90d' | 
         return (
           <Link
             key={r.key}
-            href={`/dashboard/reports?range=${r.key}`}
+            href={`${basePath}?range=${r.key}`}
             className={`px-3 py-1 text-sm rounded-md transition-colors ${
               isActive
                 ? 'bg-[var(--color-bg-input)] text-[var(--color-fg)]'

--- a/src/components/reports/pricing-coverage-panel.tsx
+++ b/src/components/reports/pricing-coverage-panel.tsx
@@ -1,0 +1,28 @@
+import { AlertTriangleIcon } from 'lucide-react'
+import type { AiSpendDetail } from '@/actions/reports'
+
+type Props = {
+  data: AiSpendDetail['pricingCoverage']
+}
+
+export function PricingCoveragePanel({ data }: Props) {
+  if (data.callsWithZeroCost === 0) return null
+
+  const callWord = data.callsWithZeroCost === 1 ? 'call' : 'calls'
+
+  return (
+    <div className="bg-amber-950/40 border border-amber-800 rounded-xl p-4 flex items-start gap-3">
+      <AlertTriangleIcon className="h-5 w-5 text-amber-400 flex-shrink-0 mt-0.5" />
+      <div>
+        <p className="text-sm font-semibold text-amber-200">Some AI calls priced as $0</p>
+        <p className="text-xs text-amber-300 mt-1">
+          {data.callsWithZeroCost} {callWord} in this range have{' '}
+          <code>cost_usd = 0</code> because their model isn&apos;t in{' '}
+          <code>src/lib/ai/pricing.ts</code>:{' '}
+          <strong>{data.distinctUnknownModels.join(', ')}</strong>.{' '}
+          Add these to the pricing table to capture their cost.
+        </p>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #151. Follow-up to the closed #36 (ledger-persistence) — this is the dashboard surface that closes the loop.

## Summary

New admin-only `/dashboard/reports/ai-spend` page linked from the existing `<AiCostTrendChart>` on `/dashboard/reports` (no new sidebar nav entry — discoverable via "View breakdown →").

Six sections answering questions the single-line trend chart can't:

1. **KPI grid** — total spend, total calls, avg cost per call, MoM %
2. **Per-operation breakdown** — sortable table, default `desc(totalUsd)`
3. **Per-model breakdown** — Recharts horizontal bar chart with share %
4. **Daily stacked area** — top-8 operations + "other" rollup
5. **Latency by operation** — samples / p50 / p95 / avg / max ms via PostgreSQL `percentile_cont` raw SQL
6. **Pricing-coverage warning** — only renders when calls with `cost_usd=0` from unknown models exist; lists the model names so the admin can add them to `src/lib/ai/pricing.ts`

CSV exports for the three new slices via the existing `/api/reports/[metric]/csv` route. Daily-stacked-area's export reuses the existing `ai-cost-trend` route.

## Test plan

- [x] Typecheck clean (excluding pre-existing `src/instrumentation.ts` carry-over)
- [x] Lint clean on all new + edited feature files
- [ ] As admin: navigate to `/dashboard/reports` → click "View breakdown →" → land on `/dashboard/reports/ai-spend?range=30d`. KPIs match the leadership-page total spend.
- [ ] By-operation table sort order matches `desc(totalUsd)`
- [ ] Per-model chart shares sum to ~100%
- [ ] Daily stacked area total matches the existing line chart on the leadership page
- [ ] Latency table p50/p95 populated for ops with samples; `—` for ops with all-null
- [ ] Pricing-coverage panel only visible when forced via `INSERT INTO ai_usage` with a fake model name
- [ ] Date-range switching updates the URL and reloads
- [ ] CSV exports return correctly-formatted CSVs for the 3 new metrics
- [ ] Non-admin → 403 card on the page; non-admin → 403 on the CSV routes
- [ ] No regression on `/dashboard/reports`

🤖 Generated with [Claude Code](https://claude.com/claude-code)