### PR TITLE
fix(roles): show empty-state for Framework Level when customer has no framework (closes #153)

### DIFF
--- a/src/components/roles/framework-level-field.tsx
+++ b/src/components/roles/framework-level-field.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import Link from 'next/link'
+
+export type FrameworkLevelOption = {
+  id: string
+  code: string
+  title: string
+  description: string
+  order: number
+}
+
+type Props = {
+  customerId: string
+  levels: FrameworkLevelOption[]
+  value: { id: string; label: string }
+  onChange: (next: { id: string; label: string }) => void
+  disabled?: boolean
+}
+
+// Three render states:
+// 1. No customer selected → render nothing (frameworks are customer-scoped)
+// 2. Customer has framework levels → dropdown (the original behaviour)
+// 3. Customer has no framework yet → empty state + link to configure.
+//    Sub-case: a stale `value.label` may exist on the role (the customer's
+//    framework was deleted after the role was set). Surface it with a Clear
+//    button so it can be removed.
+export function FrameworkLevelField({
+  customerId,
+  levels,
+  value,
+  onChange,
+  disabled = false,
+}: Props) {
+  if (!customerId) return null
+
+  const sortedLevels = [...levels].sort((a, b) => a.order - b.order)
+  const selected = sortedLevels.find((l) => l.id === value.id)
+
+  if (sortedLevels.length === 0) {
+    return (
+      <div>
+        <label className="block text-sm font-medium text-zinc-300 mb-1">
+          Framework Level <span className="text-zinc-500 font-normal">(optional)</span>
+        </label>
+        <div className="rounded-md border border-dashed border-zinc-700 bg-zinc-900/50 px-3 py-3 text-sm text-zinc-400">
+          {value.label ? (
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="text-zinc-300">
+                  Current value: <span className="font-medium">{value.label}</span>
+                </p>
+                <p className="text-xs text-zinc-500 mt-1">
+                  This level is no longer in the customer&apos;s framework.{' '}
+                  <Link
+                    href={`/dashboard/customers/${customerId}`}
+                    className="text-blue-400 hover:text-blue-300 underline"
+                  >
+                    Configure framework →
+                  </Link>
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => onChange({ id: '', label: '' })}
+                disabled={disabled}
+                className="rounded-md border border-zinc-600 bg-zinc-800 px-2.5 py-1 text-xs text-zinc-300
+                           hover:bg-zinc-700 hover:text-zinc-100 disabled:opacity-50 transition-colors flex-shrink-0"
+              >
+                Clear
+              </button>
+            </div>
+          ) : (
+            <p>
+              This customer doesn&apos;t have a band framework yet.{' '}
+              <Link
+                href={`/dashboard/customers/${customerId}`}
+                className="text-blue-400 hover:text-blue-300 underline"
+              >
+                Configure framework →
+              </Link>
+            </p>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <label htmlFor="frameworkLevelId" className="block text-sm font-medium text-zinc-300 mb-1">
+        Framework Level <span className="text-zinc-500 font-normal">(optional)</span>
+      </label>
+      <select
+        id="frameworkLevelId"
+        name="frameworkLevelId"
+        disabled={disabled}
+        value={value.id}
+        onChange={(e) => {
+          const level = sortedLevels.find((l) => l.id === e.target.value)
+          onChange({
+            id: e.target.value,
+            label: level ? `${level.code} — ${level.title}` : '',
+          })
+        }}
+        className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
+                   focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
+                   disabled:opacity-50"
+      >
+        <option value="">Select band level…</option>
+        {sortedLevels.map((level) => (
+          <option key={level.id} value={level.id}>
+            {level.code} — {level.title}
+          </option>
+        ))}
+      </select>
+      {selected && (
+        <p className="text-xs text-zinc-500 mt-1">{selected.description}</p>
+      )}
+    </div>
+  )
+}

--- a/src/components/roles/role-edit-form.tsx
+++ b/src/components/roles/role-edit-form.tsx
@@ -7,6 +7,7 @@ import { Loader2 } from 'lucide-react'
 import { updateRole } from '@/actions/roles'
 import type { UpdateRoleState } from '@/actions/roles'
 import { ChipInput } from '@/components/ui/chip-input'
+import { FrameworkLevelField } from './framework-level-field'
 
 interface RoleData {
   id: string
@@ -197,42 +198,19 @@ export function RoleEditForm({ role, customers = [], frameworks = {}, customerRo
         </div>
       )}
 
-      {fields.customerId && (frameworks[fields.customerId]?.length ?? 0) > 0 && (
-        <div>
-          <label htmlFor="frameworkLevelId" className="block text-sm font-medium text-zinc-300 mb-1">
-            Framework Level <span className="text-zinc-500 font-normal">(optional)</span>
-          </label>
-          <select
-            id="frameworkLevelId"
-            name="frameworkLevelId"
-            disabled={pending}
-            value={fields.frameworkLevelId}
-            onChange={(e) => {
-              const level = frameworks[fields.customerId]?.find((l) => l.id === e.target.value)
-              setFields((f) => ({
-                ...f,
-                frameworkLevelId: e.target.value,
-                frameworkLevelLabel: level ? `${level.code} — ${level.title}` : '',
-              }))
-            }}
-            className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                       focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
-                       disabled:opacity-50"
-          >
-            <option value="">Select band level…</option>
-            {[...(frameworks[fields.customerId] ?? [])].sort((a, b) => a.order - b.order).map((level) => (
-              <option key={level.id} value={level.id}>
-                {level.code} — {level.title}
-              </option>
-            ))}
-          </select>
-          {fields.frameworkLevelId && (
-            <p className="text-xs text-zinc-500 mt-1">
-              {frameworks[fields.customerId]?.find((l) => l.id === fields.frameworkLevelId)?.description}
-            </p>
-          )}
-        </div>
-      )}
+      <FrameworkLevelField
+        customerId={fields.customerId}
+        levels={frameworks[fields.customerId] ?? []}
+        value={{ id: fields.frameworkLevelId, label: fields.frameworkLevelLabel }}
+        onChange={(next) =>
+          setFields((f) => ({
+            ...f,
+            frameworkLevelId: next.id,
+            frameworkLevelLabel: next.label,
+          }))
+        }
+        disabled={pending}
+      />
 
       <div>
         <label htmlFor="title" className="block text-sm font-medium text-zinc-300 mb-1">

--- a/src/components/roles/role-form.tsx
+++ b/src/components/roles/role-form.tsx
@@ -7,6 +7,7 @@ import { Loader2, Sparkles, UploadCloud, X } from 'lucide-react'
 import { createRole } from '@/actions/roles'
 import type { CreateRoleState } from '@/actions/roles'
 import { ChipInput } from '@/components/ui/chip-input'
+import { FrameworkLevelField } from './framework-level-field'
 
 interface RoleFields {
   title: string
@@ -283,42 +284,19 @@ export function RoleForm({ customers = [], frameworks = {}, customerRoleIdLabels
           </div>
         )}
 
-        {fields.customerId && (frameworks[fields.customerId]?.length ?? 0) > 0 && (
-          <div>
-            <label htmlFor="frameworkLevelId" className="block text-sm font-medium text-zinc-300 mb-1">
-              Framework Level <span className="text-zinc-500 font-normal">(optional)</span>
-            </label>
-            <select
-              id="frameworkLevelId"
-              name="frameworkLevelId"
-              disabled={pending || importing}
-              value={fields.frameworkLevelId}
-              onChange={(e) => {
-                const level = frameworks[fields.customerId]?.find((l) => l.id === e.target.value)
-                setFields((f) => ({
-                  ...f,
-                  frameworkLevelId: e.target.value,
-                  frameworkLevelLabel: level ? `${level.code} — ${level.title}` : '',
-                }))
-              }}
-              className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                         focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
-                         disabled:opacity-50"
-            >
-              <option value="">Select band level…</option>
-              {[...(frameworks[fields.customerId] ?? [])].sort((a, b) => a.order - b.order).map((level) => (
-                <option key={level.id} value={level.id}>
-                  {level.code} — {level.title}
-                </option>
-              ))}
-            </select>
-            {fields.frameworkLevelId && (
-              <p className="text-xs text-zinc-500 mt-1">
-                {frameworks[fields.customerId]?.find((l) => l.id === fields.frameworkLevelId)?.description}
-              </p>
-            )}
-          </div>
-        )}
+        <FrameworkLevelField
+          customerId={fields.customerId}
+          levels={frameworks[fields.customerId] ?? []}
+          value={{ id: fields.frameworkLevelId, label: fields.frameworkLevelLabel }}
+          onChange={(next) =>
+            setFields((f) => ({
+              ...f,
+              frameworkLevelId: next.id,
+              frameworkLevelLabel: next.label,
+            }))
+          }
+          disabled={pending || importing}
+        />
 
         <div>
           <label htmlFor="title" className="block text-sm font-medium text-zinc-300 mb-1">


### PR DESCRIPTION
Closes #153.

## Summary

The "Framework Level (optional)" field on role create + edit forms used to disappear silently when the role's customer had no framework defined — and there was no path to fix it from the role page. PR adds a three-state field that renders whenever a `customerId` is set:

- **Customer has framework levels** → existing dropdown (unchanged)
- **Customer has no framework yet** → empty-state + "Configure framework →" link to `/dashboard/customers/{id}`
- **Stale label edge case** (label set on role but no longer in the customer's framework) → show stale value muted + Clear button + Configure link

Extracted as a shared `<FrameworkLevelField>` component so create + edit forms can't drift apart.

## Test plan

- [x] Typecheck clean (the only remaining lint error in `role-form.tsx:577` is pre-existing from commit `b2f46f7`)
- [ ] Customer with framework: dropdown appears as today
- [ ] Customer without framework: empty-state with Configure link visible
- [ ] No customer: section hidden (today's behaviour)
- [ ] Stale label: shown + Clear button works
- [ ] Role detail page (`role-meta-bar.tsx`) still renders the level pill correctly
- [ ] No regression on existing role create / edit happy path

🤖 Generated with [Claude Code](https://claude.com/claude-code)