### PR TITLE
feat(mobile): PR2 — candidate list cards + ComparisonTray + submissions index cards (closes #68)

### DIFF
--- a/src/app/(dashboard)/dashboard/submissions/page.tsx
+++ b/src/app/(dashboard)/dashboard/submissions/page.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/actions/role-submissions'
 import { SubmissionFilters } from '@/components/submissions/submission-filters'
 import { SubmissionStatusPill } from '@/components/roles/submission-status-pill'
+import { SubmissionCard } from '@/components/submissions/submission-card'
 import type { SubmissionStatus } from '@/db/schema/role-submissions'
 
 // Agent A extends SubmissionWithDetails with roleTitle and customerName for the
@@ -270,8 +271,19 @@ export default async function SubmissionsPage({ searchParams }: PageProps) {
         </div>
       ) : (
         <>
-          {/* Table */}
-          <div className="overflow-hidden rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-elevated)]">
+          {/* Mobile card list — hidden md:+ */}
+          <div className="md:hidden">
+            {allSubmissions.map((sub) => (
+              <SubmissionCard
+                key={sub.id}
+                submission={sub}
+                timeAgo={timeAgo}
+              />
+            ))}
+          </div>
+
+          {/* Desktop table — hidden below md */}
+          <div className="hidden md:block overflow-hidden rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-elevated)]">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-[var(--color-border)]">

--- a/src/components/candidates/comparison-tray.tsx
+++ b/src/components/candidates/comparison-tray.tsx
@@ -60,8 +60,13 @@ export function ComparisonTray() {
   if (items.length === 0) return null
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 z-40 bg-zinc-900 border-t border-zinc-700 shadow-2xl">
-      <div className="max-w-7xl mx-auto px-6 py-3 flex items-center gap-4">
+    // bottom-16 on mobile keeps the tray above any sticky pagination row;
+    // md:bottom-0 restores flush-bottom on larger screens.
+    // z-30 keeps below drawer scrim (z-40) and drawer panel (z-50).
+    <div className="fixed bottom-16 left-0 right-0 z-30 bg-zinc-900 border-t border-zinc-700 shadow-2xl
+                    md:bottom-0">
+      <div className="max-w-7xl mx-auto px-4 py-3 flex items-center gap-4
+                      sm:px-6">
         <span className="text-sm text-zinc-400 flex-shrink-0">
           Compare ({items.length}/5):
         </span>

--- a/src/components/candidates/selectable-candidate-list.tsx
+++ b/src/components/candidates/selectable-candidate-list.tsx
@@ -6,6 +6,38 @@ import { Download, HomeIcon } from 'lucide-react'
 import { ComparisonCheckbox } from './comparison-checkbox'
 import { BulkStatusBar } from './bulk-status-bar'
 
+// Agency logo + initials-fallback — mirrors the pattern in the table cells below
+function AgencyLogo({
+  agencyId,
+  agencyLogoPath,
+  agencyName,
+}: {
+  agencyId: string | null
+  agencyLogoPath: string | null
+  agencyName: string | null
+}) {
+  if (!agencyId) return null
+  return agencyLogoPath ? (
+    <img
+      src={`/api/agencies/${agencyId}/logo`}
+      alt=""
+      width={20}
+      height={20}
+      style={{ width: 20, height: 20 }}
+      className="rounded-full border border-[var(--color-border)] bg-[var(--color-bg-input)] object-contain shrink-0"
+    />
+  ) : (
+    <div
+      className="flex items-center justify-center rounded-full bg-[var(--color-bg-input)]
+                 text-[var(--color-fg-muted)] text-xs font-semibold shrink-0"
+      style={{ width: 20, height: 20 }}
+      aria-hidden="true"
+    >
+      {agencyName?.charAt(0).toUpperCase() ?? '?'}
+    </div>
+  )
+}
+
 // Status pills resolve through CSS-var tokens so each status reads correctly
 // in both dark and light themes. See globals.css for the per-theme palette.
 const STATUS_BADGE: Record<string, string> = {
@@ -87,7 +119,8 @@ export function SelectableCandidateList({ candidates }: Props) {
 
   return (
     <>
-      <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] overflow-hidden">
+      {/* ── Desktop / tablet table (≥768 px) ─────────────────────────── */}
+      <div className="hidden md:block bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] overflow-hidden">
         <table className="w-full text-sm">
           <thead>
             <tr className="border-b border-[var(--color-border)] bg-[var(--color-bg-input)]">
@@ -173,7 +206,7 @@ export function SelectableCandidateList({ candidates }: Props) {
                       )}
                     </div>
                   </td>
-                  <td className="px-5 py-3 text-[var(--color-fg-subtle)] truncate max-w-[200px]">
+                  <td className="px-5 py-3 text-[var(--color-fg-subtle)] truncate md:max-w-[200px]">
                     {c.email ?? '—'}
                   </td>
                   <td className="px-5 py-3 hidden sm:table-cell">
@@ -252,6 +285,154 @@ export function SelectableCandidateList({ candidates }: Props) {
             })}
           </tbody>
         </table>
+      </div>
+
+      {/* ── Mobile / small-tablet card stack (<768 px) ──────────────── */}
+      <div className="md:hidden space-y-2">
+        {/* Select-all header row */}
+        <label className="flex items-center gap-3 px-1 py-1 cursor-pointer select-none">
+          <span className="inline-flex items-center justify-center p-3 -m-3">
+            <input
+              type="checkbox"
+              checked={allSelected}
+              ref={(el) => {
+                if (el) el.indeterminate = someSelected
+              }}
+              onChange={toggleAll}
+              className="h-4 w-4 rounded border-[var(--color-border)] bg-[var(--color-bg-input)] text-blue-600 cursor-pointer
+                         focus:ring-blue-500 focus:ring-offset-[var(--color-bg-elevated)]"
+              aria-label={allSelected ? 'Deselect all candidates' : 'Select all candidates'}
+            />
+          </span>
+          <span className="text-xs text-[var(--color-fg-muted)]">
+            {allSelected ? 'Deselect all' : 'Select all'}
+          </span>
+        </label>
+
+        {candidates.map((c) => {
+          const isSelected = selectedIds.has(c.id)
+          return (
+            <div
+              key={c.id}
+              className={`bg-[var(--color-bg-elevated)] rounded-lg border border-[var(--color-border)] p-4
+                          transition-colors
+                          ${isSelected ? 'border-blue-500/40 bg-[var(--color-bg-input)]' : ''}`}
+            >
+              {/* Row 1: checkbox + name + status */}
+              <div className="flex items-center gap-3 min-w-0">
+                {/* Checkbox with ≥44×44px tap target via negative margin expansion */}
+                <label
+                  className="inline-flex items-center justify-center p-3 -m-3 shrink-0 cursor-pointer"
+                  aria-label={`Select ${c.firstName} ${c.lastName}`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={isSelected}
+                    onChange={() => toggleOne(c.id)}
+                    className="h-4 w-4 rounded border-[var(--color-border)] bg-[var(--color-bg-input)] text-blue-600 cursor-pointer
+                               focus:ring-blue-500 focus:ring-offset-[var(--color-bg-elevated)]"
+                    aria-label={`Select ${c.firstName} ${c.lastName}`}
+                  />
+                </label>
+
+                <Link
+                  href={`/dashboard/candidates/${c.id}`}
+                  className="font-medium text-[var(--color-fg)] hover:text-blue-400 transition-colors truncate flex-1 min-w-0"
+                >
+                  {c.firstName} {c.lastName}
+                </Link>
+
+                <span
+                  className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium capitalize shrink-0
+                              ${STATUS_BADGE[c.status] ?? 'bg-[var(--color-status-new-bg)] text-[var(--color-status-new-fg)]'}`}
+                >
+                  {c.status}
+                </span>
+              </div>
+
+              {/* Row 2: agency + availability badge */}
+              <div className="mt-2 flex items-center gap-1.5 text-xs text-[var(--color-fg-subtle)] pl-1 flex-wrap">
+                {c.isInternalAgency ? (
+                  <span
+                    className="inline-flex items-center gap-1 rounded-full bg-[var(--color-status-shortlisted-bg)]
+                               text-[var(--color-status-shortlisted-fg)] text-xs font-medium px-2 py-0.5"
+                  >
+                    <HomeIcon className="h-3 w-3" />
+                    Internal
+                  </span>
+                ) : c.agencyId ? (
+                  <span className="inline-flex items-center gap-1.5">
+                    <AgencyLogo
+                      agencyId={c.agencyId}
+                      agencyLogoPath={c.agencyLogoPath}
+                      agencyName={c.agencyName}
+                    />
+                    <span>{c.agencyName ?? '—'}</span>
+                  </span>
+                ) : null}
+
+                {c.availabilityStatus === 'on_project' && (
+                  <span
+                    className="inline-flex items-center rounded-full bg-[var(--color-status-offered-bg)]
+                               text-[var(--color-status-offered-fg)] text-xs font-medium px-2 py-0.5"
+                  >
+                    {c.availableFrom
+                      ? `On project until ${formatAvailableFrom(c.availableFrom)}`
+                      : 'On project'}
+                  </span>
+                )}
+                {c.availabilityStatus === 'unavailable' && (
+                  <span
+                    className="inline-flex items-center rounded-full border border-[var(--color-border)] bg-[var(--color-bg-input)]
+                               text-[var(--color-fg)] text-xs font-medium px-2 py-0.5"
+                  >
+                    Unavailable
+                  </span>
+                )}
+
+                {c.email && (
+                  <span className="text-[var(--color-fg-subtle)] truncate max-w-[180px]">
+                    · {c.email}
+                  </span>
+                )}
+              </div>
+
+              {/* Row 3: rate (left) + actions (right) */}
+              <div className="mt-3 flex items-center justify-between">
+                <span className="text-xs text-[var(--color-fg-muted)] tabular-nums">
+                  {c.candidateRate
+                    ? `${c.rateCurrency ?? ''} ${Number(c.candidateRate).toFixed(0)}/day`
+                    : <span className="text-[var(--color-fg-subtle)]">{new Date(c.createdAt).toLocaleDateString('en-GB')}</span>}
+                </span>
+
+                {/* Actions — each ≥44×44px via h-11 w-11 */}
+                <div className="flex items-center gap-1">
+                  {/* ComparisonCheckbox has its own h-7 w-7; wrap in a larger hit area */}
+                  <span className="inline-flex items-center justify-center h-11 w-11">
+                    <ComparisonCheckbox
+                      candidateId={c.id}
+                      candidateName={`${c.firstName} ${c.lastName}`}
+                    />
+                  </span>
+
+                  {c.filePath && (
+                    <a
+                      href={`/api/candidates/${c.id}/cv`}
+                      download
+                      title="Download original CV"
+                      aria-label={`Download CV for ${c.firstName} ${c.lastName}`}
+                      className="h-11 w-11 rounded inline-flex items-center justify-center
+                                 text-[var(--color-fg-subtle)] hover:text-blue-400 hover:bg-blue-950
+                                 transition-colors"
+                    >
+                      <Download className="h-4 w-4" />
+                    </a>
+                  )}
+                </div>
+              </div>
+            </div>
+          )
+        })}
       </div>
 
       {/* Bulk action bar — appears when 1+ candidates are selected */}

--- a/src/components/submissions/submission-card.tsx
+++ b/src/components/submissions/submission-card.tsx
@@ -1,0 +1,79 @@
+import Link from 'next/link'
+import { SubmissionStatusPill } from '@/components/roles/submission-status-pill'
+import type { SubmissionWithDetails } from '@/actions/role-submissions'
+
+// Page-level extended type: getAllSubmissionsForTenant joins roleTitle + customerName
+// onto SubmissionWithDetails. We re-declare the minimal shape the card needs so this
+// component doesn't have to import the page-private SubmissionRow typedef.
+type SubmissionCardProps = {
+  submission: SubmissionWithDetails & {
+    roleTitle: string
+    customerName: string | null
+  }
+  timeAgo: (date: Date) => string
+}
+
+export function SubmissionCard({ submission, timeAgo }: SubmissionCardProps) {
+  const { candidate } = submission
+
+  const initials = (
+    (candidate.firstName[0] ?? '') +
+    (candidate.lastName[0] ?? '')
+  ).toUpperCase()
+
+  const roleLine = submission.customerName
+    ? `${submission.roleTitle} · ${submission.customerName}`
+    : submission.roleTitle
+
+  return (
+    <div
+      className="bg-[var(--color-bg-elevated)] rounded-lg border border-[var(--color-border)] p-4 mb-2"
+    >
+      {/* Row 1: candidate name + status pill */}
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          {/* Agency logo / initials — 20px per codebase convention */}
+          {candidate.agencyId && candidate.agencyLogoPath ? (
+            <img
+              src={`/api/agencies/${candidate.agencyId}/logo`}
+              alt={candidate.agencyName ?? ''}
+              width={20}
+              height={20}
+              className="rounded-full bg-zinc-800 object-contain shrink-0"
+              style={{ width: 20, height: 20 }}
+            />
+          ) : (
+            <div
+              className="flex items-center justify-center rounded-full bg-zinc-800
+                         text-zinc-400 text-[10px] font-semibold shrink-0"
+              style={{ width: 20, height: 20 }}
+              aria-hidden="true"
+            >
+              {initials}
+            </div>
+          )}
+
+          <Link
+            href={`/dashboard/candidates/${submission.candidateId}?roleId=${submission.roleId}`}
+            className="font-semibold text-[var(--color-fg)] hover:text-blue-400 truncate
+                       transition-colors"
+          >
+            {candidate.firstName} {candidate.lastName}
+          </Link>
+        </div>
+
+        <SubmissionStatusPill status={submission.status} />
+      </div>
+
+      {/* Row 2: role · customer */}
+      <p className="mt-1.5 text-xs text-[var(--color-fg-subtle)] truncate">
+        {roleLine}
+      </p>
+
+      {/* Row 3: timing */}
+      <p className="mt-0.5 text-xs text-[var(--color-fg-subtle)] tabular-nums">
+        Sent {timeAgo(submission.sentAt)} · last update {timeAgo(submission.statusUpdatedAt)}
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #68. Part of [Epic #66](https://github.com/olafkfreund/SkillAi/issues/66). PR2 of 5.

Includes the **Path B addition**: submissions index page (`/dashboard/submissions`) was shipped after Epic #66 was written, so wasn't in the original PR2 scope. Folded in here so the mobile loop is closed across all the table-heavy pages.

## Summary

- **Candidate list** (`selectable-candidate-list.tsx`): existing 8-column `<table>` wrapped in `hidden md:block` (inert below 768px); new `md:hidden` card stack — three rows per card with shared selection state. Tap targets ≥44×44px.
- **ComparisonTray** (`comparison-tray.tsx`): `fixed bottom-0` → `fixed bottom-16 md:bottom-0` so the tray sits 64px above the bottom on mobile, clearing sticky pagination. `z-40` → `z-30` (below drawer scrim).
- **Submissions index** (`dashboard/submissions/page.tsx`): 7-column `<table>` wrapped `hidden md:block`; new `md:hidden` card stack via new `<SubmissionCard>` component.
- **`candidate-filters.tsx`**: confirmed no `xs:` change needed (existing `flex-col gap-3 sm:flex-row` already stacks vertically on 375px without overflow).

## Strict invariant honoured

Desktop ≥`md:` is byte-identical. All new card markup is gated `<md:` only; tables are inert below `md`.

## Test plan

- [x] Typecheck clean (excluding pre-existing `src/instrumentation.ts` carry-over)
- [x] Lint: 4 `<img>` warnings (established agency-logo convention) + 1 `set-state-in-effect` error in `comparison-tray.tsx:21` (PRE-EXISTING from commit `a52b063`, out of scope)
- [x] Dev server compiled cleanly + dashboard served 200
- [ ] At 375px: candidate list shows cards (3-row layout) instead of table; tapping a card navigates; checkbox is ≥44×44 tap target
- [ ] At 1024px+: existing table preserved (byte-identical)
- [ ] ComparisonTray when 2+ candidates selected: appears 64px above bottom on mobile, flush bottom on desktop
- [ ] Submissions index: cards on mobile, table on desktop; status pill, role · customer subtitle, sent/last-update visible
- [ ] No regression on bulk-status-bar (potential overlap risk at the bottom; flagged for visual smoke)

## What's next

PR3 (#69) — candidate detail page (492-line hot leg) responsive reflow + Path B addition: manager-flow approval optimization (top-of-page Approve/Reject for `audience='manager'`). 2–3 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)