### PR TITLE
feat(mobile): PR3 — candidate detail page reflow + manager mobile Approve/Reject (closes #69)

### DIFF
--- a/src/app/(dashboard)/dashboard/candidates/[candidateId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/candidates/[candidateId]/page.tsx
@@ -40,6 +40,8 @@ import { listEmailTemplates } from '@/actions/email-templates'
 import { listSentEmailsForCandidate } from '@/actions/emails'
 import { GdprActionsPanel } from '@/components/candidates/gdpr-actions-panel'
 import { WelcomeLetterButton } from '@/components/candidates/welcome-letter-button'
+import { ManagerMobileActions } from '@/components/candidates/manager-mobile-actions'
+import { MobilePanel } from '@/components/candidates/mobile-panel'
 
 type Props = { params: Promise<{ candidateId: string }>; searchParams: Promise<{ roleId?: string }> }
 
@@ -249,11 +251,19 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
         {roleId ? 'Back to role' : 'All candidates'}
       </Link>
 
+      {/* Quick approve/reject for hiring managers on mobile — full ApprovalControls remains further down */}
+      <ManagerMobileActions
+        audience={audience}
+        roleId={roleId ?? null}
+        candidateId={candidateId}
+        currentDecision={roleId ? (myApprovalByRole.get(roleId)?.decision ?? null) : null}
+      />
+
       {/* Header */}
-      <div className="flex items-start justify-between mb-6">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between mb-6">
         <div>
           <div className="flex items-center gap-3 flex-wrap">
-            <h1 className="text-2xl font-bold text-zinc-100">
+            <h1 className="text-2xl font-bold text-zinc-100 break-words min-w-0">
               {candidate.firstName} {candidate.lastName}
             </h1>
             {canEdit && (
@@ -352,7 +362,7 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
           </div>
         </div>
         {activeScore?.score.scoreStatus === 'complete' && activeScore.score.overallScore !== null && (
-          <div className="text-center bg-blue-950 border border-blue-700 rounded-xl px-6 py-3">
+          <div className="text-center bg-blue-950 border border-blue-700 rounded-xl px-6 py-3 flex-shrink-0 self-start">
             <p className="text-3xl font-bold text-blue-300">{activeScore.score.overallScore}</p>
             <p className="text-xs text-blue-400 mt-0.5">Overall score</p>
           </div>
@@ -386,9 +396,9 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
 
       {/* Location & Language */}
       {(candidate.country || candidate.city || (candidate.languagesSpoken && candidate.languagesSpoken.length > 0)) && (
-        <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-6 mb-6">
+        <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-4 md:p-6 mb-6">
           <h3 className="text-sm font-semibold text-zinc-300 uppercase tracking-wide mb-3">Location & Language</h3>
-          <div className="flex flex-wrap gap-x-8 gap-y-2">
+          <div className="flex flex-wrap gap-x-3 gap-y-2 md:gap-x-8">
             {(candidate.country || candidate.city) && (
               <div>
                 <p className="text-xs text-zinc-500">Location</p>
@@ -415,9 +425,9 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
 
       {/* Commercial Details — hidden for hiring managers */}
       {!isHiringManager && (candidate.candidateRate || candidate.customerRate) && (
-        <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-6 mb-6">
+        <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-4 md:p-6 mb-6">
           <h3 className="text-sm font-semibold text-zinc-300 uppercase tracking-wide mb-3">Commercial Details</h3>
-          <div className="grid grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 xs:grid-cols-2 sm:grid-cols-3 gap-4">
             {candidate.candidateRate && (
               <div>
                 <p className="text-xs text-zinc-500">Candidate Rate/day</p>
@@ -457,7 +467,7 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
           currentStatus={activeScore.score.scoreStatus}
         />
       ) : activeScore?.score.scoreStatus === 'complete' ? (
-        <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-6 mb-6">
+        <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-4 md:p-6 mb-6">
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center gap-3 flex-wrap">
               <h2 className="font-semibold text-zinc-100">Score for: {activeScore.role.title}</h2>
@@ -507,7 +517,7 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
       {/* Manager approval controls — shown when the manager is assigned to one or
           more roles that this candidate has been scored on */}
       {isHiringManager && rolesWithThisCandidate.length > 0 && (
-        <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-6 mb-6">
+        <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-4 md:p-6 mb-6">
           <h2 className="font-semibold text-zinc-100 mb-1">Your Approval</h2>
           <p className="text-xs text-zinc-500 mb-4">
             Record your approval decision for each role this candidate has been shortlisted on.
@@ -536,45 +546,49 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
       )}
 
       {/* Web intelligence */}
-      <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-6 mb-6">
-        <div className="flex items-center justify-between mb-4">
-          <div>
-            <h2 className="font-semibold text-zinc-100">Web Intelligence</h2>
-            <p className="text-xs text-zinc-500 mt-0.5">
-              Search LinkedIn, GitHub, Reddit and more to build a fuller picture
-            </p>
+      <MobilePanel title="Web Intelligence">
+        <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-4 md:p-6 mb-6">
+          <div className="flex items-center justify-between mb-4">
+            <div>
+              <h2 className="font-semibold text-zinc-100">Web Intelligence</h2>
+              <p className="text-xs text-zinc-500 mt-0.5">
+                Search LinkedIn, GitHub, Reddit and more to build a fuller picture
+              </p>
+            </div>
           </div>
+          <EnrichmentPanel
+            candidateId={candidateId}
+            initialLinkedinUrl={candidate.linkedinUrl ?? null}
+            initialGithubUsername={candidate.githubUsername ?? null}
+            initialEnrichment={initialEnrichment}
+            canEdit={canEdit}
+          />
         </div>
-        <EnrichmentPanel
-          candidateId={candidateId}
-          initialLinkedinUrl={candidate.linkedinUrl ?? null}
-          initialGithubUsername={candidate.githubUsername ?? null}
-          initialEnrichment={initialEnrichment}
-          canEdit={canEdit}
-        />
-      </div>
+      </MobilePanel>
 
       {/* Interview packs */}
-      <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-6 mb-6">
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="font-semibold text-zinc-100">Interview Packs</h2>
-          {allRoles.length > 0 && (
-            <div className="flex flex-wrap gap-2">
-              {allRoles.map((role) => (
-                <PackGenerator
-                  key={role.id}
-                  candidateId={candidateId}
-                  roleId={role.id}
-                  roleName={role.title}
-                  candidateLanguages={candidate.languagesSpoken ?? []}
-                  tenantDefaultLanguage={tenantDefaultLanguage}
-                />
-              ))}
-            </div>
-          )}
+      <MobilePanel title="Interview Packs">
+        <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-4 md:p-6 mb-6">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="font-semibold text-zinc-100">Interview Packs</h2>
+            {allRoles.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {allRoles.map((role) => (
+                  <PackGenerator
+                    key={role.id}
+                    candidateId={candidateId}
+                    roleId={role.id}
+                    roleName={role.title}
+                    candidateLanguages={candidate.languagesSpoken ?? []}
+                    tenantDefaultLanguage={tenantDefaultLanguage}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+          <PackList candidateId={candidateId} />
         </div>
-        <PackList candidateId={candidateId} />
-      </div>
+      </MobilePanel>
 
       {/* Interview Transcripts */}
       <TranscriptSection
@@ -583,45 +597,49 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
       />
 
       {/* Interview Schedule */}
-      <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-6 mb-6">
-        <h2 className="font-semibold text-zinc-100 mb-4">Interview Schedule</h2>
-        {canEdit && (
-          <div className="mb-4">
-            <IcsImportButton candidateId={candidateId} roleId={roleId ?? null} />
-          </div>
-        )}
-        <InterviewCalendar
-          candidateId={candidateId}
-          candidateName={`${candidate.firstName} ${candidate.lastName}`}
-          roleId={roleId}
-          initialSlots={initialSlots}
-          canSchedule={canEdit}
-          allRoles={allRoles}
-          hasGoogleCalendar={hasGoogleCalendar}
-          hasMicrosoftCalendar={hasMicrosoftCalendar}
-        />
-      </div>
+      <MobilePanel title="Interview Schedule">
+        <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-4 md:p-6 mb-6">
+          <h2 className="font-semibold text-zinc-100 mb-4">Interview Schedule</h2>
+          {canEdit && (
+            <div className="mb-4">
+              <IcsImportButton candidateId={candidateId} roleId={roleId ?? null} />
+            </div>
+          )}
+          <InterviewCalendar
+            candidateId={candidateId}
+            candidateName={`${candidate.firstName} ${candidate.lastName}`}
+            roleId={roleId}
+            initialSlots={initialSlots}
+            canSchedule={canEdit}
+            allRoles={allRoles}
+            hasGoogleCalendar={hasGoogleCalendar}
+            hasMicrosoftCalendar={hasMicrosoftCalendar}
+          />
+        </div>
+      </MobilePanel>
 
       {/* CV Profile */}
-      <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-6 mb-6">
-        <h2 className="font-semibold text-zinc-100 mb-4">CV Profile</h2>
-        <CandidateCvProfile
-          candidateId={candidateId}
-          cvText={candidate.cvText}
-          cvTextFormatted={candidate.cvTextFormatted}
-          profile={cvProfileRow ? {
-            experienceLevel: cvProfileRow.experienceLevel,
-            summary: cvProfileRow.summary,
-            technicalSkills: cvProfileRow.technicalSkills ?? [],
-            companies: cvProfileRow.companies ?? [],
-            personalizableMoments: cvProfileRow.personalizableMoments ?? [],
-            extractionStatus: cvProfileRow.extractionStatus,
-            errorMessage: cvProfileRow.errorMessage,
-            extractedAt: cvProfileRow.extractedAt ? cvProfileRow.extractedAt.toISOString() : null,
-          } : null}
-          canEdit={canEdit}
-        />
-      </div>
+      <MobilePanel title="CV Profile">
+        <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-4 md:p-6 mb-6">
+          <h2 className="font-semibold text-zinc-100 mb-4">CV Profile</h2>
+          <CandidateCvProfile
+            candidateId={candidateId}
+            cvText={candidate.cvText}
+            cvTextFormatted={candidate.cvTextFormatted}
+            profile={cvProfileRow ? {
+              experienceLevel: cvProfileRow.experienceLevel,
+              summary: cvProfileRow.summary,
+              technicalSkills: cvProfileRow.technicalSkills ?? [],
+              companies: cvProfileRow.companies ?? [],
+              personalizableMoments: cvProfileRow.personalizableMoments ?? [],
+              extractionStatus: cvProfileRow.extractionStatus,
+              errorMessage: cvProfileRow.errorMessage,
+              extractedAt: cvProfileRow.extractedAt ? cvProfileRow.extractedAt.toISOString() : null,
+            } : null}
+            canEdit={canEdit}
+          />
+        </div>
+      </MobilePanel>
 
       {/* Notes */}
       <NotesPanel

--- a/src/components/candidates/manager-mobile-actions.tsx
+++ b/src/components/candidates/manager-mobile-actions.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { CheckIcon, XIcon } from 'lucide-react'
+import { approveCandidate, rejectCandidate } from '@/actions/approvals'
+
+type Props = {
+  audience: 'recruiter' | 'customer' | 'manager'
+  roleId: string | null
+  candidateId: string
+  currentDecision?: 'approved' | 'rejected' | 'pending' | null
+}
+
+export function ManagerMobileActions({
+  audience,
+  roleId,
+  candidateId,
+  currentDecision,
+}: Props) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+
+  // Only render for managers with a role context — decision is always per-role
+  if (audience !== 'manager' || roleId === null) return null
+
+  function handleApprove() {
+    startTransition(async () => {
+      await approveCandidate(roleId!, candidateId)
+      router.refresh()
+    })
+  }
+
+  function handleReject() {
+    startTransition(async () => {
+      await rejectCandidate(roleId!, candidateId)
+      router.refresh()
+    })
+  }
+
+  const isApproved = currentDecision === 'approved'
+  const isRejected = currentDecision === 'rejected'
+
+  return (
+    <div className="md:hidden mb-4 grid grid-cols-2 gap-2">
+      <button
+        type="button"
+        onClick={handleApprove}
+        disabled={isPending}
+        aria-label="Approve candidate"
+        className={`flex items-center justify-center gap-2 rounded-lg py-3 text-sm font-semibold transition-colors
+                    min-h-[44px]
+                    ${isApproved
+                      ? 'bg-emerald-700 text-emerald-100 ring-2 ring-emerald-400'
+                      : 'bg-emerald-600 hover:bg-emerald-500 text-white'
+                    }
+                    disabled:opacity-50 disabled:cursor-not-allowed`}
+      >
+        <CheckIcon className="h-4 w-4 shrink-0" />
+        {isApproved ? 'Approved' : 'Approve'}
+      </button>
+
+      <button
+        type="button"
+        onClick={handleReject}
+        disabled={isPending}
+        aria-label="Reject candidate"
+        className={`flex items-center justify-center gap-2 rounded-lg py-3 text-sm font-semibold transition-colors
+                    min-h-[44px]
+                    ${isRejected
+                      ? 'bg-red-700 text-red-100 ring-2 ring-red-400'
+                      : 'bg-red-600 hover:bg-red-500 text-white'
+                    }
+                    disabled:opacity-50 disabled:cursor-not-allowed`}
+      >
+        <XIcon className="h-4 w-4 shrink-0" />
+        {isRejected ? 'Rejected' : 'Reject'}
+      </button>
+    </div>
+  )
+}

--- a/src/components/candidates/mobile-panel.tsx
+++ b/src/components/candidates/mobile-panel.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { ChevronDownIcon } from 'lucide-react'
+
+type Props = {
+  title: string
+  /**
+   * Whether the panel is expanded on mount.
+   * Defaults to true — mobile users expect to see content immediately
+   * rather than having to tap every section open.
+   */
+  defaultOpen?: boolean
+  /**
+   * Must be a SINGLE child component instance.
+   *
+   * At md:+ both this <details> and the inner <div> have `display: contents`,
+   * which removes them from the layout box model entirely. Their children
+   * flow directly into the parent grid/flex context as if the wrapper were
+   * not there at all. If you pass multiple siblings as children they will
+   * each claim a grid track, breaking the parent's expected column layout.
+   */
+  children: React.ReactNode
+}
+
+/**
+ * Collapsible panel for mobile, invisible wrapper for desktop.
+ *
+ * Below md: renders as a themed <details> / <summary> accordion.
+ * At md+:   `display: contents` on both the <details> and inner <div>
+ *           removes the wrapper from the layout entirely — the single child
+ *           flows straight into whatever grid or flex context the parent uses,
+ *           keeping desktop layout byte-identical to a plain unwrapped render.
+ */
+export function MobilePanel({ title, defaultOpen = true, children }: Props) {
+  return (
+    <details
+      open={defaultOpen}
+      // md:contents — the element has no layout box at md+; only its children
+      // participate in the parent layout. This is the mechanism that makes the
+      // wrapper invisible to desktop grid/flex parents.
+      className="group md:contents bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] md:bg-transparent md:rounded-none md:border-0"
+    >
+      {/* md:hidden — belt + braces alongside md:contents; summary never renders
+          a click target on desktop regardless of how the browser handles
+          display:contents on a <details> element. */}
+      <summary className="md:hidden flex items-center justify-between gap-3 px-4 py-3 cursor-pointer list-none select-none">
+        <span className="text-sm font-semibold text-[var(--color-fg)]">{title}</span>
+        <ChevronDownIcon
+          className="h-4 w-4 text-[var(--color-fg-muted)] transition-transform group-open:rotate-180"
+          aria-hidden="true"
+        />
+      </summary>
+      {/* md:contents mirrors the outer element — removes this div from layout
+          at md+ so the single child component lands directly in the parent context. */}
+      <div className="md:contents px-4 pb-4 md:p-0">
+        {children}
+      </div>
+    </details>
+  )
+}


### PR DESCRIPTION
Closes #69. Part of [Epic #66](https://github.com/olafkfreund/SkillAi/issues/66). PR3 of 5 — largest reflow effort in the epic (492-line candidate detail page).

Includes the **Path B addition**: hiring managers get a top-of-page Approve/Reject bar on mobile so they can decide without scrolling past recruiter chrome.

## Summary

**Page reflow:**
- Header: stacks on mobile, original layout at `md:+`
- Candidate name `h1`: `break-words min-w-0` for long-name overflow safety
- Commercial Details grid: `grid-cols-1 xs:grid-cols-2 sm:grid-cols-3` (uses the new `xs:400px` breakpoint from PR1)
- Panel padding: `p-6 → p-4 md:p-6` across all card containers
- Header gaps: `gap-x-3 md:gap-x-8`
- Web Intel / Interview Packs / Schedule / CV Profile wrapped in `<MobilePanel>`

**`<MobilePanel>` (new):** `<details>`-based wrapper. Collapsible on `<md:`, transparent via `display: contents` on `md:+`. Single-child constraint documented — wrapping multiple siblings would break the parent's column grid at `md:+`.

**`<ManagerMobileActions>` (new — Path B):** `md:hidden` 2-column grid of Approve / Reject buttons (≥44×44px tap target). Renders only when `audience='manager' && roleId`. Reflects prior decision via `myApprovalByRole`. Uses existing `approveCandidate`/`rejectCandidate` server actions. Per-card `<ApprovalControls>` below remains unchanged — additive only.

## Strict invariant honoured

Desktop ≥`md:` byte-identical. Every `md:` class added is paired with a new `<md:` base; no existing `md:`/`lg:` class was removed or changed. `<MobilePanel>` transparently disappears at `md:+` so existing card chrome inside child components renders untouched.

## Test plan

- [x] Typecheck clean (only the pre-existing `src/instrumentation.ts` carry-over)
- [x] Lint: 1 pre-existing `<img>` warning at line 288 (agency-logo convention)
- [x] Dev server compiled cleanly + dashboard 200
- [ ] At 375px: candidate detail page is fully scannable top-to-bottom; no horizontal scroll; long names don't overflow; Web Intel/Schedule/CV Profile panels are collapsible
- [ ] At 1024px+: existing layout preserved (byte-identical)
- [ ] As hiring manager on mobile with a candidate in role context: top-of-page Approve/Reject bar visible; tapping calls the existing actions; current decision reflected with muted/ring styling
- [ ] As hiring manager on desktop: top-of-page bar hidden (`md:hidden`); per-card `<ApprovalControls>` still works
- [ ] As recruiter on mobile: top-of-page bar hidden (`audience !== 'manager'`)

## What's next

PR4 (#70) — forms + modals + tap-target audit. ~50 icon buttons get bumped from `p-1` to `p-2`+; form `grid-cols-2/3` gets `<md:` stacking. 2 days. Same parallel-agents pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)