### PR TITLE
feat(mobile): PR5 — PWA capstone (closes #71, completes Epic #66)

### DIFF
--- a/public/icons/icon-192.svg
+++ b/public/icons/icon-192.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" role="img" aria-label="SkillAI">
+  <rect width="192" height="192" rx="32" fill="#09090b"/>
+  <text x="96" y="118" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, sans-serif"
+        font-size="92" font-weight="700" fill="#3b82f6" text-anchor="middle">S</text>
+</svg>

--- a/public/icons/icon-512.svg
+++ b/public/icons/icon-512.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="SkillAI">
+  <rect width="512" height="512" rx="80" fill="#09090b"/>
+  <text x="256" y="318" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, sans-serif"
+        font-size="248" font-weight="700" fill="#3b82f6" text-anchor="middle">S</text>
+</svg>

--- a/public/icons/icon-maskable-512.svg
+++ b/public/icons/icon-maskable-512.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="SkillAI">
+  <rect width="512" height="512" fill="#09090b"/>
+  <text x="256" y="298" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, sans-serif"
+        font-size="200" font-weight="700" fill="#3b82f6" text-anchor="middle">S</text>
+</svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,32 @@
+{
+  "name": "SkillAI — Recruiting Portal",
+  "short_name": "SkillAI",
+  "description": "AI-powered candidate ranking and interview management",
+  "start_url": "/dashboard",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "any",
+  "theme_color": "#09090b",
+  "background_color": "#09090b",
+  "categories": ["business", "productivity"],
+  "icons": [
+    {
+      "src": "/icons/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/icons/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/icons/icon-maskable-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,100 @@
+// SkillAi service worker — minimal, hand-rolled.
+// Strategy:
+//   * /api/*           → never touched (always live; never cached)
+//   * /_next/static/*  → cache-first (immutable Next.js build assets)
+//   * everything else  → network-first with a cache fallback for offline browsing
+//
+// Bump CACHE_VERSION when the SW logic changes; old caches are pruned in `activate`.
+
+const CACHE_VERSION = 'v1'
+const STATIC_CACHE = `skillai-static-${CACHE_VERSION}`
+const RUNTIME_CACHE = `skillai-runtime-${CACHE_VERSION}`
+
+self.addEventListener('install', (event) => {
+  // Activate immediately on first install — no waiting for an old SW to release.
+  self.skipWaiting()
+  event.waitUntil(
+    caches.open(STATIC_CACHE).then((cache) =>
+      // Pre-cache the manifest so installation works offline-first
+      cache.addAll(['/manifest.json']).catch(() => {})
+    )
+  )
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    Promise.all([
+      // Claim all open clients so the new SW takes effect without a reload
+      self.clients.claim(),
+      // Prune any prior-version caches
+      caches.keys().then((keys) =>
+        Promise.all(
+          keys
+            .filter((k) => !k.endsWith(`-${CACHE_VERSION}`))
+            .map((k) => caches.delete(k))
+        )
+      ),
+    ])
+  )
+})
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event
+  if (request.method !== 'GET') return
+
+  const url = new URL(request.url)
+  if (url.origin !== self.location.origin) return
+
+  // Never intercept API calls — server must always be live.
+  if (url.pathname.startsWith('/api/')) return
+
+  // Cache-first for immutable Next.js build assets.
+  if (url.pathname.startsWith('/_next/static/')) {
+    event.respondWith(cacheFirst(request))
+    return
+  }
+
+  // Network-first for everything else (HTML pages + public static assets).
+  event.respondWith(networkFirst(request))
+})
+
+async function cacheFirst(request) {
+  const cached = await caches.match(request)
+  if (cached) return cached
+  try {
+    const fresh = await fetch(request)
+    if (fresh.ok) {
+      const cache = await caches.open(STATIC_CACHE)
+      cache.put(request, fresh.clone())
+    }
+    return fresh
+  } catch (err) {
+    return new Response('Offline — asset unavailable', { status: 503 })
+  }
+}
+
+async function networkFirst(request) {
+  try {
+    const fresh = await fetch(request)
+    if (fresh.ok) {
+      const cache = await caches.open(RUNTIME_CACHE)
+      cache.put(request, fresh.clone())
+    }
+    return fresh
+  } catch (err) {
+    const cached = await caches.match(request)
+    if (cached) return cached
+    // Last-resort offline page — return a minimal HTML response.
+    if (request.mode === 'navigate') {
+      return new Response(
+        `<!doctype html><html><head><meta charset="utf-8"><title>Offline</title>
+         <meta name="viewport" content="width=device-width,initial-scale=1">
+         <style>body{font-family:system-ui;background:#09090b;color:#e4e4e7;margin:0;padding:32px;text-align:center;}
+         h1{font-size:18px;font-weight:600;margin:32px 0 8px}p{font-size:14px;color:#71717a}</style></head>
+         <body><h1>You're offline</h1><p>Reconnect and reload to continue.</p></body></html>`,
+        { headers: { 'Content-Type': 'text/html; charset=utf-8' }, status: 200 }
+      )
+    }
+    return new Response('Offline', { status: 503 })
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,6 +16,19 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "SkillAI — Recruiting Portal",
   description: "AI-powered candidate ranking and interview management",
+  manifest: "/manifest.json",
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: "black-translucent",
+    title: "SkillAI",
+  },
+  icons: {
+    icon: [
+      { url: "/icons/icon-192.svg", sizes: "192x192", type: "image/svg+xml" },
+      { url: "/icons/icon-512.svg", sizes: "512x512", type: "image/svg+xml" },
+    ],
+    apple: [{ url: "/icons/icon-192.svg", sizes: "192x192", type: "image/svg+xml" }],
+  },
 };
 
 export const viewport: Viewport = {

--- a/src/components/layout/top-app-bar.tsx
+++ b/src/components/layout/top-app-bar.tsx
@@ -2,6 +2,7 @@
 
 import { MenuIcon } from 'lucide-react'
 import { ThemeToggle } from '@/components/theme/theme-toggle'
+import { InstallPrompt } from '@/components/pwa/install-prompt'
 
 type Props = {
   /** Called when the hamburger button is tapped — opens the mobile drawer. */
@@ -47,15 +48,9 @@ export function TopAppBar({ onMenuClick, title }: Props) {
         <span className="flex-1 text-sm font-bold text-[var(--color-fg)]">SkillAI</span>
       )}
 
-      {/* Right side: theme toggle */}
-      {/*
-        ThemeToggle renders a full-width button styled for the sidebar.
-        Here we constrain it to icon-only size.
-        TODO: extract an icon-only variant from ThemeToggle if the label
-        becomes visually awkward in narrow bars — for now the component
-        is hidden at ≥lg so desktop layout is unaffected.
-      */}
-      <div className="flex-shrink-0">
+      {/* Right side: install prompt (when eligible) + theme toggle */}
+      <div className="flex items-center gap-2 flex-shrink-0">
+        <InstallPrompt />
         <ThemeToggle />
       </div>
     </header>

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -2,6 +2,7 @@
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useState } from 'react'
+import { ServiceWorkerRegister } from '@/components/pwa/service-worker-register'
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -18,6 +19,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
 
   return (
     <QueryClientProvider client={queryClient}>
+      <ServiceWorkerRegister />
       {children}
     </QueryClientProvider>
   )

--- a/src/components/pwa/install-prompt.tsx
+++ b/src/components/pwa/install-prompt.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { DownloadIcon } from 'lucide-react'
+
+// `beforeinstallprompt` is non-standard but supported in Chromium + Edge.
+// Safari iOS doesn't fire it (users install via the share-sheet "Add to Home
+// Screen"); the apple-mobile-web-app-capable meta in the root layout makes
+// that path work without an in-app prompt. So this component is effectively
+// the Android / Chromium install affordance.
+type BeforeInstallPromptEvent = Event & {
+  prompt: () => Promise<void>
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>
+}
+
+export function InstallPrompt() {
+  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null)
+  const [installed, setInstalled] = useState(false)
+
+  useEffect(() => {
+    const onBeforeInstall = (e: Event) => {
+      // Suppress the browser's default mini-bar; we'll trigger via our own button.
+      e.preventDefault()
+      setDeferredPrompt(e as BeforeInstallPromptEvent)
+    }
+    const onInstalled = () => {
+      setDeferredPrompt(null)
+      setInstalled(true)
+    }
+    window.addEventListener('beforeinstallprompt', onBeforeInstall)
+    window.addEventListener('appinstalled', onInstalled)
+    return () => {
+      window.removeEventListener('beforeinstallprompt', onBeforeInstall)
+      window.removeEventListener('appinstalled', onInstalled)
+    }
+  }, [])
+
+  if (installed || !deferredPrompt) return null
+
+  return (
+    <button
+      type="button"
+      onClick={async () => {
+        await deferredPrompt.prompt()
+        const choice = await deferredPrompt.userChoice
+        if (choice.outcome === 'accepted') setInstalled(true)
+        setDeferredPrompt(null)
+      }}
+      className="inline-flex items-center gap-1.5 rounded-md border border-blue-700 bg-blue-950 text-blue-300 text-xs font-medium
+                 px-2.5 py-1.5 hover:bg-blue-900 hover:text-blue-200 transition-colors"
+      aria-label="Install SkillAI as an app"
+    >
+      <DownloadIcon className="h-3.5 w-3.5" />
+      Install
+    </button>
+  )
+}

--- a/src/components/pwa/service-worker-register.tsx
+++ b/src/components/pwa/service-worker-register.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { useEffect } from 'react'
+
+// Registers /sw.js once on mount. Runs only in the browser. Failures are
+// non-fatal and quietly logged — a missing or broken SW must never block
+// the app from rendering.
+export function ServiceWorkerRegister() {
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    if (!('serviceWorker' in navigator)) return
+    navigator.serviceWorker
+      .register('/sw.js', { scope: '/' })
+      .catch((err) => {
+        console.warn('[sw] registration failed:', err)
+      })
+  }, [])
+
+  return null
+}


### PR DESCRIPTION
Closes #71. **Final piece of [Epic #66](https://github.com/olafkfreund/SkillAi/issues/66).** SkillAi is now installable on phones + tablets as a Progressive Web App.

## Summary

- `public/manifest.json` — name, start_url=/dashboard, display=standalone, theme/background = `#09090b`, 3 SVG icons (192, 512, maskable-512)
- `public/icons/icon-{192,512,maskable-512}.svg` — simple zinc-950 background + blue "S" letter; maskable variant has flat background for Android adaptive icon safe-zone
- `public/sw.js` — hand-rolled ~80-line service worker:
  - `/api/*` never intercepted
  - `/_next/static/*` cache-first
  - everything else network-first with cache fallback + offline HTML
  - versioned caches with prune-on-activate
- `<InstallPrompt>` — Chromium `beforeinstallprompt` capture, renders a small "Install" pill in the top app bar
- `<ServiceWorkerRegister>` — registers `/sw.js` once on mount
- Root `layout.tsx` wired with `manifest`, `appleWebApp`, and `icons` metadata
- Top app bar hosts `<InstallPrompt>` alongside `<ThemeToggle>`
- `<Providers>` mounts `<ServiceWorkerRegister>`

## Test plan

- [x] Typecheck clean
- [x] Lint clean (zero warnings on touched files)
- [x] `/manifest.json`, `/sw.js`, `/icons/icon-192.svg` all served `200`
- [x] Dev server compiled cleanly
- [ ] Chrome on Android: "Add to Home Screen" works → app launches in standalone (no browser chrome) at `/dashboard`
- [ ] iOS Safari: share-sheet "Add to Home Screen" → standalone launch with `apple-mobile-web-app-capable`
- [ ] Service worker registers on first visit; check DevTools → Application → Service Workers
- [ ] Offline test: load app online, then go offline → reload → see cached HTML (or the offline-fallback page for routes not yet cached)
- [ ] `/api/*` requests fail when offline (intentional — never cached)
- [ ] Install pill appears in the top app bar on mobile Chrome (Chromium `beforeinstallprompt`); not on iOS Safari (uses share-sheet path)

## Out of scope (deferred to v2)

- Push notifications (server push infra needed)
- Background sync
- Offline editing of candidates

## Epic #66 progress

**5/5 PRs delivered.** Mobile + tablet responsive support is now feature-complete.

| PR | What | Status |
|---|---|---|
| #155 (#67) | Sidebar drawer + top app bar + viewport meta + xs:400 | ✅ Merged |
| #156 (#68) | Candidate list cards + ComparisonTray + submissions index | ✅ Merged |
| #157 (#69) | Candidate detail reflow + manager mobile Approve/Reject | ✅ Merged |
| #158 (#70) | Forms + modals + tap-target audit | ✅ Merged |
| **This PR (#71)** | **PWA capstone** | **Pending merge** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)