### PR TITLE
refactor(theme): PR1 — dashboard pages + status-pill light/dark sweep (part of #103)

### DIFF
--- a/src/app/(dashboard)/dashboard/agencies/[agencyId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/agencies/[agencyId]/page.tsx
@@ -125,7 +125,7 @@ export default async function AgencyDetailPage({ params }: Props) {
   return (
     <div>
       <div className="mb-6">
-        <Link href="/dashboard/agencies" className="text-sm text-zinc-500 hover:text-zinc-300">
+        <Link href="/dashboard/agencies" className="text-sm text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)]">
           ← Back to agencies
         </Link>
         <div className="flex items-center gap-4 mt-2">
@@ -136,12 +136,12 @@ export default async function AgencyDetailPage({ params }: Props) {
               alt=""
               width={64}
               height={64}
-              className="rounded-xl border border-zinc-700 bg-zinc-800 object-contain shrink-0"
+              className="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-input)] object-contain shrink-0"
               style={{ width: 64, height: 64 }}
             />
           ) : (
             <div
-              className="flex items-center justify-center rounded-xl bg-zinc-800 text-zinc-400
+              className="flex items-center justify-center rounded-xl bg-[var(--color-bg-input)] text-[var(--color-fg-muted)]
                          text-xl font-semibold shrink-0"
               style={{ width: 64, height: 64 }}
               aria-hidden="true"
@@ -149,13 +149,13 @@ export default async function AgencyDetailPage({ params }: Props) {
               {agency.name.charAt(0).toUpperCase()}
             </div>
           )}
-          <h1 className="text-2xl font-bold text-zinc-100 flex items-center gap-2">
+          <h1 className="text-2xl font-bold text-[var(--color-fg)] flex items-center gap-2">
             {agency.isInternal && <HomeIcon className="h-5 w-5 text-blue-400" />}
             {agency.name}
             {agency.isSystem && (
               <span
-                className="inline-flex items-center gap-1 rounded-full border border-zinc-600 bg-zinc-800
-                           text-zinc-300 text-xs font-medium px-2 py-0.5"
+                className="inline-flex items-center gap-1 rounded-full border border-[var(--color-border)] bg-[var(--color-bg-input)]
+                           text-[var(--color-fg)] text-xs font-medium px-2 py-0.5"
                 title="System agency — managed by SkillAI, cannot be archived"
               >
                 <LockIcon className="h-3 w-3" />
@@ -172,23 +172,23 @@ export default async function AgencyDetailPage({ params }: Props) {
           {canEdit ? (
             <AgencyEditForm agency={agency} />
           ) : (
-            <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-6 space-y-4">
+            <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-6 space-y-4">
               {agency.contactEmail && (
                 <div>
-                  <p className="text-xs font-medium text-zinc-500 uppercase tracking-wide">Email</p>
-                  <p className="text-sm text-zinc-300 mt-0.5">{agency.contactEmail}</p>
+                  <p className="text-xs font-medium text-[var(--color-fg-subtle)] uppercase tracking-wide">Email</p>
+                  <p className="text-sm text-[var(--color-fg)] mt-0.5">{agency.contactEmail}</p>
                 </div>
               )}
               {agency.contactPhone && (
                 <div>
-                  <p className="text-xs font-medium text-zinc-500 uppercase tracking-wide">Phone</p>
-                  <p className="text-sm text-zinc-300 mt-0.5">{agency.contactPhone}</p>
+                  <p className="text-xs font-medium text-[var(--color-fg-subtle)] uppercase tracking-wide">Phone</p>
+                  <p className="text-sm text-[var(--color-fg)] mt-0.5">{agency.contactPhone}</p>
                 </div>
               )}
               {agency.notes && (
                 <div>
-                  <p className="text-xs font-medium text-zinc-500 uppercase tracking-wide">Notes</p>
-                  <p className="text-sm text-zinc-300 mt-0.5 whitespace-pre-wrap">{agency.notes}</p>
+                  <p className="text-xs font-medium text-[var(--color-fg-subtle)] uppercase tracking-wide">Notes</p>
+                  <p className="text-sm text-[var(--color-fg)] mt-0.5 whitespace-pre-wrap">{agency.notes}</p>
                 </div>
               )}
             </div>
@@ -212,38 +212,38 @@ export default async function AgencyDetailPage({ params }: Props) {
 
       {/* ── Agency Performance ─────────────────────────────────────────────── */}
       <div className="mt-8">
-        <h2 className="text-lg font-semibold text-zinc-100 mb-4">Agency Performance</h2>
+        <h2 className="text-lg font-semibold text-[var(--color-fg)] mb-4">Agency Performance</h2>
 
         {/* Stat cards */}
         <div className="grid grid-cols-1
                         sm:grid-cols-3 gap-4 mb-6">
           {/* Total candidates */}
-          <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-5">
-            <p className="text-xs text-zinc-500 mb-2">Total Candidates</p>
-            <p className="text-3xl font-bold text-zinc-100">
+          <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-5">
+            <p className="text-xs text-[var(--color-fg-subtle)] mb-2">Total Candidates</p>
+            <p className="text-3xl font-bold text-[var(--color-fg)]">
               {perfStats?.totalCandidates ?? 0}
             </p>
           </div>
 
           {/* Average overall score */}
-          <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-5">
-            <p className="text-xs text-zinc-500 mb-2">Avg Overall Score</p>
+          <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-5">
+            <p className="text-xs text-[var(--color-fg-subtle)] mb-2">Avg Overall Score</p>
             {avgScoreDisplay !== null ? (
-              <p className="text-3xl font-bold text-zinc-100">
+              <p className="text-3xl font-bold text-[var(--color-fg)]">
                 {avgScoreDisplay}
-                <span className="text-base font-normal text-zinc-500">/100</span>
+                <span className="text-base font-normal text-[var(--color-fg-subtle)]">/100</span>
               </p>
             ) : (
-              <p className="text-3xl font-bold text-zinc-500">—</p>
+              <p className="text-3xl font-bold text-[var(--color-fg-subtle)]">—</p>
             )}
           </div>
 
           {/* Highest scoring candidate */}
-          <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-5">
-            <p className="text-xs text-zinc-500 mb-2">Top Candidate</p>
+          <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-5">
+            <p className="text-xs text-[var(--color-fg-subtle)] mb-2">Top Candidate</p>
             {topCandidate ? (
               <div>
-                <p className="text-base font-semibold text-zinc-100 truncate">
+                <p className="text-base font-semibold text-[var(--color-fg)] truncate">
                   {topCandidate.firstName} {topCandidate.lastName}
                 </p>
                 <p className="text-sm text-green-400 font-medium">
@@ -251,44 +251,44 @@ export default async function AgencyDetailPage({ params }: Props) {
                 </p>
               </div>
             ) : (
-              <p className="text-base text-zinc-500">No scored candidates</p>
+              <p className="text-base text-[var(--color-fg-subtle)]">No scored candidates</p>
             )}
           </div>
         </div>
 
         {/* Score distribution */}
-        <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-5">
-          <h3 className="text-sm font-semibold text-zinc-300 uppercase tracking-wide mb-4">
+        <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-5">
+          <h3 className="text-sm font-semibold text-[var(--color-fg)] uppercase tracking-wide mb-4">
             Score Distribution
           </h3>
           {(distribution?.excellent ?? 0) + (distribution?.good ?? 0) + (distribution?.below ?? 0) === 0 ? (
-            <p className="text-sm text-zinc-500">No completed scores yet for this agency.</p>
+            <p className="text-sm text-[var(--color-fg-subtle)]">No completed scores yet for this agency.</p>
           ) : (
             <ul className="space-y-3">
               <li className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
                   <span className="inline-block w-2.5 h-2.5 rounded-full bg-green-500" />
-                  <span className="text-sm text-zinc-300">Excellent (≥ 75)</span>
+                  <span className="text-sm text-[var(--color-fg)]">Excellent (≥ 75)</span>
                 </div>
-                <span className="text-sm font-semibold text-zinc-100">
+                <span className="text-sm font-semibold text-[var(--color-fg)]">
                   {distribution?.excellent ?? 0} candidate{(distribution?.excellent ?? 0) === 1 ? '' : 's'}
                 </span>
               </li>
               <li className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
                   <span className="inline-block w-2.5 h-2.5 rounded-full bg-blue-500" />
-                  <span className="text-sm text-zinc-300">Good (50 – 74)</span>
+                  <span className="text-sm text-[var(--color-fg)]">Good (50 – 74)</span>
                 </div>
-                <span className="text-sm font-semibold text-zinc-100">
+                <span className="text-sm font-semibold text-[var(--color-fg)]">
                   {distribution?.good ?? 0} candidate{(distribution?.good ?? 0) === 1 ? '' : 's'}
                 </span>
               </li>
               <li className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
                   <span className="inline-block w-2.5 h-2.5 rounded-full bg-red-500" />
-                  <span className="text-sm text-zinc-300">Below threshold (&lt; 50)</span>
+                  <span className="text-sm text-[var(--color-fg)]">Below threshold (&lt; 50)</span>
                 </div>
-                <span className="text-sm font-semibold text-zinc-100">
+                <span className="text-sm font-semibold text-[var(--color-fg)]">
                   {distribution?.below ?? 0} candidate{(distribution?.below ?? 0) === 1 ? '' : 's'}
                 </span>
               </li>

--- a/src/app/(dashboard)/dashboard/agencies/new/page.tsx
+++ b/src/app/(dashboard)/dashboard/agencies/new/page.tsx
@@ -10,13 +10,13 @@ export default function NewAgencyPage() {
   return (
     <div className="max-w-xl">
       <div className="mb-6">
-        <Link href="/dashboard/agencies" className="text-sm text-zinc-500 hover:text-zinc-300">
+        <Link href="/dashboard/agencies" className="text-sm text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)]">
           ← Back to agencies
         </Link>
-        <h1 className="text-2xl font-bold text-zinc-100 mt-2">Add agency</h1>
+        <h1 className="text-2xl font-bold text-[var(--color-fg)] mt-2">Add agency</h1>
       </div>
 
-      <form action={action} className="space-y-5 bg-zinc-900 rounded-xl border border-zinc-700 p-6">
+      <form action={action} className="space-y-5 bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-6">
         {state?.error && (
           <div className="rounded-md bg-red-950 border border-red-800 px-4 py-3 text-sm text-red-400">
             {state.error}
@@ -24,7 +24,7 @@ export default function NewAgencyPage() {
         )}
 
         <div>
-          <label className="block text-sm font-medium text-zinc-300 mb-1" htmlFor="name">
+          <label className="block text-sm font-medium text-[var(--color-fg)] mb-1" htmlFor="name">
             Agency name <span className="text-red-500">*</span>
           </label>
           <input
@@ -33,14 +33,14 @@ export default function NewAgencyPage() {
             type="text"
             required
             placeholder="e.g. TechSearch Partners"
-            className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                       placeholder:text-zinc-500
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                       placeholder:text-[var(--color-fg-subtle)]
                        focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-zinc-300 mb-1" htmlFor="contactEmail">
+          <label className="block text-sm font-medium text-[var(--color-fg)] mb-1" htmlFor="contactEmail">
             Contact email
           </label>
           <input
@@ -48,14 +48,14 @@ export default function NewAgencyPage() {
             name="contactEmail"
             type="email"
             placeholder="contact@agency.com"
-            className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                       placeholder:text-zinc-500
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                       placeholder:text-[var(--color-fg-subtle)]
                        focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-zinc-300 mb-1" htmlFor="contactPhone">
+          <label className="block text-sm font-medium text-[var(--color-fg)] mb-1" htmlFor="contactPhone">
             Contact phone
           </label>
           <input
@@ -63,14 +63,14 @@ export default function NewAgencyPage() {
             name="contactPhone"
             type="tel"
             placeholder="+1 (555) 000-0000"
-            className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                       placeholder:text-zinc-500
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                       placeholder:text-[var(--color-fg-subtle)]
                        focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-zinc-300 mb-1" htmlFor="notes">
+          <label className="block text-sm font-medium text-[var(--color-fg)] mb-1" htmlFor="notes">
             Notes
           </label>
           <textarea
@@ -78,8 +78,8 @@ export default function NewAgencyPage() {
             name="notes"
             rows={3}
             placeholder="Specialisations, terms, performance history..."
-            className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                       placeholder:text-zinc-500
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                       placeholder:text-[var(--color-fg-subtle)]
                        focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
           />
         </div>
@@ -95,8 +95,8 @@ export default function NewAgencyPage() {
           </button>
           <Link
             href="/dashboard/agencies"
-            className="rounded-md border border-zinc-600 text-zinc-300 text-sm font-medium
-                       px-4 py-2 hover:bg-zinc-800 transition-colors"
+            className="rounded-md border border-[var(--color-border)] text-[var(--color-fg)] text-sm font-medium
+                       px-4 py-2 hover:bg-[var(--color-bg-input)] transition-colors"
           >
             Cancel
           </Link>

--- a/src/app/(dashboard)/dashboard/candidates/[candidateId]/interview/[packId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/candidates/[candidateId]/interview/[packId]/page.tsx
@@ -63,7 +63,7 @@ export default async function InterviewPackPage({ params }: Props) {
     <div className="max-w-3xl">
       <Link
         href={`/dashboard/candidates/${candidateId}`}
-        className="inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-zinc-300 mb-6"
+        className="inline-flex items-center gap-1.5 text-sm text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)] mb-6"
       >
         <ArrowLeftIcon className="h-3.5 w-3.5" />
         Back to candidate
@@ -76,12 +76,12 @@ export default async function InterviewPackPage({ params }: Props) {
             <BrainIcon className="h-5 w-5 text-violet-400" />
           </div>
           <div>
-            <h1 className="text-xl font-bold text-zinc-100">
+            <h1 className="text-xl font-bold text-[var(--color-fg)]">
               {role ? role.title : 'Interview Pack'}
             </h1>
-            <p className="text-sm text-zinc-500 mt-0.5">
+            <p className="text-sm text-[var(--color-fg-subtle)] mt-0.5">
               Interview pack for{' '}
-              <span className="text-zinc-300">
+              <span className="text-[var(--color-fg)]">
                 {candidate.firstName} {candidate.lastName}
               </span>
             </p>
@@ -96,7 +96,7 @@ export default async function InterviewPackPage({ params }: Props) {
               </span>
             )}
             {pack.language && pack.language !== 'en' && (
-              <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-zinc-800 text-zinc-300 border border-zinc-700">
+              <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-[var(--color-bg-input)] text-[var(--color-fg)] border border-[var(--color-border)]">
                 {pack.language.toUpperCase()}
               </span>
             )}
@@ -106,12 +106,12 @@ export default async function InterviewPackPage({ params }: Props) {
               </span>
             )}
             {pack.recommendedDurationMinutes && (
-              <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium bg-zinc-800 text-zinc-400 border border-zinc-700">
+              <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium bg-[var(--color-bg-input)] text-[var(--color-fg-muted)] border border-[var(--color-border)]">
                 <ClockIcon className="h-3 w-3" />
                 {pack.recommendedDurationMinutes} min recommended
               </span>
             )}
-            <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-zinc-800 text-zinc-400 border border-zinc-700">
+            <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-[var(--color-bg-input)] text-[var(--color-fg-muted)] border border-[var(--color-border)]">
               {questions.length} questions
             </span>
             {pack.includesCodeChallenge && (
@@ -150,7 +150,7 @@ export default async function InterviewPackPage({ params }: Props) {
       {/* Questions */}
       {questions.length > 0 && (
         <div className="mb-6">
-          <h2 className="text-sm font-semibold text-zinc-300 uppercase tracking-wide mb-3">
+          <h2 className="text-sm font-semibold text-[var(--color-fg)] uppercase tracking-wide mb-3">
             Interview Questions
           </h2>
           <div className="space-y-2">
@@ -164,7 +164,7 @@ export default async function InterviewPackPage({ params }: Props) {
       {/* Code challenge */}
       {codeChallenge && (
         <div>
-          <h2 className="text-sm font-semibold text-zinc-300 uppercase tracking-wide mb-3">
+          <h2 className="text-sm font-semibold text-[var(--color-fg)] uppercase tracking-wide mb-3">
             Code Challenge
           </h2>
           <CodeChallengeCard challenge={codeChallenge} />

--- a/src/app/(dashboard)/dashboard/candidates/[candidateId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/candidates/[candidateId]/page.tsx
@@ -245,7 +245,7 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
     <div className="max-w-4xl">
       <Link
         href={roleId ? `/dashboard/roles/${roleId}` : '/dashboard/candidates'}
-        className="inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-zinc-300 mb-6"
+        className="inline-flex items-center gap-1.5 text-sm text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)] mb-6"
       >
         <ArrowLeftIcon className="h-3.5 w-3.5" />
         {roleId ? 'Back to role' : 'All candidates'}
@@ -263,7 +263,7 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
       <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between mb-6">
         <div>
           <div className="flex items-center gap-3 flex-wrap">
-            <h1 className="text-2xl font-bold text-zinc-100 break-words min-w-0">
+            <h1 className="text-2xl font-bold text-[var(--color-fg)] break-words min-w-0">
               {candidate.firstName} {candidate.lastName}
             </h1>
             {canEdit && (
@@ -279,7 +279,7 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
               />
             )}
           </div>
-          <div className="flex items-center gap-3 mt-1 text-sm text-zinc-500">
+          <div className="flex items-center gap-3 mt-1 text-sm text-[var(--color-fg-subtle)]">
             {candidate.email && <span>{candidate.email}</span>}
             {candidate.phone && <span>{candidate.phone}</span>}
             {agency && audience !== 'manager' && (
@@ -291,12 +291,12 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
                     width={24}
                     height={24}
                     style={{ width: 24, height: 24 }}
-                    className="rounded-full border border-zinc-700 bg-zinc-800 object-contain shrink-0"
+                    className="rounded-full border border-[var(--color-border)] bg-[var(--color-bg-input)] object-contain shrink-0"
                   />
                 ) : (
                   <div
-                    className="flex items-center justify-center rounded-full bg-zinc-800
-                               text-zinc-400 text-xs font-semibold shrink-0"
+                    className="flex items-center justify-center rounded-full bg-[var(--color-bg-input)]
+                               text-[var(--color-fg-muted)] text-xs font-semibold shrink-0"
                     style={{ width: 24, height: 24 }}
                     aria-hidden="true"
                   >
@@ -329,8 +329,8 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
               <form action={archiveCandidate.bind(null, candidateId)}>
                 <button
                   type="submit"
-                  className="flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-800
-                             text-zinc-400 text-xs font-medium px-3 py-1.5
+                  className="flex items-center gap-1.5 rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)]
+                             text-[var(--color-fg-muted)] text-xs font-medium px-3 py-1.5
                              hover:bg-red-950 hover:text-red-400 hover:border-red-800 transition-colors"
                 >
                   <ArchiveIcon className="h-3.5 w-3.5" />
@@ -396,27 +396,27 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
 
       {/* Location & Language */}
       {(candidate.country || candidate.city || (candidate.languagesSpoken && candidate.languagesSpoken.length > 0)) && (
-        <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-4 md:p-6 mb-6">
-          <h3 className="text-sm font-semibold text-zinc-300 uppercase tracking-wide mb-3">Location & Language</h3>
+        <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-4 md:p-6 mb-6">
+          <h3 className="text-sm font-semibold text-[var(--color-fg)] uppercase tracking-wide mb-3">Location & Language</h3>
           <div className="flex flex-wrap gap-x-3 gap-y-2 md:gap-x-8">
             {(candidate.country || candidate.city) && (
               <div>
-                <p className="text-xs text-zinc-500">Location</p>
-                <p className="text-sm text-zinc-100">
+                <p className="text-xs text-[var(--color-fg-subtle)]">Location</p>
+                <p className="text-sm text-[var(--color-fg)]">
                   {[candidate.city, candidate.country].filter(Boolean).join(', ')}
                 </p>
               </div>
             )}
             {candidate.languagesSpoken && candidate.languagesSpoken.length > 0 && (
               <div>
-                <p className="text-xs text-zinc-500">Languages</p>
-                <p className="text-sm text-zinc-100">{candidate.languagesSpoken.join(', ')}</p>
+                <p className="text-xs text-[var(--color-fg-subtle)]">Languages</p>
+                <p className="text-sm text-[var(--color-fg)]">{candidate.languagesSpoken.join(', ')}</p>
               </div>
             )}
             {candidate.willingToRelocate !== null && (
               <div>
-                <p className="text-xs text-zinc-500">Willing to Relocate</p>
-                <p className="text-sm text-zinc-100">{candidate.willingToRelocate ? 'Yes' : 'No'}</p>
+                <p className="text-xs text-[var(--color-fg-subtle)]">Willing to Relocate</p>
+                <p className="text-sm text-[var(--color-fg)]">{candidate.willingToRelocate ? 'Yes' : 'No'}</p>
               </div>
             )}
           </div>
@@ -425,31 +425,31 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
 
       {/* Commercial Details — hidden for hiring managers */}
       {!isHiringManager && (candidate.candidateRate || candidate.customerRate) && (
-        <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-4 md:p-6 mb-6">
-          <h3 className="text-sm font-semibold text-zinc-300 uppercase tracking-wide mb-3">Commercial Details</h3>
+        <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-4 md:p-6 mb-6">
+          <h3 className="text-sm font-semibold text-[var(--color-fg)] uppercase tracking-wide mb-3">Commercial Details</h3>
           <div className="grid grid-cols-1 xs:grid-cols-2 sm:grid-cols-3 gap-4">
             {candidate.candidateRate && (
               <div>
-                <p className="text-xs text-zinc-500">Candidate Rate/day</p>
-                <p className="text-lg font-semibold text-zinc-100">
+                <p className="text-xs text-[var(--color-fg-subtle)]">Candidate Rate/day</p>
+                <p className="text-lg font-semibold text-[var(--color-fg)]">
                   {candidate.rateCurrency ?? ''} {Number(candidate.candidateRate).toFixed(2)}
                 </p>
               </div>
             )}
             {candidate.customerRate && (
               <div>
-                <p className="text-xs text-zinc-500">Customer Rate/day</p>
-                <p className="text-lg font-semibold text-zinc-100">
+                <p className="text-xs text-[var(--color-fg-subtle)]">Customer Rate/day</p>
+                <p className="text-lg font-semibold text-[var(--color-fg)]">
                   {candidate.rateCurrency ?? ''} {Number(candidate.customerRate).toFixed(2)}
                 </p>
               </div>
             )}
             {candidate.candidateRate && candidate.customerRate && (
               <div>
-                <p className="text-xs text-zinc-500">Margin</p>
+                <p className="text-xs text-[var(--color-fg-subtle)]">Margin</p>
                 <p className="text-lg font-semibold text-emerald-400">
                   {candidate.rateCurrency ?? ''} {(Number(candidate.customerRate) - Number(candidate.candidateRate)).toFixed(2)}
-                  <span className="text-sm text-zinc-500 ml-1">
+                  <span className="text-sm text-[var(--color-fg-subtle)] ml-1">
                     ({((Number(candidate.customerRate) - Number(candidate.candidateRate)) / Number(candidate.customerRate) * 100).toFixed(1)}%)
                   </span>
                 </p>
@@ -467,10 +467,10 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
           currentStatus={activeScore.score.scoreStatus}
         />
       ) : activeScore?.score.scoreStatus === 'complete' ? (
-        <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-4 md:p-6 mb-6">
+        <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-4 md:p-6 mb-6">
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center gap-3 flex-wrap">
-              <h2 className="font-semibold text-zinc-100">Score for: {activeScore.role.title}</h2>
+              <h2 className="font-semibold text-[var(--color-fg)]">Score for: {activeScore.role.title}</h2>
               {isScoreOutdatedAgainstPriorities(activeScore.score, activeScore.role) && canEdit && (
                 <StaleScorePill
                   candidateId={candidateId}
@@ -489,9 +489,9 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
           </div>
           <ScoreChart score={activeScore.score} />
           {activeScore.score.aiSummary && (
-            <div className="mt-5 pt-5 border-t border-zinc-700">
-              <h3 className="text-sm font-semibold text-zinc-300 mb-1">AI Summary</h3>
-              <p className="text-sm text-zinc-400">{activeScore.score.aiSummary}</p>
+            <div className="mt-5 pt-5 border-t border-[var(--color-border)]">
+              <h3 className="text-sm font-semibold text-[var(--color-fg)] mb-1">AI Summary</h3>
+              <p className="text-sm text-[var(--color-fg-muted)]">{activeScore.score.aiSummary}</p>
             </div>
           )}
         </div>
@@ -517,9 +517,9 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
       {/* Manager approval controls — shown when the manager is assigned to one or
           more roles that this candidate has been scored on */}
       {isHiringManager && rolesWithThisCandidate.length > 0 && (
-        <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-4 md:p-6 mb-6">
-          <h2 className="font-semibold text-zinc-100 mb-1">Your Approval</h2>
-          <p className="text-xs text-zinc-500 mb-4">
+        <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-4 md:p-6 mb-6">
+          <h2 className="font-semibold text-[var(--color-fg)] mb-1">Your Approval</h2>
+          <p className="text-xs text-[var(--color-fg-subtle)] mb-4">
             Record your approval decision for each role this candidate has been shortlisted on.
           </p>
           <div className="space-y-4">
@@ -529,7 +529,7 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
               if (!roleEntry) return null
               return (
                 <div key={rid}>
-                  <p className="text-xs font-medium text-zinc-400 mb-2 uppercase tracking-wide">
+                  <p className="text-xs font-medium text-[var(--color-fg-muted)] mb-2 uppercase tracking-wide">
                     {roleEntry.role.title}
                   </p>
                   <ApprovalControls
@@ -547,11 +547,11 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
 
       {/* Web intelligence */}
       <MobilePanel title="Web Intelligence">
-        <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-4 md:p-6 mb-6">
+        <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-4 md:p-6 mb-6">
           <div className="flex items-center justify-between mb-4">
             <div>
-              <h2 className="font-semibold text-zinc-100">Web Intelligence</h2>
-              <p className="text-xs text-zinc-500 mt-0.5">
+              <h2 className="font-semibold text-[var(--color-fg)]">Web Intelligence</h2>
+              <p className="text-xs text-[var(--color-fg-subtle)] mt-0.5">
                 Search LinkedIn, GitHub, Reddit and more to build a fuller picture
               </p>
             </div>
@@ -568,9 +568,9 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
 
       {/* Interview packs */}
       <MobilePanel title="Interview Packs">
-        <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-4 md:p-6 mb-6">
+        <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-4 md:p-6 mb-6">
           <div className="flex items-center justify-between mb-4">
-            <h2 className="font-semibold text-zinc-100">Interview Packs</h2>
+            <h2 className="font-semibold text-[var(--color-fg)]">Interview Packs</h2>
             {allRoles.length > 0 && (
               <div className="flex flex-wrap gap-2">
                 {allRoles.map((role) => (
@@ -598,8 +598,8 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
 
       {/* Interview Schedule */}
       <MobilePanel title="Interview Schedule">
-        <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-4 md:p-6 mb-6">
-          <h2 className="font-semibold text-zinc-100 mb-4">Interview Schedule</h2>
+        <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-4 md:p-6 mb-6">
+          <h2 className="font-semibold text-[var(--color-fg)] mb-4">Interview Schedule</h2>
           {canEdit && (
             <div className="mb-4">
               <IcsImportButton candidateId={candidateId} roleId={roleId ?? null} />
@@ -620,8 +620,8 @@ export default async function CandidateProfilePage({ params, searchParams }: Pro
 
       {/* CV Profile */}
       <MobilePanel title="CV Profile">
-        <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-4 md:p-6 mb-6">
-          <h2 className="font-semibold text-zinc-100 mb-4">CV Profile</h2>
+        <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-4 md:p-6 mb-6">
+          <h2 className="font-semibold text-[var(--color-fg)] mb-4">CV Profile</h2>
           <CandidateCvProfile
             candidateId={candidateId}
             cvText={candidate.cvText}

--- a/src/app/(dashboard)/dashboard/compare/page.tsx
+++ b/src/app/(dashboard)/dashboard/compare/page.tsx
@@ -25,11 +25,11 @@ function DimensionBar({ label, value }: { label: string; value: number | null })
   const pct = value ?? 0
   return (
     <div className="mb-2">
-      <div className="flex justify-between text-xs text-zinc-500 mb-1">
+      <div className="flex justify-between text-xs text-[var(--color-fg-subtle)] mb-1">
         <span className="capitalize">{label.replace('_', ' ')}</span>
-        <span className="text-zinc-400">{value ?? '—'}</span>
+        <span className="text-[var(--color-fg-muted)]">{value ?? '—'}</span>
       </div>
-      <div className="h-1.5 bg-zinc-700 rounded-full overflow-hidden">
+      <div className="h-1.5 bg-[var(--color-border)] rounded-full overflow-hidden">
         <div
           className="h-full bg-blue-500 rounded-full transition-all"
           style={{ width: `${pct}%` }}
@@ -44,7 +44,7 @@ function DimensionBar({ label, value }: { label: string; value: number | null })
 // ---------------------------------------------------------------------------
 
 const STATUS_STYLES: Record<string, string> = {
-  new: 'bg-zinc-700 text-zinc-300',
+  new: 'bg-[var(--color-bg-input)] text-[var(--color-fg-muted)]',
   shortlisted: 'bg-blue-900 text-blue-300',
   interviewing: 'bg-amber-900 text-amber-300',
   offered: 'bg-purple-900 text-purple-300',
@@ -76,15 +76,15 @@ function CandidateCard({ data }: { data: CandidateData }) {
     summary && summary.length > 250 ? summary.slice(0, 247) + '…' : summary
 
   return (
-    <div className="bg-zinc-900 border border-zinc-700 rounded-xl p-5 flex flex-col gap-4">
+    <div className="bg-[var(--color-bg-elevated)] border border-[var(--color-border)] rounded-xl p-5 flex flex-col gap-4">
       {/* Header */}
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">
-          <h2 className="text-base font-semibold text-zinc-100 truncate">
+          <h2 className="text-base font-semibold text-[var(--color-fg)] truncate">
             {candidate.firstName} {candidate.lastName}
           </h2>
           {candidate.email && (
-            <p className="text-xs text-zinc-500 truncate mt-0.5">{candidate.email}</p>
+            <p className="text-xs text-[var(--color-fg-subtle)] truncate mt-0.5">{candidate.email}</p>
           )}
           <div className="mt-2">
             <StatusBadge status={candidate.status ?? 'new'} />
@@ -102,9 +102,9 @@ function CandidateCard({ data }: { data: CandidateData }) {
 
       {/* Role */}
       {topScore && (
-        <p className="text-xs text-zinc-500">
+        <p className="text-xs text-[var(--color-fg-subtle)]">
           Scored for:{' '}
-          <span className="text-zinc-400 font-medium">{topScore.roleTitle}</span>
+          <span className="text-[var(--color-fg-muted)] font-medium">{topScore.roleTitle}</span>
         </p>
       )}
 
@@ -120,12 +120,12 @@ function CandidateCard({ data }: { data: CandidateData }) {
 
       {/* No score state */}
       {!topScore && (
-        <p className="text-xs text-zinc-600 italic">No completed score yet</p>
+        <p className="text-xs text-[var(--color-fg-subtle)] italic">No completed score yet</p>
       )}
 
       {/* AI summary */}
       {truncatedSummary && (
-        <p className="text-xs text-zinc-400 leading-relaxed border-t border-zinc-800 pt-3">
+        <p className="text-xs text-[var(--color-fg-muted)] leading-relaxed border-t border-[var(--color-border)] pt-3">
           {truncatedSummary}
         </p>
       )}
@@ -182,15 +182,15 @@ export default async function ComparePage({ searchParams }: Props) {
       <div className="max-w-4xl">
         <Link
           href="/dashboard/candidates"
-          className="inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-zinc-300 mb-6"
+          className="inline-flex items-center gap-1.5 text-sm text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)] mb-6"
         >
           <ArrowLeftIcon className="h-3.5 w-3.5" />
           All candidates
         </Link>
-        <div className="flex flex-col items-center justify-center rounded-xl border border-zinc-700 bg-zinc-900 py-20 text-center">
-          <UsersIcon className="h-10 w-10 text-zinc-600 mb-4" />
-          <h1 className="text-lg font-semibold text-zinc-300 mb-2">No candidates selected</h1>
-          <p className="text-sm text-zinc-500 max-w-xs mb-6">
+        <div className="flex flex-col items-center justify-center rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-elevated)] py-20 text-center">
+          <UsersIcon className="h-10 w-10 text-[var(--color-fg-subtle)] mb-4" />
+          <h1 className="text-lg font-semibold text-[var(--color-fg)] mb-2">No candidates selected</h1>
+          <p className="text-sm text-[var(--color-fg-subtle)] max-w-xs mb-6">
             Select 2–5 candidates from the candidates list using the comparison checkboxes, then
             click &ldquo;Compare&rdquo;.
           </p>
@@ -247,13 +247,13 @@ export default async function ComparePage({ searchParams }: Props) {
       <div className="max-w-4xl">
         <Link
           href="/dashboard/candidates"
-          className="inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-zinc-300 mb-6"
+          className="inline-flex items-center gap-1.5 text-sm text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)] mb-6"
         >
           <ArrowLeftIcon className="h-3.5 w-3.5" />
           All candidates
         </Link>
-        <div className="rounded-xl border border-zinc-700 bg-zinc-900 px-6 py-10 text-center">
-          <p className="text-sm text-zinc-400">
+        <div className="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-elevated)] px-6 py-10 text-center">
+          <p className="text-sm text-[var(--color-fg-muted)]">
             Could not load enough candidates. They may have been archived or the IDs are invalid.
           </p>
           <Link
@@ -274,12 +274,12 @@ export default async function ComparePage({ searchParams }: Props) {
         <div>
           <Link
             href="/dashboard/candidates"
-            className="inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-zinc-300 mb-2"
+            className="inline-flex items-center gap-1.5 text-sm text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)] mb-2"
           >
             <ArrowLeftIcon className="h-3.5 w-3.5" />
             All candidates
           </Link>
-          <h1 className="text-xl font-bold text-zinc-100">
+          <h1 className="text-xl font-bold text-[var(--color-fg)]">
             Comparing {candidatesData.length} candidates
           </h1>
         </div>

--- a/src/app/(dashboard)/dashboard/customers/[customerId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/customers/[customerId]/page.tsx
@@ -57,7 +57,7 @@ export default async function CustomerDetailPage({ params }: Props) {
   return (
     <div>
       <div className="mb-6">
-        <Link href="/dashboard/customers" className="text-sm text-zinc-500 hover:text-zinc-300">
+        <Link href="/dashboard/customers" className="text-sm text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)]">
           ← Back to customers
         </Link>
         <div className="flex items-center gap-4 mt-2">
@@ -68,12 +68,12 @@ export default async function CustomerDetailPage({ params }: Props) {
               alt=""
               width={64}
               height={64}
-              className="rounded-xl border border-zinc-700 bg-zinc-800 object-contain shrink-0"
+              className="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-input)] object-contain shrink-0"
               style={{ width: 64, height: 64 }}
             />
           ) : (
             <div
-              className="flex items-center justify-center rounded-xl bg-zinc-800 text-zinc-400
+              className="flex items-center justify-center rounded-xl bg-[var(--color-bg-input)] text-[var(--color-fg-muted)]
                          text-xl font-semibold shrink-0"
               style={{ width: 64, height: 64 }}
               aria-hidden="true"
@@ -81,7 +81,7 @@ export default async function CustomerDetailPage({ params }: Props) {
               {customer.name.charAt(0).toUpperCase()}
             </div>
           )}
-          <h1 className="text-2xl font-bold text-zinc-100">{customer.name}</h1>
+          <h1 className="text-2xl font-bold text-[var(--color-fg)]">{customer.name}</h1>
         </div>
       </div>
 
@@ -91,28 +91,28 @@ export default async function CustomerDetailPage({ params }: Props) {
           {canEdit ? (
             <CustomerEditForm customer={customer} isAdmin={isAdmin} />
           ) : (
-            <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-6 space-y-4">
+            <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-6 space-y-4">
               {customer.contactName && (
                 <div>
-                  <p className="text-xs font-medium text-zinc-500 uppercase tracking-wide">Contact</p>
-                  <p className="text-sm text-zinc-300 mt-0.5">{customer.contactName}</p>
+                  <p className="text-xs font-medium text-[var(--color-fg-subtle)] uppercase tracking-wide">Contact</p>
+                  <p className="text-sm text-[var(--color-fg)] mt-0.5">{customer.contactName}</p>
                 </div>
               )}
               {customer.contactEmail && (
                 <div>
-                  <p className="text-xs font-medium text-zinc-500 uppercase tracking-wide">Email</p>
-                  <p className="text-sm text-zinc-300 mt-0.5">{customer.contactEmail}</p>
+                  <p className="text-xs font-medium text-[var(--color-fg-subtle)] uppercase tracking-wide">Email</p>
+                  <p className="text-sm text-[var(--color-fg)] mt-0.5">{customer.contactEmail}</p>
                 </div>
               )}
               {customer.contactPhone && (
                 <div>
-                  <p className="text-xs font-medium text-zinc-500 uppercase tracking-wide">Phone</p>
-                  <p className="text-sm text-zinc-300 mt-0.5">{customer.contactPhone}</p>
+                  <p className="text-xs font-medium text-[var(--color-fg-subtle)] uppercase tracking-wide">Phone</p>
+                  <p className="text-sm text-[var(--color-fg)] mt-0.5">{customer.contactPhone}</p>
                 </div>
               )}
               {customer.website && (
                 <div>
-                  <p className="text-xs font-medium text-zinc-500 uppercase tracking-wide">Website</p>
+                  <p className="text-xs font-medium text-[var(--color-fg-subtle)] uppercase tracking-wide">Website</p>
                   <a
                     href={customer.website}
                     target="_blank"
@@ -125,7 +125,7 @@ export default async function CustomerDetailPage({ params }: Props) {
               )}
               {customer.portalBaseUrl && (
                 <div>
-                  <p className="text-xs font-medium text-zinc-500 uppercase tracking-wide">Portal Base URL</p>
+                  <p className="text-xs font-medium text-[var(--color-fg-subtle)] uppercase tracking-wide">Portal Base URL</p>
                   <a
                     href={customer.portalBaseUrl}
                     target="_blank"
@@ -138,8 +138,8 @@ export default async function CustomerDetailPage({ params }: Props) {
               )}
               {customer.notes && (
                 <div>
-                  <p className="text-xs font-medium text-zinc-500 uppercase tracking-wide">Notes</p>
-                  <p className="text-sm text-zinc-300 mt-0.5 whitespace-pre-wrap">{customer.notes}</p>
+                  <p className="text-xs font-medium text-[var(--color-fg-subtle)] uppercase tracking-wide">Notes</p>
+                  <p className="text-sm text-[var(--color-fg)] mt-0.5 whitespace-pre-wrap">{customer.notes}</p>
                 </div>
               )}
             </div>
@@ -149,7 +149,7 @@ export default async function CustomerDetailPage({ params }: Props) {
         {/* Hiring Framework + Active Roles */}
         <div className="lg:col-span-2 space-y-6">
           <div>
-            <h2 className="text-lg font-semibold text-zinc-100 mb-4">Hiring Framework</h2>
+            <h2 className="text-lg font-semibold text-[var(--color-fg)] mb-4">Hiring Framework</h2>
             <FrameworkEditor
               customerId={customerId}
               existingFramework={
@@ -163,12 +163,12 @@ export default async function CustomerDetailPage({ params }: Props) {
 
           {/* Active roles for this customer */}
           <div>
-            <h2 className="text-lg font-semibold text-zinc-100 mb-3">
+            <h2 className="text-lg font-semibold text-[var(--color-fg)] mb-3">
               Active roles ({customerRoles.length})
             </h2>
             {customerRoles.length === 0 ? (
-              <div className="rounded-xl border-2 border-dashed border-zinc-700 bg-zinc-950 px-6 py-10 text-center">
-                <p className="text-zinc-500 text-sm">No active roles linked to this customer yet.</p>
+              <div className="rounded-xl border-2 border-dashed border-[var(--color-border)] bg-[var(--color-bg-app)] px-6 py-10 text-center">
+                <p className="text-[var(--color-fg-subtle)] text-sm">No active roles linked to this customer yet.</p>
               </div>
             ) : (
               <div className="grid gap-2">
@@ -176,11 +176,11 @@ export default async function CustomerDetailPage({ params }: Props) {
                   <Link
                     key={role.id}
                     href={`/dashboard/roles/${role.id}`}
-                    className="flex items-center justify-between rounded-lg bg-zinc-900 border border-zinc-700
+                    className="flex items-center justify-between rounded-lg bg-[var(--color-bg-elevated)] border border-[var(--color-border)]
                                px-5 py-3 hover:border-blue-500 hover:shadow-sm transition-all"
                   >
-                    <span className="text-sm font-medium text-zinc-100">{role.title}</span>
-                    <time className="text-xs text-zinc-500">
+                    <span className="text-sm font-medium text-[var(--color-fg)]">{role.title}</span>
+                    <time className="text-xs text-[var(--color-fg-subtle)]">
                       {new Date(role.createdAt).toLocaleDateString('en-GB')}
                     </time>
                   </Link>

--- a/src/app/(dashboard)/dashboard/customers/new/page.tsx
+++ b/src/app/(dashboard)/dashboard/customers/new/page.tsx
@@ -10,13 +10,13 @@ export default function NewCustomerPage() {
   return (
     <div className="max-w-xl">
       <div className="mb-6">
-        <Link href="/dashboard/customers" className="text-sm text-zinc-500 hover:text-zinc-300">
+        <Link href="/dashboard/customers" className="text-sm text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)]">
           ← Back to customers
         </Link>
-        <h1 className="text-2xl font-bold text-zinc-100 mt-2">Add customer</h1>
+        <h1 className="text-2xl font-bold text-[var(--color-fg)] mt-2">Add customer</h1>
       </div>
 
-      <form action={action} className="space-y-5 bg-zinc-900 rounded-xl border border-zinc-700 p-6">
+      <form action={action} className="space-y-5 bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-6">
         {state?.error && (
           <div className="rounded-md bg-red-950 border border-red-800 px-4 py-3 text-sm text-red-400">
             {state.error}
@@ -24,7 +24,7 @@ export default function NewCustomerPage() {
         )}
 
         <div>
-          <label className="block text-sm font-medium text-zinc-300 mb-1" htmlFor="name">
+          <label className="block text-sm font-medium text-[var(--color-fg)] mb-1" htmlFor="name">
             Company name <span className="text-red-500">*</span>
           </label>
           <input
@@ -33,8 +33,8 @@ export default function NewCustomerPage() {
             type="text"
             required
             placeholder="e.g. Acme Corp"
-            className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                       placeholder:text-zinc-500
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                       placeholder:text-[var(--color-fg-subtle)]
                        focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
           {state?.fieldErrors?.name && (
@@ -43,7 +43,7 @@ export default function NewCustomerPage() {
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-zinc-300 mb-1" htmlFor="contactName">
+          <label className="block text-sm font-medium text-[var(--color-fg)] mb-1" htmlFor="contactName">
             Contact name
           </label>
           <input
@@ -51,14 +51,14 @@ export default function NewCustomerPage() {
             name="contactName"
             type="text"
             placeholder="e.g. Jane Smith"
-            className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                       placeholder:text-zinc-500
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                       placeholder:text-[var(--color-fg-subtle)]
                        focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-zinc-300 mb-1" htmlFor="contactEmail">
+          <label className="block text-sm font-medium text-[var(--color-fg)] mb-1" htmlFor="contactEmail">
             Contact email
           </label>
           <input
@@ -66,8 +66,8 @@ export default function NewCustomerPage() {
             name="contactEmail"
             type="email"
             placeholder="jane@acmecorp.com"
-            className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                       placeholder:text-zinc-500
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                       placeholder:text-[var(--color-fg-subtle)]
                        focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
           {state?.fieldErrors?.contactEmail && (
@@ -76,7 +76,7 @@ export default function NewCustomerPage() {
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-zinc-300 mb-1" htmlFor="contactPhone">
+          <label className="block text-sm font-medium text-[var(--color-fg)] mb-1" htmlFor="contactPhone">
             Contact phone
           </label>
           <input
@@ -84,14 +84,14 @@ export default function NewCustomerPage() {
             name="contactPhone"
             type="tel"
             placeholder="+1 (555) 000-0000"
-            className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                       placeholder:text-zinc-500
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                       placeholder:text-[var(--color-fg-subtle)]
                        focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-zinc-300 mb-1" htmlFor="website">
+          <label className="block text-sm font-medium text-[var(--color-fg)] mb-1" htmlFor="website">
             Website
           </label>
           <input
@@ -99,14 +99,14 @@ export default function NewCustomerPage() {
             name="website"
             type="url"
             placeholder="https://acmecorp.com"
-            className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                       placeholder:text-zinc-500
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                       placeholder:text-[var(--color-fg-subtle)]
                        focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-zinc-300 mb-1" htmlFor="portalBaseUrl">
+          <label className="block text-sm font-medium text-[var(--color-fg)] mb-1" htmlFor="portalBaseUrl">
             Customer portal base URL
           </label>
           <input
@@ -114,17 +114,17 @@ export default function NewCustomerPage() {
             name="portalBaseUrl"
             type="url"
             placeholder="https://jobs.acmecorp.com"
-            className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                       placeholder:text-zinc-500
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                       placeholder:text-[var(--color-fg-subtle)]
                        focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
-          <p className="mt-1 text-xs text-zinc-500">
+          <p className="mt-1 text-xs text-[var(--color-fg-subtle)]">
             Used as the base URL for per-role portal links.
           </p>
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-zinc-300 mb-1" htmlFor="roleIdLabel">
+          <label className="block text-sm font-medium text-[var(--color-fg)] mb-1" htmlFor="roleIdLabel">
             Role ID label
           </label>
           <input
@@ -133,11 +133,11 @@ export default function NewCustomerPage() {
             type="text"
             maxLength={60}
             placeholder="e.g. CtoolId"
-            className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                       placeholder:text-zinc-500
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                       placeholder:text-[var(--color-fg-subtle)]
                        focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
-          <p className="mt-1 text-xs text-zinc-500">
+          <p className="mt-1 text-xs text-[var(--color-fg-subtle)]">
             Optional. The name your customer uses for their role identifiers (e.g. CtoolId, Job Number, Req ID).
             Leave blank to use the default &ldquo;Customer Role ID&rdquo;.
           </p>
@@ -147,7 +147,7 @@ export default function NewCustomerPage() {
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-zinc-300 mb-1" htmlFor="notes">
+          <label className="block text-sm font-medium text-[var(--color-fg)] mb-1" htmlFor="notes">
             Notes
           </label>
           <textarea
@@ -155,8 +155,8 @@ export default function NewCustomerPage() {
             name="notes"
             rows={3}
             placeholder="Industry, hiring context, preferences..."
-            className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                       placeholder:text-zinc-500
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                       placeholder:text-[var(--color-fg-subtle)]
                        focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
           />
         </div>
@@ -172,8 +172,8 @@ export default function NewCustomerPage() {
           </button>
           <Link
             href="/dashboard/customers"
-            className="rounded-md border border-zinc-600 text-zinc-300 text-sm font-medium
-                       px-4 py-2 hover:bg-zinc-800 transition-colors"
+            className="rounded-md border border-[var(--color-border)] text-[var(--color-fg)] text-sm font-medium
+                       px-4 py-2 hover:bg-[var(--color-bg-input)] transition-colors"
           >
             Cancel
           </Link>

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -20,7 +20,7 @@ import { getForYouFeed } from '@/actions/dashboard-tasks'
 export const metadata = { title: 'Dashboard — SkillAI' }
 
 const STATUS_BADGE: Record<string, string> = {
-  new:          'bg-zinc-700 text-zinc-300',
+  new:          'bg-[var(--color-bg-input)] text-[var(--color-fg-muted)]',
   shortlisted:  'bg-blue-900/60 text-blue-300',
   interviewing: 'bg-violet-900/60 text-violet-300',
   offered:      'bg-amber-900/60 text-amber-300',
@@ -352,7 +352,7 @@ export default async function DashboardPage() {
                       </p>
                     </div>
                     <span
-                      className={`text-xs px-2 py-0.5 rounded-full font-medium capitalize whitespace-nowrap ${STATUS_BADGE[c.status] ?? 'bg-zinc-700 text-zinc-300'}`}
+                      className={`text-xs px-2 py-0.5 rounded-full font-medium capitalize whitespace-nowrap ${STATUS_BADGE[c.status] ?? 'bg-[var(--color-bg-input)] text-[var(--color-fg-muted)]'}`}
                     >
                       {c.status}
                     </span>

--- a/src/app/(dashboard)/dashboard/profile/page.tsx
+++ b/src/app/(dashboard)/dashboard/profile/page.tsx
@@ -10,27 +10,27 @@ export default async function ProfilePage() {
   return (
     <div className="max-w-lg">
       <div className="flex items-center gap-3 mb-8">
-        <div className="p-2 bg-zinc-800 rounded-lg">
-          <UserIcon className="h-5 w-5 text-zinc-400" />
+        <div className="p-2 bg-[var(--color-bg-input)] rounded-lg">
+          <UserIcon className="h-5 w-5 text-[var(--color-fg-muted)]" />
         </div>
         <div>
-          <h1 className="text-xl font-bold text-zinc-100">Profile</h1>
-          <p className="text-sm text-zinc-500">Manage your account details</p>
+          <h1 className="text-xl font-bold text-[var(--color-fg)]">Profile</h1>
+          <p className="text-sm text-[var(--color-fg-subtle)]">Manage your account details</p>
         </div>
       </div>
 
       <div className="space-y-8">
         {/* Profile section */}
-        <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-6">
-          <h2 className="text-sm font-semibold text-zinc-300 uppercase tracking-wide mb-4">
+        <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-6">
+          <h2 className="text-sm font-semibold text-[var(--color-fg)] uppercase tracking-wide mb-4">
             Profile
           </h2>
           <UpdateProfileForm currentName={userName} />
         </div>
 
         {/* Change password section */}
-        <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-6">
-          <h2 className="text-sm font-semibold text-zinc-300 uppercase tracking-wide mb-4">
+        <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-6">
+          <h2 className="text-sm font-semibold text-[var(--color-fg)] uppercase tracking-wide mb-4">
             Change Password
           </h2>
           <ChangePasswordForm />

--- a/src/app/(dashboard)/dashboard/roles/[roleId]/bulk-upload/page.tsx
+++ b/src/app/(dashboard)/dashboard/roles/[roleId]/bulk-upload/page.tsx
@@ -28,16 +28,16 @@ export default async function BulkUploadPage({ params }: Props) {
     <div className="max-w-2xl">
       <Link
         href={`/dashboard/roles/${roleId}`}
-        className="inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-zinc-300 mb-6"
+        className="inline-flex items-center gap-1.5 text-sm text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)] mb-6"
       >
         <ArrowLeftIcon className="h-3.5 w-3.5" />
         Back to {role.title}
       </Link>
 
-      <h1 className="text-2xl font-bold text-zinc-100 mb-2">Bulk Upload CVs</h1>
-      <p className="text-sm text-zinc-500 mb-8">
+      <h1 className="text-2xl font-bold text-[var(--color-fg)] mb-2">Bulk Upload CVs</h1>
+      <p className="text-sm text-[var(--color-fg-subtle)] mb-8">
         Upload multiple CV files at once. Each file will be parsed and scored against{' '}
-        <span className="text-zinc-300 font-medium">{role.title}</span> automatically.
+        <span className="text-[var(--color-fg)] font-medium">{role.title}</span> automatically.
       </p>
 
       <BulkUploadZone roleId={roleId} />

--- a/src/app/(dashboard)/dashboard/roles/[roleId]/edit/page.tsx
+++ b/src/app/(dashboard)/dashboard/roles/[roleId]/edit/page.tsx
@@ -45,15 +45,15 @@ export default async function RoleEditPage({ params }: Props) {
     <div>
       <Link
         href={`/dashboard/roles/${roleId}`}
-        className="inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-zinc-300 mb-6"
+        className="inline-flex items-center gap-1.5 text-sm text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)] mb-6"
       >
         <ArrowLeftIcon className="h-3.5 w-3.5" />
         Back to role
       </Link>
 
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-zinc-100">Edit role</h1>
-        <p className="text-zinc-500 mt-1 text-sm">{role.title}</p>
+        <h1 className="text-2xl font-bold text-[var(--color-fg)]">Edit role</h1>
+        <p className="text-[var(--color-fg-subtle)] mt-1 text-sm">{role.title}</p>
       </div>
 
       <RoleEditForm

--- a/src/app/(dashboard)/dashboard/roles/[roleId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/roles/[roleId]/page.tsx
@@ -135,7 +135,7 @@ export default async function RoleDetailPage({ params }: Props) {
     <div>
       <Link
         href="/dashboard/roles"
-        className="inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-zinc-300 mb-6"
+        className="inline-flex items-center gap-1.5 text-sm text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)] mb-6"
       >
         <ArrowLeftIcon className="h-3.5 w-3.5" />
         All roles
@@ -143,12 +143,12 @@ export default async function RoleDetailPage({ params }: Props) {
 
       <div className="flex items-start justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-zinc-100">{role.title}</h1>
-          <div className="flex items-center gap-3 mt-1 text-sm text-zinc-500 flex-wrap">
+          <h1 className="text-2xl font-bold text-[var(--color-fg)]">{role.title}</h1>
+          <div className="flex items-center gap-3 mt-1 text-sm text-[var(--color-fg-subtle)] flex-wrap">
             <span>Created {new Date(role.createdAt).toLocaleDateString('en-GB')}</span>
             {customer && (
-              <span className="text-zinc-400">
-                &middot; <span className="font-medium text-zinc-300">{customer.name}</span>
+              <span className="text-[var(--color-fg-muted)]">
+                &middot; <span className="font-medium text-[var(--color-fg)]">{customer.name}</span>
               </span>
             )}
             {role.frameworkLevelLabel && (
@@ -158,7 +158,7 @@ export default async function RoleDetailPage({ params }: Props) {
               </span>
             )}
             {!role.isActive && (
-              <span className="text-xs bg-zinc-800 text-zinc-400 border border-zinc-600 px-2 py-0.5 rounded-full">
+              <span className="text-xs bg-[var(--color-bg-input)] text-[var(--color-fg-muted)] border border-[var(--color-border)] px-2 py-0.5 rounded-full">
                 Archived
               </span>
             )}
@@ -196,8 +196,8 @@ export default async function RoleDetailPage({ params }: Props) {
           {canEdit && (
             <Link
               href={`/dashboard/roles/${roleId}/edit`}
-              className="flex items-center gap-2 rounded-md bg-zinc-700 text-zinc-100 text-sm
-                         font-medium px-4 py-2 hover:bg-zinc-600 transition-colors"
+              className="flex items-center gap-2 rounded-md bg-[var(--color-bg-input)] text-[var(--color-fg)] text-sm
+                         font-medium px-4 py-2 hover:bg-[var(--color-border)] transition-colors"
             >
               <PencilIcon className="h-4 w-4" />
               Edit role
@@ -206,8 +206,8 @@ export default async function RoleDetailPage({ params }: Props) {
           {!isHiringManager && (
             <Link
               href={`/dashboard/roles/${roleId}/bulk-upload`}
-              className="flex items-center gap-2 rounded-md bg-zinc-700 text-zinc-100 text-sm
-                         font-medium px-4 py-2 hover:bg-zinc-600 transition-colors"
+              className="flex items-center gap-2 rounded-md bg-[var(--color-bg-input)] text-[var(--color-fg)] text-sm
+                         font-medium px-4 py-2 hover:bg-[var(--color-border)] transition-colors"
             >
               <UploadCloudIcon className="h-4 w-4" />
               Bulk Upload
@@ -228,9 +228,9 @@ export default async function RoleDetailPage({ params }: Props) {
               <button
                 type="submit"
                 formAction={archiveRole.bind(null, roleId)}
-                className="flex items-center gap-2 rounded-md bg-zinc-800 text-zinc-400 text-sm
+                className="flex items-center gap-2 rounded-md bg-[var(--color-bg-input)] text-[var(--color-fg-muted)] text-sm
                            font-medium px-4 py-2 hover:bg-red-950 hover:text-red-400
-                           border border-zinc-700 hover:border-red-800 transition-colors"
+                           border border-[var(--color-border)] hover:border-red-800 transition-colors"
               >
                 <ArchiveIcon className="h-4 w-4" />
                 Archive role
@@ -259,7 +259,7 @@ export default async function RoleDetailPage({ params }: Props) {
               {canEdit && (
                 <Link
                   href={`/dashboard/roles/${roleId}/edit`}
-                  className="inline-flex items-center gap-1.5 rounded-md bg-zinc-800 border border-zinc-700 text-zinc-200 text-xs font-medium px-2.5 py-1.5 hover:bg-zinc-700 transition-colors"
+                  className="inline-flex items-center gap-1.5 rounded-md bg-[var(--color-bg-input)] border border-[var(--color-border)] text-[var(--color-fg)] text-xs font-medium px-2.5 py-1.5 hover:bg-[var(--color-border)] transition-colors"
                 >
                   <PencilIcon className="h-3 w-3" />
                   Edit
@@ -308,16 +308,16 @@ export default async function RoleDetailPage({ params }: Props) {
       />
 
       {/* Role description */}
-      <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-6 mb-6">
-        <h2 className="text-sm font-semibold text-zinc-300 uppercase tracking-wide mb-4">
+      <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-6 mb-6">
+        <h2 className="text-sm font-semibold text-[var(--color-fg)] uppercase tracking-wide mb-4">
           Role Description
         </h2>
         <RoleContent text={role.description} />
       </div>
 
       {/* Requirements */}
-      <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-6 mb-6">
-        <h2 className="text-sm font-semibold text-zinc-300 uppercase tracking-wide mb-4">
+      <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-6 mb-6">
+        <h2 className="text-sm font-semibold text-[var(--color-fg)] uppercase tracking-wide mb-4">
           Requirements
         </h2>
         <RoleContent text={role.requirements} />
@@ -335,7 +335,7 @@ export default async function RoleDetailPage({ params }: Props) {
       {/* Candidates shortlist */}
       <div>
         <div className="flex items-center justify-between gap-3 mb-3 flex-wrap">
-          <h2 className="font-semibold text-zinc-100">
+          <h2 className="font-semibold text-[var(--color-fg)]">
             Candidates ({scoredCandidates.length})
           </h2>
           {/* Recruiter: send shortlist to managers for approval */}
@@ -354,7 +354,7 @@ export default async function RoleDetailPage({ params }: Props) {
           )}
         </div>
         {scoredCandidates.length === 0 ? (
-          <p className="text-zinc-500 text-sm">No candidates scored for this role yet.</p>
+          <p className="text-[var(--color-fg-subtle)] text-sm">No candidates scored for this role yet.</p>
         ) : (
           <SelectableRoleCandidateList
             roleId={roleId}

--- a/src/app/(dashboard)/dashboard/roles/[roleId]/upload/page.tsx
+++ b/src/app/(dashboard)/dashboard/roles/[roleId]/upload/page.tsx
@@ -28,13 +28,13 @@ export default async function UploadCvPage({ params }: Props) {
     <div className="max-w-xl">
       <Link
         href={`/dashboard/roles/${roleId}`}
-        className="inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-zinc-300 mb-6"
+        className="inline-flex items-center gap-1.5 text-sm text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)] mb-6"
       >
         <ArrowLeftIcon className="h-3.5 w-3.5" />
         Back to {role.title}
       </Link>
 
-      <h1 className="text-2xl font-bold text-zinc-100 mb-6">Upload CV</h1>
+      <h1 className="text-2xl font-bold text-[var(--color-fg)] mb-6">Upload CV</h1>
       <CandidateUploadForm roleId={roleId} agencies={agencyList} />
     </div>
   )

--- a/src/app/(dashboard)/dashboard/roles/new/page.tsx
+++ b/src/app/(dashboard)/dashboard/roles/new/page.tsx
@@ -34,7 +34,7 @@ export default async function NewRolePage() {
 
   return (
     <div>
-      <h1 className="text-2xl font-bold text-zinc-100 mb-6">Create role</h1>
+      <h1 className="text-2xl font-bold text-[var(--color-fg)] mb-6">Create role</h1>
       <RoleForm
         customers={activeCustomers.map(({ id, name }) => ({ id, name }))}
         frameworks={frameworks}

--- a/src/app/(dashboard)/dashboard/submissions/page.tsx
+++ b/src/app/(dashboard)/dashboard/submissions/page.tsx
@@ -335,13 +335,13 @@ export default async function SubmissionsPage({ searchParams }: PageProps) {
                               alt={agencyName ?? ''}
                               width={20}
                               height={20}
-                              className="rounded-full bg-zinc-800 object-contain shrink-0"
+                              className="rounded-full bg-[var(--color-bg-input)] object-contain shrink-0"
                               style={{ width: 20, height: 20 }}
                             />
                           ) : (
                             <div
-                              className="flex items-center justify-center rounded-full bg-zinc-800
-                                         text-zinc-400 text-[10px] font-semibold shrink-0"
+                              className="flex items-center justify-center rounded-full bg-[var(--color-bg-input)]
+                                         text-[var(--color-fg-muted)] text-[10px] font-semibold shrink-0"
                               style={{ width: 20, height: 20 }}
                               aria-hidden="true"
                             >

--- a/src/app/(dashboard)/dashboard/users/page.tsx
+++ b/src/app/(dashboard)/dashboard/users/page.tsx
@@ -14,7 +14,7 @@ const ROLE_BADGE: Record<UserRole, string> = {
   admin: 'bg-violet-950 text-violet-400 border border-violet-700',
   recruiter: 'bg-blue-950 text-blue-400 border border-blue-700',
   hiring_manager: 'bg-emerald-950 text-emerald-400 border border-emerald-700',
-  viewer: 'bg-zinc-800 text-zinc-400 border border-zinc-700',
+  viewer: 'bg-[var(--color-bg-input)] text-[var(--color-fg-muted)] border border-[var(--color-border)]',
 }
 
 const BASE_URL = process.env.NEXTAUTH_URL ?? 'http://localhost:3001'

--- a/src/components/candidates/bulk-status-bar.tsx
+++ b/src/components/candidates/bulk-status-bar.tsx
@@ -123,8 +123,8 @@ export function BulkStatusBar({ selectedIds, onClear, roleId }: Props) {
         <button
           onClick={handleMarkInternal}
           disabled={isPending}
-          className="inline-flex items-center gap-1.5 rounded-md border border-blue-800 bg-blue-950 text-blue-300
-                     text-sm font-medium px-3 py-1.5 hover:bg-blue-900 disabled:opacity-50
+          className="inline-flex items-center gap-1.5 rounded-md border border-blue-300 dark:border-blue-800 bg-blue-100 dark:bg-blue-950 text-blue-700 dark:text-blue-300
+                     text-sm font-medium px-3 py-1.5 hover:bg-blue-200 dark:hover:bg-blue-900 disabled:opacity-50
                      disabled:cursor-not-allowed transition-colors flex-shrink-0"
           title="Move selected candidates to the Internal agency"
         >

--- a/src/components/candidates/candidate-cv-profile.tsx
+++ b/src/components/candidates/candidate-cv-profile.tsx
@@ -61,10 +61,10 @@ function categorizeSkill(skill: string): 'languages' | 'frameworks' | 'tools' | 
 
 // ── Experience level badge styles ───────────────────────────────────────────
 const LEVEL_STYLES: Record<string, string> = {
-  junior: 'bg-zinc-800 text-zinc-300 border-zinc-700',
-  mid: 'bg-blue-950 text-blue-300 border-blue-800',
-  senior: 'bg-violet-950 text-violet-300 border-violet-800',
-  lead: 'bg-amber-950 text-amber-300 border-amber-800',
+  junior: 'bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300 border-zinc-300 dark:border-zinc-700',
+  mid: 'bg-blue-100 dark:bg-blue-950 text-blue-700 dark:text-blue-300 border-blue-300 dark:border-blue-800',
+  senior: 'bg-violet-100 dark:bg-violet-950 text-violet-700 dark:text-violet-300 border-violet-300 dark:border-violet-800',
+  lead: 'bg-amber-100 dark:bg-amber-950 text-amber-700 dark:text-amber-300 border-amber-300 dark:border-amber-800',
 }
 
 export function CandidateCvProfile({ candidateId, cvText, cvTextFormatted, profile: initialProfile, canEdit }: Props) {
@@ -169,20 +169,20 @@ export function CandidateCvProfile({ candidateId, cvText, cvTextFormatted, profi
       </div>
 
       {retryError && (
-        <div className="rounded-md bg-red-950 border border-red-800 px-3 py-2 text-xs text-red-400">
+        <div className="rounded-md bg-red-100 dark:bg-red-950 border border-red-300 dark:border-red-800 px-3 py-2 text-xs text-red-700 dark:text-red-400">
           {retryError}
         </div>
       )}
 
       {/* Failed state */}
       {isFailed && (
-        <div className="rounded-xl bg-red-950 border border-red-800 px-4 py-3">
+        <div className="rounded-xl bg-red-100 dark:bg-red-950 border border-red-300 dark:border-red-800 px-4 py-3">
           <div className="flex items-start gap-3">
-            <AlertCircleIcon className="h-5 w-5 text-red-400 flex-shrink-0 mt-0.5" />
+            <AlertCircleIcon className="h-5 w-5 text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5" />
             <div className="flex-1">
-              <p className="text-sm font-semibold text-red-400">Profile extraction failed</p>
+              <p className="text-sm font-semibold text-red-700 dark:text-red-400">Profile extraction failed</p>
               {profile?.errorMessage && (
-                <p className="text-xs text-red-500 mt-0.5">{profile.errorMessage.split('\n')[0]}</p>
+                <p className="text-xs text-red-600 dark:text-red-500 mt-0.5">{profile.errorMessage.split('\n')[0]}</p>
               )}
             </div>
           </div>
@@ -272,7 +272,7 @@ export function CandidateCvProfile({ candidateId, cvText, cvTextFormatted, profi
             <span className="hidden group-open:inline">▾ Hide full CV text</span>
           </span>
           {cvTextFormatted && (
-            <span className="inline-flex items-center gap-1 rounded-full bg-violet-950 border border-violet-800 text-violet-300 text-[10px] font-medium px-2 py-0.5">
+            <span className="inline-flex items-center gap-1 rounded-full bg-violet-100 dark:bg-violet-950 border border-violet-300 dark:border-violet-800 text-violet-700 dark:text-violet-300 text-[10px] font-medium px-2 py-0.5">
               <SparklesIcon className="h-2.5 w-2.5" />
               AI-formatted
             </span>
@@ -292,7 +292,7 @@ export function CandidateCvProfile({ candidateId, cvText, cvTextFormatted, profi
                 type="button"
                 onClick={handleReformat}
                 disabled={isReformatting}
-                className="inline-flex items-center gap-1.5 rounded-md border border-violet-800 bg-violet-950 text-violet-300 text-xs font-medium px-2.5 py-1 hover:bg-violet-900 transition-colors disabled:opacity-50"
+                className="inline-flex items-center gap-1.5 rounded-md border border-violet-300 dark:border-violet-800 bg-violet-100 dark:bg-violet-950 text-violet-700 dark:text-violet-300 text-xs font-medium px-2.5 py-1 hover:bg-violet-200 dark:hover:bg-violet-900 transition-colors disabled:opacity-50"
               >
                 {isReformatting ? (
                   <Loader2Icon className="h-3 w-3 animate-spin" />
@@ -306,7 +306,7 @@ export function CandidateCvProfile({ candidateId, cvText, cvTextFormatted, profi
             </div>
           )}
           {reformatError && (
-            <div className="mb-3 rounded-md bg-red-950 border border-red-800 px-3 py-2 text-xs text-red-400">
+            <div className="mb-3 rounded-md bg-red-100 dark:bg-red-950 border border-red-300 dark:border-red-800 px-3 py-2 text-xs text-red-700 dark:text-red-400">
               {reformatError}
             </div>
           )}
@@ -325,10 +325,10 @@ export function CandidateCvProfile({ candidateId, cvText, cvTextFormatted, profi
 // ── Skill chip ──────────────────────────────────────────────────────────────
 function SkillChip({ skill, category }: { skill: string; category: 'languages' | 'frameworks' | 'tools' | 'other' }) {
   const styles = {
-    languages: 'bg-blue-950/50 border-blue-800 text-blue-300',
-    frameworks: 'bg-violet-950/50 border-violet-800 text-violet-300',
-    tools: 'bg-emerald-950/50 border-emerald-800 text-emerald-300',
-    other: 'bg-zinc-800 border-zinc-700 text-zinc-300',
+    languages: 'bg-blue-100 dark:bg-blue-950/50 border-blue-300 dark:border-blue-800 text-blue-700 dark:text-blue-300',
+    frameworks: 'bg-violet-100 dark:bg-violet-950/50 border-violet-300 dark:border-violet-800 text-violet-700 dark:text-violet-300',
+    tools: 'bg-emerald-100 dark:bg-emerald-950/50 border-emerald-300 dark:border-emerald-800 text-emerald-700 dark:text-emerald-300',
+    other: 'bg-zinc-100 dark:bg-zinc-800 border-zinc-300 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300',
   }[category]
   return (
     <span className={`inline-flex items-center rounded-full border text-xs px-2.5 py-1 ${styles}`}>

--- a/src/components/candidates/role-history-panel.tsx
+++ b/src/components/candidates/role-history-panel.tsx
@@ -18,19 +18,19 @@ type Props = {
 }
 
 function scoreBadgeClass(score: number): string {
-  if (score >= 75) return 'bg-green-900 text-green-300 border-green-700'
-  if (score >= 50) return 'bg-blue-900 text-blue-300 border-blue-700'
-  return 'bg-zinc-800 text-zinc-400 border-zinc-600'
+  if (score >= 75) return 'bg-emerald-100 dark:bg-green-900 text-emerald-700 dark:text-green-300 border-emerald-300 dark:border-green-700'
+  if (score >= 50) return 'bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 border-blue-300 dark:border-blue-700'
+  return 'bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-400 border-zinc-300 dark:border-zinc-600'
 }
 
 function DimensionPill({ label, score }: { label: string; score: number | null }) {
   if (score === null) return null
   const colorClass =
     score >= 75
-      ? 'bg-green-900/50 text-green-300'
+      ? 'bg-emerald-100 dark:bg-green-900/50 text-emerald-700 dark:text-green-300'
       : score >= 50
-        ? 'bg-blue-900/50 text-blue-300'
-        : 'bg-zinc-800 text-zinc-400'
+        ? 'bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300'
+        : 'bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-400'
   return (
     <span className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium ${colorClass}`}>
       {label} {score}
@@ -90,11 +90,11 @@ export function RoleHistoryPanel({ roleHistory }: Props) {
                       {entry.overallScore}
                     </span>
                   ) : isFailed ? (
-                    <span className="rounded-lg border border-red-800 bg-red-950 px-3 py-1 text-xs font-medium text-red-400">
+                    <span className="rounded-lg border border-red-300 dark:border-red-800 bg-red-100 dark:bg-red-950 px-3 py-1 text-xs font-medium text-red-700 dark:text-red-400">
                       Failed
                     </span>
                   ) : isPending ? (
-                    <span className="rounded-lg border border-yellow-800 bg-yellow-950 px-3 py-1 text-xs font-medium text-yellow-400">
+                    <span className="rounded-lg border border-amber-300 dark:border-yellow-800 bg-amber-100 dark:bg-yellow-950 px-3 py-1 text-xs font-medium text-amber-700 dark:text-yellow-400">
                       Pending
                     </span>
                   ) : null}

--- a/src/components/candidates/status-selector.tsx
+++ b/src/components/candidates/status-selector.tsx
@@ -15,12 +15,12 @@ const STATUS_OPTIONS: Array<{ value: CandidateStatus; label: string }> = [
 ]
 
 const STATUS_BADGE: Record<CandidateStatus, string> = {
-  new: 'bg-zinc-800 text-zinc-300 border-zinc-600',
-  shortlisted: 'bg-blue-950 text-blue-300 border-blue-700',
-  interviewing: 'bg-amber-950 text-amber-300 border-amber-700',
-  offered: 'bg-violet-950 text-violet-300 border-violet-700',
-  rejected: 'bg-red-950 text-red-300 border-red-800',
-  hired: 'bg-emerald-950 text-emerald-300 border-emerald-700',
+  new: 'bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300 border-zinc-300 dark:border-zinc-600',
+  shortlisted: 'bg-blue-100 dark:bg-blue-950 text-blue-700 dark:text-blue-300 border-blue-300 dark:border-blue-700',
+  interviewing: 'bg-amber-100 dark:bg-amber-950 text-amber-700 dark:text-amber-300 border-amber-300 dark:border-amber-700',
+  offered: 'bg-violet-100 dark:bg-violet-950 text-violet-700 dark:text-violet-300 border-violet-300 dark:border-violet-700',
+  rejected: 'bg-red-100 dark:bg-red-950 text-red-700 dark:text-red-300 border-red-300 dark:border-red-800',
+  hired: 'bg-emerald-100 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-300 border-emerald-300 dark:border-emerald-700',
 }
 
 interface StatusSelectorProps {

--- a/src/components/interview/code-challenge.tsx
+++ b/src/components/interview/code-challenge.tsx
@@ -19,7 +19,7 @@ export function CodeChallengeCard({ challenge }: Props) {
         <div className="flex-1 min-w-0">
           <p className="text-sm font-semibold text-zinc-100">{challenge.title}</p>
           <div className="flex items-center gap-3 mt-0.5">
-            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border bg-violet-950 text-violet-400 border-violet-700">
+            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border bg-violet-100 dark:bg-violet-950 text-violet-700 dark:text-violet-400 border-violet-300 dark:border-violet-700">
               {challenge.language}
             </span>
             {challenge.estimatedMinutes && (

--- a/src/components/interview/question-card.tsx
+++ b/src/components/interview/question-card.tsx
@@ -6,16 +6,16 @@ import type { InterviewQuestion } from '@/db/schema'
 import { updateQuestionNotes } from '@/actions/interview'
 
 const TYPE_COLORS: Record<string, string> = {
-  behavioral: 'bg-blue-950 text-blue-300 border-blue-700',
-  technical: 'bg-orange-950 text-orange-300 border-orange-700',
-  situational: 'bg-green-950 text-green-300 border-green-700',
-  cultural: 'bg-purple-950 text-purple-300 border-purple-700',
+  behavioral: 'bg-blue-100 dark:bg-blue-950 text-blue-700 dark:text-blue-300 border-blue-300 dark:border-blue-700',
+  technical: 'bg-orange-100 dark:bg-orange-950 text-orange-700 dark:text-orange-300 border-orange-300 dark:border-orange-700',
+  situational: 'bg-green-100 dark:bg-green-950 text-green-700 dark:text-green-300 border-green-300 dark:border-green-700',
+  cultural: 'bg-purple-100 dark:bg-purple-950 text-purple-700 dark:text-purple-300 border-purple-300 dark:border-purple-700',
 }
 
 const DIFFICULTY_COLORS: Record<string, string> = {
-  easy: 'bg-emerald-950 text-emerald-400 border-emerald-700',
-  medium: 'bg-amber-950 text-amber-400 border-amber-800',
-  hard: 'bg-red-950 text-red-400 border-red-800',
+  easy: 'bg-emerald-100 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-400 border-emerald-300 dark:border-emerald-700',
+  medium: 'bg-amber-100 dark:bg-amber-950 text-amber-700 dark:text-amber-400 border-amber-300 dark:border-amber-800',
+  hard: 'bg-red-100 dark:bg-red-950 text-red-700 dark:text-red-400 border-red-300 dark:border-red-800',
 }
 
 type Props = { question: InterviewQuestion; index: number }
@@ -85,31 +85,31 @@ export function QuestionCard({ question, index }: Props) {
             <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wide mb-2">Scoring rubric</p>
             <div className="grid gap-2">
               {question.strongAnswerSignals?.length ? (
-                <div className="rounded-md bg-green-950 border border-green-800 px-3 py-2">
-                  <p className="text-xs font-semibold text-green-400 mb-1">Strong answer signals</p>
+                <div className="rounded-md bg-emerald-100 dark:bg-green-950 border border-emerald-300 dark:border-green-800 px-3 py-2">
+                  <p className="text-xs font-semibold text-emerald-700 dark:text-green-400 mb-1">Strong answer signals</p>
                   <ul className="space-y-0.5">
                     {question.strongAnswerSignals.map((s, i) => (
-                      <li key={i} className="text-xs text-green-400">• {s}</li>
+                      <li key={i} className="text-xs text-emerald-700 dark:text-green-400">• {s}</li>
                     ))}
                   </ul>
                 </div>
               ) : null}
               {question.acceptableAnswerSignals?.length ? (
-                <div className="rounded-md bg-amber-950 border border-amber-800 px-3 py-2">
-                  <p className="text-xs font-semibold text-amber-400 mb-1">Acceptable answer signals</p>
+                <div className="rounded-md bg-amber-100 dark:bg-amber-950 border border-amber-300 dark:border-amber-800 px-3 py-2">
+                  <p className="text-xs font-semibold text-amber-700 dark:text-amber-400 mb-1">Acceptable answer signals</p>
                   <ul className="space-y-0.5">
                     {question.acceptableAnswerSignals.map((s, i) => (
-                      <li key={i} className="text-xs text-amber-400">• {s}</li>
+                      <li key={i} className="text-xs text-amber-700 dark:text-amber-400">• {s}</li>
                     ))}
                   </ul>
                 </div>
               ) : null}
               {question.weakAnswerSignals?.length ? (
-                <div className="rounded-md bg-red-950 border border-red-800 px-3 py-2">
-                  <p className="text-xs font-semibold text-red-400 mb-1">Weak answer signals</p>
+                <div className="rounded-md bg-red-100 dark:bg-red-950 border border-red-300 dark:border-red-800 px-3 py-2">
+                  <p className="text-xs font-semibold text-red-700 dark:text-red-400 mb-1">Weak answer signals</p>
                   <ul className="space-y-0.5">
                     {question.weakAnswerSignals.map((s, i) => (
-                      <li key={i} className="text-xs text-red-400">• {s}</li>
+                      <li key={i} className="text-xs text-red-700 dark:text-red-400">• {s}</li>
                     ))}
                   </ul>
                 </div>

--- a/src/components/manager/approval-controls.tsx
+++ b/src/components/manager/approval-controls.tsx
@@ -81,15 +81,15 @@ export function ApprovalControls({
   const decisionLabel: Record<Decision, { label: string; classes: string }> = {
     approved: {
       label: 'Approved',
-      classes: 'text-green-400 bg-green-950 border border-green-800',
+      classes: 'text-emerald-700 dark:text-emerald-400 bg-emerald-100 dark:bg-emerald-950 border border-emerald-300 dark:border-emerald-800',
     },
     rejected: {
       label: 'Rejected',
-      classes: 'text-red-400 bg-red-950 border border-red-800',
+      classes: 'text-red-700 dark:text-red-400 bg-red-100 dark:bg-red-950 border border-red-300 dark:border-red-800',
     },
     pending: {
       label: 'Pending',
-      classes: 'text-amber-400 bg-amber-950 border border-amber-800',
+      classes: 'text-amber-700 dark:text-amber-400 bg-amber-100 dark:bg-amber-950 border border-amber-300 dark:border-amber-800',
     },
   }
 

--- a/src/components/manager/role-card-list.tsx
+++ b/src/components/manager/role-card-list.tsx
@@ -72,8 +72,8 @@ export function RoleCardList({ roles }: Props) {
 
                   {role.isPrimary && (
                     <span
-                      className="inline-flex items-center rounded-full bg-blue-950 border border-blue-800
-                                  text-blue-300 text-xs font-semibold px-2 py-0.5 flex-shrink-0"
+                      className="inline-flex items-center rounded-full bg-blue-100 dark:bg-blue-950 border border-blue-300 dark:border-blue-800
+                                  text-blue-700 dark:text-blue-300 text-xs font-semibold px-2 py-0.5 flex-shrink-0"
                     >
                       Primary reviewer
                     </span>
@@ -81,8 +81,8 @@ export function RoleCardList({ roles }: Props) {
 
                   {role.pendingCount > 0 && (
                     <span
-                      className="inline-flex items-center gap-1 rounded-full bg-amber-950 border border-amber-800
-                                  text-amber-300 text-xs font-semibold px-2 py-0.5 flex-shrink-0"
+                      className="inline-flex items-center gap-1 rounded-full bg-amber-100 dark:bg-amber-950 border border-amber-300 dark:border-amber-800
+                                  text-amber-700 dark:text-amber-300 text-xs font-semibold px-2 py-0.5 flex-shrink-0"
                     >
                       <ClockIcon className="h-3 w-3" aria-hidden="true" />
                       {role.pendingCount} pending
@@ -91,8 +91,8 @@ export function RoleCardList({ roles }: Props) {
 
                   {role.pendingCount === 0 && role.shortlistSentAt && (
                     <span
-                      className="inline-flex items-center gap-1 rounded-full bg-emerald-950 border border-emerald-800
-                                  text-emerald-300 text-xs font-medium px-2 py-0.5 flex-shrink-0"
+                      className="inline-flex items-center gap-1 rounded-full bg-emerald-100 dark:bg-emerald-950 border border-emerald-300 dark:border-emerald-800
+                                  text-emerald-700 dark:text-emerald-300 text-xs font-medium px-2 py-0.5 flex-shrink-0"
                     >
                       <CheckCircleIcon className="h-3 w-3" aria-hidden="true" />
                       All reviewed

--- a/src/components/manager/shortlist-status-pill.tsx
+++ b/src/components/manager/shortlist-status-pill.tsx
@@ -30,8 +30,8 @@ export function ShortlistStatusPill({
   if (!sentAt) {
     return (
       <span
-        className="inline-flex items-center rounded-full border border-zinc-700 bg-zinc-800
-                   text-zinc-400 text-xs font-medium px-3 py-1"
+        className="inline-flex items-center rounded-full border border-zinc-300 dark:border-zinc-700
+                   bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-400 text-xs font-medium px-3 py-1"
         aria-label="Shortlist not yet sent for approval"
       >
         Not sent for approval
@@ -47,17 +47,17 @@ export function ShortlistStatusPill({
   // Colour logic
   let colourClasses: string
   if (total === 0) {
-    colourClasses = 'border-zinc-700 bg-zinc-800 text-zinc-400'
+    colourClasses = 'border-zinc-300 dark:border-zinc-700 bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-400'
   } else if (allApproved) {
-    colourClasses = 'border-green-800 bg-green-950 text-green-300'
+    colourClasses = 'border-emerald-300 dark:border-emerald-800 bg-emerald-100 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-300'
   } else if (allRejected) {
-    colourClasses = 'border-red-800 bg-red-950 text-red-300'
+    colourClasses = 'border-red-300 dark:border-red-800 bg-red-100 dark:bg-red-950 text-red-700 dark:text-red-300'
   } else if (allReviewed) {
     // Mix of approved + rejected — amber
-    colourClasses = 'border-amber-800 bg-amber-950 text-amber-300'
+    colourClasses = 'border-amber-300 dark:border-amber-800 bg-amber-100 dark:bg-amber-950 text-amber-700 dark:text-amber-300'
   } else {
     // Still pending reviews
-    colourClasses = 'border-blue-800 bg-blue-950 text-blue-300'
+    colourClasses = 'border-blue-300 dark:border-blue-800 bg-blue-100 dark:bg-blue-950 text-blue-700 dark:text-blue-300'
   }
 
   const sentLabel = formatSentDate(sentAt)

--- a/src/components/roles/role-candidate-card.tsx
+++ b/src/components/roles/role-candidate-card.tsx
@@ -9,9 +9,9 @@ type ScorePillProps = { label: string; score: number | null }
 function ScorePill({ label, score }: ScorePillProps) {
   if (score === null) return null
   const color =
-    score >= 75 ? 'bg-emerald-950 text-emerald-400 border-emerald-800' :
-    score >= 50 ? 'bg-blue-950 text-blue-400 border-blue-800' :
-    'bg-zinc-800 text-zinc-400 border-zinc-600'
+    score >= 75 ? 'bg-emerald-100 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-400 border-emerald-300 dark:border-emerald-800' :
+    score >= 50 ? 'bg-blue-100 dark:bg-blue-950 text-blue-700 dark:text-blue-400 border-blue-300 dark:border-blue-800' :
+    'bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-400 border-zinc-300 dark:border-zinc-600'
   return (
     <span className={`inline-flex items-center gap-1 text-xs border rounded px-1.5 py-0.5 ${color}`}>
       <span className="text-zinc-500">{label}</span>
@@ -27,8 +27,8 @@ function MarginPill({
   const mismatch = Boolean(roleCurrency && candCurrency && roleCurrency !== candCurrency)
   const margin = Number(roleRate) - Number(candRate)
   const color = margin >= 0
-    ? 'bg-emerald-950 text-emerald-300 border-emerald-800'
-    : 'bg-red-950 text-red-300 border-red-800'
+    ? 'bg-emerald-100 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-300 border-emerald-300 dark:border-emerald-800'
+    : 'bg-red-100 dark:bg-red-950 text-red-700 dark:text-red-300 border-red-300 dark:border-red-800'
   return (
     <span
       className={`inline-flex items-center gap-1 text-xs border rounded-full px-2 py-0.5 ${color}`}
@@ -135,15 +135,15 @@ export function RoleCandidateCard({
             {firstName} {lastName}
           </span>
           {isInternal && (
-            <span className="inline-flex items-center gap-1 rounded-full bg-blue-950 border border-blue-800
-                             text-blue-300 text-xs font-semibold px-2 py-0.5">
+            <span className="inline-flex items-center gap-1 rounded-full bg-blue-100 dark:bg-blue-950 border border-blue-300 dark:border-blue-800
+                             text-blue-700 dark:text-blue-300 text-xs font-semibold px-2 py-0.5">
               <HomeIcon className="h-3 w-3" />
               INTERNAL
             </span>
           )}
           {isSubmitted && (
             <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium
-                             bg-emerald-950 text-emerald-300 border border-emerald-800">
+                             bg-emerald-100 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-300 border border-emerald-300 dark:border-emerald-800">
               Submitted
             </span>
           )}
@@ -193,7 +193,7 @@ export function RoleCandidateCard({
 
       <div className="flex items-center gap-3 ml-4 flex-shrink-0">
         {scoreStatus === 'pending' || scoreStatus === 'processing' ? (
-          <span className="text-xs bg-amber-950 text-amber-400 border border-amber-800 px-2 py-0.5 rounded-full">
+          <span className="text-xs bg-amber-100 dark:bg-amber-950 text-amber-700 dark:text-amber-400 border border-amber-300 dark:border-amber-800 px-2 py-0.5 rounded-full">
             Scoring…
           </span>
         ) : scoreStatus === 'complete' && overallScore !== null ? (

--- a/src/components/roles/role-meta-bar.tsx
+++ b/src/components/roles/role-meta-bar.tsx
@@ -44,23 +44,23 @@ function daysFromNow(iso: string): number {
 
 const WORK_MODE_STYLES: Record<string, { bg: string; text: string; border: string; icon: React.ReactNode; label: string }> = {
   remote: {
-    bg: 'bg-emerald-950',
-    text: 'text-emerald-300',
-    border: 'border-emerald-800',
+    bg: 'bg-emerald-100 dark:bg-emerald-950',
+    text: 'text-emerald-700 dark:text-emerald-300',
+    border: 'border-emerald-300 dark:border-emerald-800',
     icon: <HomeIcon className="h-3 w-3" />,
     label: 'Remote',
   },
   hybrid: {
-    bg: 'bg-blue-950',
-    text: 'text-blue-300',
-    border: 'border-blue-800',
+    bg: 'bg-blue-100 dark:bg-blue-950',
+    text: 'text-blue-700 dark:text-blue-300',
+    border: 'border-blue-300 dark:border-blue-800',
     icon: <MonitorIcon className="h-3 w-3" />,
     label: 'Hybrid',
   },
   onsite: {
-    bg: 'bg-amber-950',
-    text: 'text-amber-300',
-    border: 'border-amber-800',
+    bg: 'bg-amber-100 dark:bg-amber-950',
+    text: 'text-amber-700 dark:text-amber-300',
+    border: 'border-amber-300 dark:border-amber-800',
     icon: <BuildingIcon className="h-3 w-3" />,
     label: 'Onsite',
   },
@@ -80,10 +80,10 @@ export function RoleMetaBar({ role, customer, portalUrl, customerRoleId, custome
   const cutoffStyle = cutoffDays === null
     ? null
     : cutoffDays < 0
-      ? { bg: 'bg-red-950', text: 'text-red-300', border: 'border-red-800', label: 'EXPIRED' }
+      ? { bg: 'bg-red-100 dark:bg-red-950', text: 'text-red-700 dark:text-red-300', border: 'border-red-300 dark:border-red-800', label: 'EXPIRED' }
       : cutoffDays <= 14
-        ? { bg: 'bg-amber-950', text: 'text-amber-300', border: 'border-amber-800', label: `Cut-off ${fmtDate(role.cutoffDate!)}` }
-        : { bg: 'bg-emerald-950', text: 'text-emerald-300', border: 'border-emerald-800', label: `Cut-off ${fmtDate(role.cutoffDate!)}` }
+        ? { bg: 'bg-amber-100 dark:bg-amber-950', text: 'text-amber-700 dark:text-amber-300', border: 'border-amber-300 dark:border-amber-800', label: `Cut-off ${fmtDate(role.cutoffDate!)}` }
+        : { bg: 'bg-emerald-100 dark:bg-emerald-950', text: 'text-emerald-700 dark:text-emerald-300', border: 'border-emerald-300 dark:border-emerald-800', label: `Cut-off ${fmtDate(role.cutoffDate!)}` }
 
   // No metadata at all — render nothing
   if (!workMode && !location && !hasLanguages && !customer && !role.frameworkLevelLabel
@@ -111,7 +111,7 @@ export function RoleMetaBar({ role, customer, portalUrl, customerRoleId, custome
       {hasLanguages && role.languageRequirements!.map((lang) => (
         <span
           key={lang}
-          className="inline-flex items-center gap-1.5 rounded-full border border-violet-800 bg-violet-950 text-violet-300 text-xs font-medium px-2.5 py-1"
+          className="inline-flex items-center gap-1.5 rounded-full border border-violet-300 dark:border-violet-800 bg-violet-100 dark:bg-violet-950 text-violet-700 dark:text-violet-300 text-xs font-medium px-2.5 py-1"
         >
           <GlobeIcon className="h-3 w-3" />
           {lang}
@@ -136,14 +136,14 @@ export function RoleMetaBar({ role, customer, portalUrl, customerRoleId, custome
       )}
 
       {role.frameworkLevelLabel && (
-        <span className="inline-flex items-center gap-1.5 rounded-full border border-indigo-800 bg-indigo-950 text-indigo-300 text-xs font-medium px-2.5 py-1">
+        <span className="inline-flex items-center gap-1.5 rounded-full border border-indigo-300 dark:border-indigo-800 bg-indigo-100 dark:bg-indigo-950 text-indigo-700 dark:text-indigo-300 text-xs font-medium px-2.5 py-1">
           <LayersIcon className="h-3 w-3" />
           {role.frameworkLevelLabel}
         </span>
       )}
 
       {role.customerDayRate && (
-        <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-800 bg-emerald-950 text-emerald-300 text-xs font-medium px-2.5 py-1">
+        <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-300 dark:border-emerald-800 bg-emerald-100 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-300 text-xs font-medium px-2.5 py-1">
           <BanknoteIcon className="h-3 w-3" />
           {role.rateCurrency ?? ''} {Number(role.customerDayRate).toFixed(0)}/day budget
         </span>
@@ -168,7 +168,7 @@ export function RoleMetaBar({ role, customer, portalUrl, customerRoleId, custome
           href={portalUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-1.5 rounded-full border border-blue-800 bg-blue-950 text-blue-300 text-xs font-medium px-2.5 py-1 hover:bg-blue-900 hover:text-blue-200 transition-colors"
+          className="inline-flex items-center gap-1.5 rounded-full border border-blue-300 dark:border-blue-800 bg-blue-100 dark:bg-blue-950 text-blue-700 dark:text-blue-300 text-xs font-medium px-2.5 py-1 hover:bg-blue-200 dark:hover:bg-blue-900 hover:text-blue-800 dark:hover:text-blue-200 transition-colors"
         >
           <ExternalLinkIcon className="h-3 w-3" />
           Customer portal

--- a/src/components/roles/submission-status-pill.tsx
+++ b/src/components/roles/submission-status-pill.tsx
@@ -1,13 +1,13 @@
 import type { SubmissionStatus } from '@/db/schema/role-submissions'
 
 const STATUS_STYLES: Record<SubmissionStatus, string> = {
-  submitted: 'bg-blue-950 text-blue-300 border-blue-800',
-  interview_scheduled: 'bg-violet-950 text-violet-300 border-violet-800',
-  interview_done: 'bg-indigo-950 text-indigo-300 border-indigo-800',
-  feedback_pending: 'bg-amber-950 text-amber-300 border-amber-800',
-  hired: 'bg-emerald-950 text-emerald-300 border-emerald-800',
-  rejected: 'bg-red-950 text-red-300 border-red-800',
-  withdrawn: 'bg-zinc-800 text-zinc-400 border-zinc-700',
+  submitted: 'bg-blue-100 dark:bg-blue-950 text-blue-700 dark:text-blue-300 border-blue-300 dark:border-blue-800',
+  interview_scheduled: 'bg-violet-100 dark:bg-violet-950 text-violet-700 dark:text-violet-300 border-violet-300 dark:border-violet-800',
+  interview_done: 'bg-indigo-100 dark:bg-indigo-950 text-indigo-700 dark:text-indigo-300 border-indigo-300 dark:border-indigo-800',
+  feedback_pending: 'bg-amber-100 dark:bg-amber-950 text-amber-700 dark:text-amber-300 border-amber-300 dark:border-amber-800',
+  hired: 'bg-emerald-100 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-300 border-emerald-300 dark:border-emerald-800',
+  rejected: 'bg-red-100 dark:bg-red-950 text-red-700 dark:text-red-300 border-red-300 dark:border-red-800',
+  withdrawn: 'bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-400 border-zinc-300 dark:border-zinc-700',
 }
 
 const STATUS_LABELS: Record<SubmissionStatus, string> = {

--- a/src/components/roles/submit-to-customer-button.tsx
+++ b/src/components/roles/submit-to-customer-button.tsx
@@ -57,9 +57,9 @@ export function SubmitToCustomerButton({ roleId, selectedCandidateIds, onSuccess
         type="button"
         onClick={() => setOpen(true)}
         disabled={selectedCandidateIds.length === 0}
-        className="inline-flex items-center gap-1.5 rounded-md border border-emerald-800
-                   bg-emerald-950 text-emerald-300 text-sm font-medium px-3 py-1.5
-                   hover:bg-emerald-900 disabled:opacity-50 disabled:cursor-not-allowed
+        className="inline-flex items-center gap-1.5 rounded-md border border-emerald-300 dark:border-emerald-800
+                   bg-emerald-100 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-300 text-sm font-medium px-3 py-1.5
+                   hover:bg-emerald-200 dark:hover:bg-emerald-900 disabled:opacity-50 disabled:cursor-not-allowed
                    transition-colors flex-shrink-0"
         title="Submit selected candidates to customer"
       >
@@ -119,7 +119,7 @@ export function SubmitToCustomerButton({ roleId, selectedCandidateIds, onSuccess
 
             {/* Inline error */}
             {error && (
-              <p className="mb-4 text-xs text-red-400 bg-red-950 border border-red-800 rounded-md px-3 py-2">
+              <p className="mb-4 text-xs text-red-700 dark:text-red-400 bg-red-100 dark:bg-red-950 border border-red-300 dark:border-red-800 rounded-md px-3 py-2">
                 {error}
               </p>
             )}

--- a/src/components/settings/user-management-table.tsx
+++ b/src/components/settings/user-management-table.tsx
@@ -13,10 +13,10 @@ const ROLE_OPTIONS: { value: UserRole; label: string }[] = [
 ]
 
 const ROLE_BADGE: Record<UserRole, string> = {
-  admin: 'bg-blue-950 text-blue-300 border-blue-700',
-  recruiter: 'bg-violet-950 text-violet-300 border-violet-700',
-  hiring_manager: 'bg-emerald-950 text-emerald-300 border-emerald-700',
-  viewer: 'bg-zinc-800 text-zinc-400 border-zinc-600',
+  admin: 'bg-blue-100 dark:bg-blue-950 text-blue-700 dark:text-blue-300 border-blue-300 dark:border-blue-700',
+  recruiter: 'bg-violet-100 dark:bg-violet-950 text-violet-700 dark:text-violet-300 border-violet-300 dark:border-violet-700',
+  hiring_manager: 'bg-emerald-100 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-300 border-emerald-300 dark:border-emerald-700',
+  viewer: 'bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-400 border-zinc-300 dark:border-zinc-600',
 }
 
 type Props = {
@@ -82,7 +82,7 @@ export function UserManagementTable({ users, currentUserId }: Props) {
                       Inactive
                     </span>
                   ) : (
-                    <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-emerald-950 text-emerald-400 border border-emerald-700">
+                    <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-emerald-100 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-400 border border-emerald-300 dark:border-emerald-700">
                       Active
                     </span>
                   )}


### PR DESCRIPTION
First of 5 phased PRs for [Epic #103](https://github.com/olafkfreund/SkillAi/issues/103) — full light/dark theme conversion.

## Summary

**Dashboard pages (16 files, ~196 conversions):** All `bg-zinc-*`/`text-zinc-*`/`border-zinc-*` in `src/app/(dashboard)/dashboard/**/*.tsx` mapped to CSS tokens (`var(--color-bg-{app,elevated,input})`, `var(--color-fg{,-muted,-subtle})`, `var(--color-border)`). Final grep against the dashboard page tree: zero hits.

**Status pills (14 files):** `bg-X-950 text-X-300 border-X-800` → `bg-X-100 dark:bg-X-950 text-X-700 dark:text-X-300 border-X-300 dark:border-X-800`. Pills now readable in both modes.

Saturated solid buttons (`bg-blue-600`, `bg-emerald-700`, etc.) left as-is — already light-mode-friendly. PDFs untouched (out of scope per the epic).

## What's still untouched (subsequent PRs)

- PR2: `src/components/candidates/**` (~25 files)
- PR3: `src/components/roles/**` + `src/components/manager/**`
- PR4: interview / transcripts / submissions / customers / agencies
- PR5: settings / ui / export + final sweep + close epic

## Test plan

- [x] Typecheck clean (excluding pre-existing `src/instrumentation.ts` carry-over)
- [x] Lint: 8 pre-existing `<img>` warnings (established convention) + 1 pre-existing `react-hooks/purity` error in `dashboard/page.tsx:37` (commit `a52b0636` April 9, out of scope)
- [x] Dev server compiled cleanly
- [ ] Toggle light mode in the sidebar → dashboard, role detail, candidate detail, agency detail, customer detail all render with correct light surface colours
- [ ] Status pills (submission status, shortlist status, score pills, internal/submitted badges, role badges) are readable in both modes
- [ ] No surface that was working in dark mode is now broken in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)