### PR TITLE
refactor(theme): PR2 — candidates domain converted to CSS tokens (part of #103)

### DIFF
--- a/src/components/candidates/bulk-status-bar.tsx
+++ b/src/components/candidates/bulk-status-bar.tsx
@@ -64,13 +64,13 @@ export function BulkStatusBar({ selectedIds, onClear, roleId }: Props) {
 
   return (
     <div
-      className="fixed bottom-0 left-0 right-0 bg-zinc-900 border-t border-zinc-700 px-6 py-4
+      className="fixed bottom-0 left-0 right-0 bg-[var(--color-bg-elevated)] border-t border-[var(--color-border)] px-6 py-4
                  flex items-center gap-4 z-50 shadow-2xl"
       role="region"
       aria-label="Bulk status actions"
     >
       {/* Selection count */}
-      <span className="text-sm font-medium text-zinc-200 flex-shrink-0">
+      <span className="text-sm font-medium text-[var(--color-fg)] flex-shrink-0">
         {selectedIds.length} candidate{selectedIds.length !== 1 ? 's' : ''} selected
       </span>
 
@@ -82,7 +82,7 @@ export function BulkStatusBar({ selectedIds, onClear, roleId }: Props) {
             onChange={(e) => setSelectedStatus(e.target.value as CandidateStatus)}
             disabled={isPending}
             aria-label="Select new status for selected candidates"
-            className="appearance-none rounded-md border border-zinc-600 bg-zinc-800 text-zinc-200
+            className="appearance-none rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)]
                        text-sm px-3 py-1.5 pr-7 focus:outline-none focus:ring-2 focus:ring-blue-500
                        focus:border-transparent disabled:opacity-50 cursor-pointer"
           >
@@ -93,7 +93,7 @@ export function BulkStatusBar({ selectedIds, onClear, roleId }: Props) {
             ))}
           </select>
           <svg
-            className="absolute right-1.5 h-4 w-4 text-zinc-500 pointer-events-none"
+            className="absolute right-1.5 h-4 w-4 text-[var(--color-fg-subtle)] pointer-events-none"
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
@@ -161,7 +161,7 @@ export function BulkStatusBar({ selectedIds, onClear, roleId }: Props) {
       <button
         onClick={onClear}
         disabled={isPending}
-        className="inline-flex items-center gap-1.5 text-sm text-zinc-400 hover:text-zinc-200
+        className="inline-flex items-center gap-1.5 text-sm text-[var(--color-fg-muted)] hover:text-[var(--color-fg)]
                    transition-colors px-2 py-1.5 flex-shrink-0 disabled:opacity-50"
         aria-label="Clear selection"
       >

--- a/src/components/candidates/bulk-upload-zone.tsx
+++ b/src/components/candidates/bulk-upload-zone.tsx
@@ -44,7 +44,7 @@ function isAccepted(file: File): boolean {
 
 function StatusIcon({ status }: { status: FileStatus }) {
   if (status === 'queued')
-    return <ClockIcon className="h-4 w-4 text-zinc-500 shrink-0" />
+    return <ClockIcon className="h-4 w-4 text-[var(--color-fg-subtle)] shrink-0" />
   if (status === 'uploading')
     return <Loader2Icon className="h-4 w-4 text-blue-400 shrink-0 animate-spin" />
   if (status === 'done')
@@ -165,16 +165,16 @@ export function BulkUploadZone({ roleId, agencyId }: Props) {
           'px-6 py-12 cursor-pointer select-none transition-colors',
           dragOver
             ? 'border-blue-500 bg-blue-950/30'
-            : 'border-zinc-700 bg-zinc-900 hover:border-zinc-500 hover:bg-zinc-800/60',
+            : 'border-[var(--color-border)] bg-[var(--color-bg-elevated)] hover:border-[var(--color-fg-subtle)] hover:bg-[var(--color-bg-input)]/60',
           uploading ? 'opacity-50 pointer-events-none' : '',
         ].join(' ')}
       >
-        <UploadCloudIcon className="h-10 w-10 text-zinc-500" />
-        <p className="text-sm text-zinc-400 text-center">
-          <span className="font-medium text-zinc-200">Click to browse</span> or drag and drop
+        <UploadCloudIcon className="h-10 w-10 text-[var(--color-fg-subtle)]" />
+        <p className="text-sm text-[var(--color-fg-muted)] text-center">
+          <span className="font-medium text-[var(--color-fg)]">Click to browse</span> or drag and drop
           multiple CV files
         </p>
-        <p className="text-xs text-zinc-600">PDF, DOCX, ODT, RTF, TXT, MD &mdash; max 10 MB each</p>
+        <p className="text-xs text-[var(--color-fg-subtle)]">PDF, DOCX, ODT, RTF, TXT, MD &mdash; max 10 MB each</p>
         <input
           ref={inputRef}
           type="file"
@@ -190,7 +190,7 @@ export function BulkUploadZone({ roleId, agencyId }: Props) {
       {/* File list */}
       {files.length > 0 && (
         <div
-          className="rounded-xl border border-zinc-700 bg-zinc-900 divide-y divide-zinc-800 overflow-hidden"
+          className="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-elevated)] divide-y divide-[var(--color-bg-input)] overflow-hidden"
           role="list"
           aria-label="CV files to upload"
         >
@@ -202,7 +202,7 @@ export function BulkUploadZone({ roleId, agencyId }: Props) {
             >
               <StatusIcon status={item.status} />
               <div className="flex-1 min-w-0">
-                <p className="text-sm text-zinc-200 truncate">{item.file.name}</p>
+                <p className="text-sm text-[var(--color-fg)] truncate">{item.file.name}</p>
                 {item.status === 'done' && item.candidateName && (
                   <p className="text-xs text-emerald-400 truncate">{item.candidateName}</p>
                 )}
@@ -210,13 +210,13 @@ export function BulkUploadZone({ roleId, agencyId }: Props) {
                   <p className="text-xs text-red-400 truncate">{item.error}</p>
                 )}
                 {item.status === 'queued' && (
-                  <p className="text-xs text-zinc-600">Queued</p>
+                  <p className="text-xs text-[var(--color-fg-subtle)]">Queued</p>
                 )}
                 {item.status === 'uploading' && (
                   <p className="text-xs text-blue-400">Uploading&hellip;</p>
                 )}
               </div>
-              <span className="text-xs text-zinc-600 shrink-0">
+              <span className="text-xs text-[var(--color-fg-subtle)] shrink-0">
                 {(item.file.size / 1024).toFixed(0)} KB
               </span>
               {!uploading && item.status !== 'uploading' && (
@@ -224,7 +224,7 @@ export function BulkUploadZone({ roleId, agencyId }: Props) {
                   type="button"
                   aria-label={`Remove ${item.file.name}`}
                   onClick={() => removeItem(item.id)}
-                  className="shrink-0 text-zinc-600 hover:text-red-400 transition-colors"
+                  className="shrink-0 text-[var(--color-fg-subtle)] hover:text-red-400 transition-colors"
                 >
                   <XCircleIcon className="h-4 w-4" />
                 </button>
@@ -236,7 +236,7 @@ export function BulkUploadZone({ roleId, agencyId }: Props) {
 
       {/* Progress counter */}
       {uploading && (
-        <p className="text-sm text-zinc-400" aria-live="polite">
+        <p className="text-sm text-[var(--color-fg-muted)]" aria-live="polite">
           {doneCount + errorCount} of {total} processed
           {uploadingCount > 0 && ' — uploading\u2026'}
         </p>
@@ -244,8 +244,8 @@ export function BulkUploadZone({ roleId, agencyId }: Props) {
 
       {/* Done summary */}
       {done && !uploading && total > 0 && (
-        <div className="rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-3 flex items-center justify-between gap-4">
-          <p className="text-sm text-zinc-300">
+        <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-elevated)] px-4 py-3 flex items-center justify-between gap-4">
+          <p className="text-sm text-[var(--color-fg)]">
             <span className="font-medium text-emerald-400">{doneCount} uploaded</span>
             {errorCount > 0 && (
               <span className="text-red-400">, {errorCount} failed</span>
@@ -291,7 +291,7 @@ export function BulkUploadZone({ roleId, agencyId }: Props) {
               setFiles([])
               setDone(false)
             }}
-            className="text-sm text-zinc-500 hover:text-zinc-300 transition-colors"
+            className="text-sm text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)] transition-colors"
           >
             Clear all
           </button>

--- a/src/components/candidates/candidate-cv-profile.tsx
+++ b/src/components/candidates/candidate-cv-profile.tsx
@@ -61,7 +61,7 @@ function categorizeSkill(skill: string): 'languages' | 'frameworks' | 'tools' | 
 
 // ── Experience level badge styles ───────────────────────────────────────────
 const LEVEL_STYLES: Record<string, string> = {
-  junior: 'bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300 border-zinc-300 dark:border-zinc-700',
+  junior: 'bg-zinc-100 dark:bg-[var(--color-bg-input)] text-zinc-700 dark:text-[var(--color-fg)] border-zinc-300 dark:border-[var(--color-border)]',
   mid: 'bg-blue-100 dark:bg-blue-950 text-blue-700 dark:text-blue-300 border-blue-300 dark:border-blue-800',
   senior: 'bg-violet-100 dark:bg-violet-950 text-violet-700 dark:text-violet-300 border-violet-300 dark:border-violet-800',
   lead: 'bg-amber-100 dark:bg-amber-950 text-amber-700 dark:text-amber-300 border-amber-300 dark:border-amber-800',
@@ -143,7 +143,7 @@ export function CandidateCvProfile({ candidateId, cvText, cvTextFormatted, profi
             </span>
           )}
           {isComplete && profile?.extractedAt && (
-            <span className="inline-flex items-center gap-1 text-xs text-zinc-500">
+            <span className="inline-flex items-center gap-1 text-xs text-[var(--color-fg-subtle)]">
               <CheckCircle2Icon className="h-3 w-3 text-emerald-500" />
               Extracted {new Date(profile.extractedAt).toLocaleDateString('en-GB')}
             </span>
@@ -160,7 +160,7 @@ export function CandidateCvProfile({ candidateId, cvText, cvTextFormatted, profi
             type="button"
             onClick={handleReextract}
             disabled={isPending}
-            className="inline-flex items-center gap-1.5 rounded-md border border-zinc-700 text-zinc-400 text-xs px-2.5 py-1 hover:bg-zinc-800 hover:text-zinc-200 transition-colors disabled:opacity-50"
+            className="inline-flex items-center gap-1.5 rounded-md border border-[var(--color-border)] text-[var(--color-fg-muted)] text-xs px-2.5 py-1 hover:bg-[var(--color-bg-input)] hover:text-[var(--color-fg)] transition-colors disabled:opacity-50"
           >
             <RefreshCwIcon className={`h-3 w-3 ${isPending ? 'animate-spin' : ''}`} />
             {isPending ? 'Queuing…' : 'Re-extract'}
@@ -191,15 +191,15 @@ export function CandidateCvProfile({ candidateId, cvText, cvTextFormatted, profi
 
       {/* Summary */}
       {isComplete && profile?.summary && (
-        <div className="bg-zinc-900 rounded-lg border border-zinc-700 p-4">
-          <p className="text-sm text-zinc-300 leading-relaxed">{profile.summary}</p>
+        <div className="bg-[var(--color-bg-elevated)] rounded-lg border border-[var(--color-border)] p-4">
+          <p className="text-sm text-[var(--color-fg)] leading-relaxed">{profile.summary}</p>
         </div>
       )}
 
       {/* Skills */}
       {isComplete && skills.length > 0 && (
         <div>
-          <h3 className="text-xs font-semibold text-zinc-400 uppercase tracking-wide mb-3">Skills</h3>
+          <h3 className="text-xs font-semibold text-[var(--color-fg-muted)] uppercase tracking-wide mb-3">Skills</h3>
           <div className="space-y-3">
             {(['languages', 'frameworks', 'tools', 'other'] as const).map((cat) => {
               const items = skillGroups[cat]
@@ -207,7 +207,7 @@ export function CandidateCvProfile({ candidateId, cvText, cvTextFormatted, profi
               const label = cat === 'languages' ? 'Languages' : cat === 'frameworks' ? 'Frameworks' : cat === 'tools' ? 'Tools & Platforms' : 'Other'
               return (
                 <div key={cat}>
-                  <p className="text-[11px] text-zinc-500 uppercase tracking-wide mb-1.5">{label}</p>
+                  <p className="text-[11px] text-[var(--color-fg-subtle)] uppercase tracking-wide mb-1.5">{label}</p>
                   <div className="flex flex-wrap gap-1.5">
                     {items.map((skill) => (
                       <SkillChip key={skill} skill={skill} category={cat} />
@@ -223,9 +223,9 @@ export function CandidateCvProfile({ candidateId, cvText, cvTextFormatted, profi
       {/* Company timeline */}
       {isComplete && companies.length > 0 && (
         <div>
-          <h3 className="text-xs font-semibold text-zinc-400 uppercase tracking-wide mb-3">Experience</h3>
+          <h3 className="text-xs font-semibold text-[var(--color-fg-muted)] uppercase tracking-wide mb-3">Experience</h3>
           <div className="relative pl-6">
-            <div className="absolute left-[9px] top-2 bottom-2 w-px bg-zinc-800" />
+            <div className="absolute left-[9px] top-2 bottom-2 w-px bg-[var(--color-bg-input)]" />
             <div className="space-y-4">
               {companies.map((company, i) => (
                 <div key={`${company.name}-${i}`} className="relative">
@@ -233,15 +233,15 @@ export function CandidateCvProfile({ candidateId, cvText, cvTextFormatted, profi
                     <BriefcaseIcon className="h-2 w-2 text-violet-300" />
                   </span>
                   <div>
-                    <p className="text-sm font-semibold text-zinc-100">
-                      {company.role} <span className="text-zinc-500 font-normal">·</span>{' '}
-                      <span className="text-zinc-300 font-normal">{company.name}</span>
+                    <p className="text-sm font-semibold text-[var(--color-fg)]">
+                      {company.role} <span className="text-[var(--color-fg-subtle)] font-normal">·</span>{' '}
+                      <span className="text-[var(--color-fg)] font-normal">{company.name}</span>
                     </p>
                     {company.keyAchievements.length > 0 && (
-                      <ul className="mt-1.5 space-y-1 text-sm text-zinc-400">
+                      <ul className="mt-1.5 space-y-1 text-sm text-[var(--color-fg-muted)]">
                         {company.keyAchievements.map((ach, j) => (
                           <li key={j} className="flex gap-2 leading-relaxed">
-                            <span className="text-zinc-600 flex-shrink-0">•</span>
+                            <span className="text-[var(--color-fg-subtle)] flex-shrink-0">•</span>
                             <span>{ach}</span>
                           </li>
                         ))}
@@ -258,9 +258,9 @@ export function CandidateCvProfile({ candidateId, cvText, cvTextFormatted, profi
       {/* Pending skeleton when no profile data at all */}
       {isProcessing && skills.length === 0 && companies.length === 0 && (
         <div className="space-y-3">
-          <div className="h-16 bg-zinc-900 border border-zinc-800 rounded-lg animate-pulse" />
-          <div className="h-24 bg-zinc-900 border border-zinc-800 rounded-lg animate-pulse" />
-          <div className="h-32 bg-zinc-900 border border-zinc-800 rounded-lg animate-pulse" />
+          <div className="h-16 bg-[var(--color-bg-elevated)] border border-[var(--color-bg-input)] rounded-lg animate-pulse" />
+          <div className="h-24 bg-[var(--color-bg-elevated)] border border-[var(--color-bg-input)] rounded-lg animate-pulse" />
+          <div className="h-32 bg-[var(--color-bg-elevated)] border border-[var(--color-bg-input)] rounded-lg animate-pulse" />
         </div>
       )}
 
@@ -279,11 +279,11 @@ export function CandidateCvProfile({ candidateId, cvText, cvTextFormatted, profi
           )}
         </summary>
 
-        <div className="mt-2 pt-3 border-t border-zinc-800">
+        <div className="mt-2 pt-3 border-t border-[var(--color-bg-input)]">
           {/* Reformat button — recruiters/admins only */}
           {canEdit && (
             <div className="flex items-center justify-between mb-3 flex-wrap gap-2">
-              <p className="text-xs text-zinc-500">
+              <p className="text-xs text-[var(--color-fg-subtle)]">
                 {cvTextFormatted
                   ? 'Showing AI-formatted version. Click below to regenerate from raw text.'
                   : 'Showing raw extracted text. Click "Reformat with AI" for a cleaner version.'}
@@ -328,7 +328,7 @@ function SkillChip({ skill, category }: { skill: string; category: 'languages' |
     languages: 'bg-blue-100 dark:bg-blue-950/50 border-blue-300 dark:border-blue-800 text-blue-700 dark:text-blue-300',
     frameworks: 'bg-violet-100 dark:bg-violet-950/50 border-violet-300 dark:border-violet-800 text-violet-700 dark:text-violet-300',
     tools: 'bg-emerald-100 dark:bg-emerald-950/50 border-emerald-300 dark:border-emerald-800 text-emerald-700 dark:text-emerald-300',
-    other: 'bg-zinc-100 dark:bg-zinc-800 border-zinc-300 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300',
+    other: 'bg-zinc-100 dark:bg-[var(--color-bg-input)] border-zinc-300 dark:border-[var(--color-border)] text-zinc-700 dark:text-[var(--color-fg)]',
   }[category]
   return (
     <span className={`inline-flex items-center rounded-full border text-xs px-2.5 py-1 ${styles}`}>

--- a/src/components/candidates/candidate-upload-form.tsx
+++ b/src/components/candidates/candidate-upload-form.tsx
@@ -113,7 +113,7 @@ export function CandidateUploadForm({ roleId, agencies }: Props) {
 
       {/* CV upload — top of form so extraction happens before user fills fields */}
       <div>
-        <label className="block text-sm font-medium text-zinc-300 mb-2">
+        <label className="block text-sm font-medium text-[var(--color-fg)] mb-2">
           CV file <span className="text-red-500">*</span>
         </label>
         <CvDropzone
@@ -140,7 +140,7 @@ export function CandidateUploadForm({ roleId, agencies }: Props) {
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
-          <label htmlFor="firstName" className="block text-sm font-medium text-zinc-300 mb-1">
+          <label htmlFor="firstName" className="block text-sm font-medium text-[var(--color-fg)] mb-1">
             First name <span className="text-red-500">*</span>
           </label>
           <input
@@ -150,8 +150,8 @@ export function CandidateUploadForm({ roleId, agencies }: Props) {
             disabled={pending || extracting}
             value={fields.firstName}
             onChange={(e) => setFields((f) => ({ ...f, firstName: e.target.value }))}
-            className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                       placeholder:text-zinc-500
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                       placeholder:text-[var(--color-fg-subtle)]
                        focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
           />
           {fieldErrors?.firstName && (
@@ -159,7 +159,7 @@ export function CandidateUploadForm({ roleId, agencies }: Props) {
           )}
         </div>
         <div>
-          <label htmlFor="lastName" className="block text-sm font-medium text-zinc-300 mb-1">
+          <label htmlFor="lastName" className="block text-sm font-medium text-[var(--color-fg)] mb-1">
             Last name <span className="text-red-500">*</span>
           </label>
           <input
@@ -169,15 +169,15 @@ export function CandidateUploadForm({ roleId, agencies }: Props) {
             disabled={pending || extracting}
             value={fields.lastName}
             onChange={(e) => setFields((f) => ({ ...f, lastName: e.target.value }))}
-            className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                       placeholder:text-zinc-500
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                       placeholder:text-[var(--color-fg-subtle)]
                        focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
           />
         </div>
       </div>
 
       <div>
-        <label htmlFor="email" className="block text-sm font-medium text-zinc-300 mb-1">
+        <label htmlFor="email" className="block text-sm font-medium text-[var(--color-fg)] mb-1">
           Email
         </label>
         <input
@@ -187,14 +187,14 @@ export function CandidateUploadForm({ roleId, agencies }: Props) {
           disabled={pending || extracting}
           value={fields.email}
           onChange={(e) => setFields((f) => ({ ...f, email: e.target.value }))}
-          className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                     placeholder:text-zinc-500
+          className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                     placeholder:text-[var(--color-fg-subtle)]
                      focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
         />
       </div>
 
       <div>
-        <label htmlFor="phone" className="block text-sm font-medium text-zinc-300 mb-1">
+        <label htmlFor="phone" className="block text-sm font-medium text-[var(--color-fg)] mb-1">
           Phone
         </label>
         <input
@@ -204,22 +204,22 @@ export function CandidateUploadForm({ roleId, agencies }: Props) {
           disabled={pending || extracting}
           value={fields.phone}
           onChange={(e) => setFields((f) => ({ ...f, phone: e.target.value }))}
-          className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                     placeholder:text-zinc-500
+          className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                     placeholder:text-[var(--color-fg-subtle)]
                      focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
         />
       </div>
 
       {agencies.length > 0 && (
         <div>
-          <label htmlFor="agencyId" className="block text-sm font-medium text-zinc-300 mb-1">
+          <label htmlFor="agencyId" className="block text-sm font-medium text-[var(--color-fg)] mb-1">
             Agency
           </label>
           <select
             id="agencyId"
             name="agencyId"
             disabled={pending}
-            className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
                        focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
           >
             <option value="">— No agency —</option>
@@ -231,11 +231,11 @@ export function CandidateUploadForm({ roleId, agencies }: Props) {
       )}
 
       {/* Location & Language */}
-      <div className="border-t border-zinc-800 pt-4 mt-2">
-        <p className="text-sm font-medium text-zinc-400 mb-3">Location & Language (optional)</p>
+      <div className="border-t border-[var(--color-bg-input)] pt-4 mt-2">
+        <p className="text-sm font-medium text-[var(--color-fg-muted)] mb-3">Location & Language (optional)</p>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-3">
           <div>
-            <label htmlFor="country" className="block text-xs font-medium text-zinc-400 mb-1">Country</label>
+            <label htmlFor="country" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">Country</label>
             <input
               id="country"
               name="country"
@@ -244,12 +244,12 @@ export function CandidateUploadForm({ roleId, agencies }: Props) {
               onChange={(e) => setFields((f) => ({ ...f, country: e.target.value }))}
               disabled={pending}
               placeholder="United Kingdom"
-              className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
+              className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
                          focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
             />
           </div>
           <div>
-            <label htmlFor="city" className="block text-xs font-medium text-zinc-400 mb-1">City</label>
+            <label htmlFor="city" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">City</label>
             <input
               id="city"
               name="city"
@@ -258,15 +258,15 @@ export function CandidateUploadForm({ roleId, agencies }: Props) {
               onChange={(e) => setFields((f) => ({ ...f, city: e.target.value }))}
               disabled={pending}
               placeholder="London"
-              className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
+              className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
                          focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
             />
           </div>
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           <div>
-            <label htmlFor="languagesSpoken" className="block text-xs font-medium text-zinc-400 mb-1">
-              Languages <span className="text-zinc-600">(comma-separated)</span>
+            <label htmlFor="languagesSpoken" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">
+              Languages <span className="text-[var(--color-fg-subtle)]">(comma-separated)</span>
             </label>
             <input
               id="languagesSpoken"
@@ -276,19 +276,19 @@ export function CandidateUploadForm({ roleId, agencies }: Props) {
               onChange={(e) => setFields((f) => ({ ...f, languagesSpoken: e.target.value }))}
               disabled={pending}
               placeholder="English, German"
-              className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
+              className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
                          focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
             />
           </div>
           <div>
-            <label htmlFor="willingToRelocate" className="block text-xs font-medium text-zinc-400 mb-1">Willing to Relocate</label>
+            <label htmlFor="willingToRelocate" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">Willing to Relocate</label>
             <select
               id="willingToRelocate"
               name="willingToRelocate"
               value={fields.willingToRelocate}
               onChange={(e) => setFields((f) => ({ ...f, willingToRelocate: e.target.value }))}
               disabled={pending}
-              className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
+              className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
                          focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
             >
               <option value="">— Not specified —</option>
@@ -300,11 +300,11 @@ export function CandidateUploadForm({ roleId, agencies }: Props) {
       </div>
 
       {/* Commercial Details */}
-      <div className="border-t border-zinc-800 pt-4 mt-2">
-        <p className="text-sm font-medium text-zinc-400 mb-3">Commercial Details (optional)</p>
+      <div className="border-t border-[var(--color-bg-input)] pt-4 mt-2">
+        <p className="text-sm font-medium text-[var(--color-fg-muted)] mb-3">Commercial Details (optional)</p>
         <div className="grid grid-cols-1 xs:grid-cols-2 md:grid-cols-3 gap-3">
           <div>
-            <label htmlFor="candidateRate" className="block text-xs font-medium text-zinc-400 mb-1">
+            <label htmlFor="candidateRate" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">
               Candidate Rate/day
             </label>
             <input
@@ -317,12 +317,12 @@ export function CandidateUploadForm({ roleId, agencies }: Props) {
               onChange={(e) => setFields((f) => ({ ...f, candidateRate: e.target.value }))}
               disabled={pending}
               placeholder="650.00"
-              className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
+              className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
                          focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
             />
           </div>
           <div>
-            <label htmlFor="customerRate" className="block text-xs font-medium text-zinc-400 mb-1">
+            <label htmlFor="customerRate" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">
               Customer Rate/day
             </label>
             <input
@@ -335,12 +335,12 @@ export function CandidateUploadForm({ roleId, agencies }: Props) {
               onChange={(e) => setFields((f) => ({ ...f, customerRate: e.target.value }))}
               disabled={pending}
               placeholder="850.00"
-              className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
+              className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
                          focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
             />
           </div>
           <div>
-            <label htmlFor="rateCurrency" className="block text-xs font-medium text-zinc-400 mb-1">
+            <label htmlFor="rateCurrency" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">
               Currency
             </label>
             <select
@@ -349,7 +349,7 @@ export function CandidateUploadForm({ roleId, agencies }: Props) {
               value={fields.rateCurrency}
               onChange={(e) => setFields((f) => ({ ...f, rateCurrency: e.target.value }))}
               disabled={pending}
-              className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
+              className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
                          focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
             >
               <option value="GBP">GBP</option>

--- a/src/components/candidates/comparison-checkbox.tsx
+++ b/src/components/candidates/comparison-checkbox.tsx
@@ -34,7 +34,7 @@ export function ComparisonCheckbox({ candidateId, candidateName }: ComparisonChe
                   disabled:cursor-not-allowed disabled:opacity-40
                   ${selected
                     ? 'bg-violet-950/40 text-violet-400'
-                    : 'text-zinc-600 hover:text-violet-400'
+                    : 'text-[var(--color-fg-subtle)] hover:text-violet-400'
                   }`}
     >
       <GitCompareArrows className="h-4 w-4" />

--- a/src/components/candidates/comparison-tray.tsx
+++ b/src/components/candidates/comparison-tray.tsx
@@ -63,23 +63,23 @@ export function ComparisonTray() {
     // bottom-16 on mobile keeps the tray above any sticky pagination row;
     // md:bottom-0 restores flush-bottom on larger screens.
     // z-30 keeps below drawer scrim (z-40) and drawer panel (z-50).
-    <div className="fixed bottom-16 left-0 right-0 z-30 bg-zinc-900 border-t border-zinc-700 shadow-2xl
+    <div className="fixed bottom-16 left-0 right-0 z-30 bg-[var(--color-bg-elevated)] border-t border-[var(--color-border)] shadow-2xl
                     md:bottom-0">
       <div className="max-w-7xl mx-auto px-4 py-3 flex items-center gap-4
                       sm:px-6">
-        <span className="text-sm text-zinc-400 flex-shrink-0">
+        <span className="text-sm text-[var(--color-fg-muted)] flex-shrink-0">
           Compare ({items.length}/5):
         </span>
         <div className="flex flex-wrap gap-2 flex-1 min-w-0">
           {items.map((item) => (
             <span
               key={item.id}
-              className="inline-flex items-center gap-1.5 bg-zinc-800 border border-zinc-700 rounded-full px-3 py-1 text-xs text-zinc-300"
+              className="inline-flex items-center gap-1.5 bg-[var(--color-bg-input)] border border-[var(--color-border)] rounded-full px-3 py-1 text-xs text-[var(--color-fg)]"
             >
               {item.name}
               <button
                 onClick={() => remove(item.id)}
-                className="text-zinc-500 hover:text-zinc-300 leading-none"
+                className="text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)] leading-none"
                 aria-label={`Remove ${item.name} from comparison`}
               >
                 &times;
@@ -90,7 +90,7 @@ export function ComparisonTray() {
         <div className="flex gap-2 flex-shrink-0">
           <button
             onClick={clear}
-            className="text-xs text-zinc-500 hover:text-zinc-300 px-3 py-1.5 transition-colors"
+            className="text-xs text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)] px-3 py-1.5 transition-colors"
           >
             Clear
           </button>

--- a/src/components/candidates/confidence-pill.tsx
+++ b/src/components/candidates/confidence-pill.tsx
@@ -25,7 +25,7 @@ export function ConfidencePill({ score, className }: ConfidencePillProps) {
   const tierStyles = {
     high: 'bg-emerald-900/40 border-emerald-700 text-emerald-200',
     medium: 'bg-yellow-900/40 border-yellow-700 text-yellow-200',
-    low: 'bg-zinc-800 border-zinc-700 text-zinc-400',
+    low: 'bg-[var(--color-bg-input)] border-[var(--color-border)] text-[var(--color-fg-muted)]',
     not_match: 'bg-red-900/40 border-red-700 text-red-300',
   }[tier]
 

--- a/src/components/candidates/cv-display.tsx
+++ b/src/components/candidates/cv-display.tsx
@@ -253,16 +253,16 @@ function collapseSpacers(blocks: Block[]): Block[] {
 
 function NameBlock({ text }: { text: string }) {
   return (
-    <p className="text-lg font-bold text-zinc-100 leading-tight">{text}</p>
+    <p className="text-lg font-bold text-[var(--color-fg)] leading-tight">{text}</p>
   )
 }
 
 function TaglineBlock({ parts }: { parts: string[] }) {
   return (
-    <p className="text-sm text-zinc-400 mt-0.5">
+    <p className="text-sm text-[var(--color-fg-muted)] mt-0.5">
       {parts.map((p, i) => (
         <span key={i}>
-          {i > 0 && <span className="mx-2 text-zinc-600">·</span>}
+          {i > 0 && <span className="mx-2 text-[var(--color-fg-subtle)]">·</span>}
           {p}
         </span>
       ))}
@@ -279,13 +279,13 @@ function ContactBlock({ items }: { items: string[] }) {
           const label = item.slice(0, colonIdx).trim()
           const value = item.slice(colonIdx + 1).trim()
           return (
-            <span key={i} className="text-xs text-zinc-500">
-              <span className="text-zinc-600 font-medium">{label}:</span>{' '}
-              <span className="text-zinc-400">{value}</span>
+            <span key={i} className="text-xs text-[var(--color-fg-subtle)]">
+              <span className="text-[var(--color-fg-subtle)] font-medium">{label}:</span>{' '}
+              <span className="text-[var(--color-fg-muted)]">{value}</span>
             </span>
           )
         }
-        return <span key={i} className="text-xs text-zinc-500">{item}</span>
+        return <span key={i} className="text-xs text-[var(--color-fg-subtle)]">{item}</span>
       })}
     </div>
   )
@@ -294,7 +294,7 @@ function ContactBlock({ items }: { items: string[] }) {
 function HeaderBlock({ text }: { text: string }) {
   return (
     <div className="mt-5 mb-2.5">
-      <h3 className="text-[11px] font-bold uppercase tracking-[0.12em] text-violet-400 border-b border-zinc-800 pb-1.5">
+      <h3 className="text-[11px] font-bold uppercase tracking-[0.12em] text-violet-400 border-b border-[var(--color-bg-input)] pb-1.5">
         {text}
       </h3>
     </div>
@@ -305,13 +305,13 @@ function RoleBlock({ title, org, dates }: { title: string; org: string; dates: s
   return (
     <div className="mt-2.5 mb-0.5 flex items-start justify-between gap-3 flex-wrap">
       <div className="min-w-0">
-        <span className="text-sm font-semibold text-zinc-200">{title}</span>
+        <span className="text-sm font-semibold text-[var(--color-fg)]">{title}</span>
         {org && (
-          <span className="text-sm text-zinc-500 font-normal"> · {org}</span>
+          <span className="text-sm text-[var(--color-fg-subtle)] font-normal"> · {org}</span>
         )}
       </div>
       {dates && (
-        <span className="text-xs text-zinc-500 whitespace-nowrap shrink-0 mt-0.5 font-mono">
+        <span className="text-xs text-[var(--color-fg-subtle)] whitespace-nowrap shrink-0 mt-0.5 font-mono">
           {dates}
         </span>
       )}
@@ -323,7 +323,7 @@ function BulletBlock({ text }: { text: string }) {
   return (
     <div className="flex gap-2.5 items-start mt-1">
       <span className="mt-[7px] h-1 w-1 flex-shrink-0 rounded-full bg-violet-500/70" />
-      <p className="text-sm text-zinc-400 leading-relaxed flex-1">{text}</p>
+      <p className="text-sm text-[var(--color-fg-muted)] leading-relaxed flex-1">{text}</p>
     </div>
   )
 }
@@ -333,17 +333,17 @@ function PlainBlock({ text }: { text: string }) {
   if (/\s*\|\s*/.test(text) && text.split(/\s*\|\s*/).length >= 2) {
     const parts = text.split(/\s*\|\s*/)
     return (
-      <p className="text-sm text-zinc-400 leading-relaxed">
+      <p className="text-sm text-[var(--color-fg-muted)] leading-relaxed">
         {parts.map((p, i) => (
           <span key={i}>
-            {i > 0 && <span className="mx-2 text-zinc-700">|</span>}
+            {i > 0 && <span className="mx-2 text-[var(--color-border)]">|</span>}
             {p}
           </span>
         ))}
       </p>
     )
   }
-  return <p className="text-sm text-zinc-400 leading-relaxed mt-0.5">{text}</p>
+  return <p className="text-sm text-[var(--color-fg-muted)] leading-relaxed mt-0.5">{text}</p>
 }
 
 // ─── Main component ───────────────────────────────────────────────────────────
@@ -352,7 +352,7 @@ export function CvDisplay({ cvText }: { cvText: string }) {
   const [expanded, setExpanded] = useState(false)
 
   if (!cvText?.trim()) {
-    return <p className="text-sm text-zinc-500 italic">No CV text available.</p>
+    return <p className="text-sm text-[var(--color-fg-subtle)] italic">No CV text available.</p>
   }
 
   const blocks = parse(cvText)
@@ -378,7 +378,7 @@ export function CvDisplay({ cvText }: { cvText: string }) {
       </div>
 
       {!expanded && (
-        <div className="absolute bottom-0 left-0 right-0 h-24 bg-gradient-to-t from-zinc-900 to-transparent pointer-events-none" />
+        <div className="absolute bottom-0 left-0 right-0 h-24 bg-gradient-to-t from-[var(--color-bg-elevated)] to-transparent pointer-events-none" />
       )}
 
       <div className={expanded ? 'mt-4' : 'relative mt-2 flex justify-center'}>

--- a/src/components/candidates/cv-file-panel.tsx
+++ b/src/components/candidates/cv-file-panel.tsx
@@ -101,9 +101,9 @@ export function CvFilePanel({ candidateId, filePath, fileType }: Props) {
             <a
               href={`/api/candidates/${candidateId}/cv`}
               download
-              className="flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-800
-                         text-zinc-400 text-xs font-medium px-3 py-1.5
-                         hover:bg-zinc-700 hover:text-zinc-200 transition-colors"
+              className="flex items-center gap-1.5 rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)]
+                         text-[var(--color-fg-muted)] text-xs font-medium px-3 py-1.5
+                         hover:bg-[var(--color-border)] hover:text-[var(--color-fg)] transition-colors"
             >
               <DownloadIcon className="h-3.5 w-3.5" />
               Download original CV
@@ -111,8 +111,8 @@ export function CvFilePanel({ candidateId, filePath, fileType }: Props) {
 
             {/* File-type badge */}
             {fileType && (
-              <span className="inline-flex items-center gap-1 rounded-full bg-zinc-800 border border-zinc-700
-                               text-zinc-400 text-xs font-medium px-2 py-0.5">
+              <span className="inline-flex items-center gap-1 rounded-full bg-[var(--color-bg-input)] border border-[var(--color-border)]
+                               text-[var(--color-fg-muted)] text-xs font-medium px-2 py-0.5">
                 <FileTextIcon className="h-3 w-3" />
                 {fileType.toUpperCase()}
               </span>
@@ -121,9 +121,9 @@ export function CvFilePanel({ candidateId, filePath, fileType }: Props) {
             {/* Replace button */}
             <button
               onClick={openModal}
-              className="flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-800
-                         text-zinc-400 text-xs font-medium px-3 py-1.5
-                         hover:bg-zinc-700 hover:text-zinc-200 transition-colors"
+              className="flex items-center gap-1.5 rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)]
+                         text-[var(--color-fg-muted)] text-xs font-medium px-3 py-1.5
+                         hover:bg-[var(--color-border)] hover:text-[var(--color-fg)] transition-colors"
             >
               <UploadIcon className="h-3.5 w-3.5" />
               Replace…
@@ -131,12 +131,12 @@ export function CvFilePanel({ candidateId, filePath, fileType }: Props) {
           </>
         ) : (
           <>
-            <span className="text-xs text-zinc-500 italic">No original file on record</span>
+            <span className="text-xs text-[var(--color-fg-subtle)] italic">No original file on record</span>
             <button
               onClick={openModal}
-              className="flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-800
-                         text-zinc-400 text-xs font-medium px-3 py-1.5
-                         hover:bg-zinc-700 hover:text-zinc-200 transition-colors"
+              className="flex items-center gap-1.5 rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)]
+                         text-[var(--color-fg-muted)] text-xs font-medium px-3 py-1.5
+                         hover:bg-[var(--color-border)] hover:text-[var(--color-fg)] transition-colors"
             >
               <UploadIcon className="h-3.5 w-3.5" />
               Attach CV
@@ -161,17 +161,17 @@ export function CvFilePanel({ candidateId, filePath, fileType }: Props) {
           onClick={closeModal}
         >
           <div
-            className="relative bg-zinc-950 border border-zinc-700 rounded-xl p-6 max-w-md w-[calc(100vw-2rem)] shadow-xl"
+            className="relative bg-[var(--color-bg-app)] border border-[var(--color-border)] rounded-xl p-6 max-w-md w-[calc(100vw-2rem)] shadow-xl"
             onClick={(e) => e.stopPropagation()}
           >
             {/* Header */}
             <div className="flex items-center justify-between mb-5">
-              <h3 className="text-sm font-semibold text-zinc-100">
+              <h3 className="text-sm font-semibold text-[var(--color-fg)]">
                 {filePath ? 'Replace original CV' : 'Attach original CV'}
               </h3>
               <button
                 onClick={closeModal}
-                className="text-zinc-500 hover:text-zinc-300 transition-colors rounded-md p-2 md:p-1 hover:bg-zinc-800"
+                className="text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)] transition-colors rounded-md p-2 md:p-1 hover:bg-[var(--color-bg-input)]"
                 aria-label="Close"
               >
                 <XIcon className="h-4 w-4" />
@@ -195,7 +195,7 @@ export function CvFilePanel({ candidateId, filePath, fileType }: Props) {
             )}
 
             {uploadState.status === 'uploading' && (
-              <div className="mt-4 flex items-center justify-center gap-2 text-sm text-zinc-400">
+              <div className="mt-4 flex items-center justify-center gap-2 text-sm text-[var(--color-fg-muted)]">
                 <Loader2Icon className="h-4 w-4 animate-spin" />
                 Uploading…
               </div>

--- a/src/components/candidates/edit-details-form.tsx
+++ b/src/components/candidates/edit-details-form.tsx
@@ -64,18 +64,18 @@ export function EditDetailsForm({ candidate, agencies, audience = 'recruiter' }:
   const fieldErrors = state && !state.success ? state.fieldErrors : {}
 
   return (
-    <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-6 mb-6">
+    <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-6 mb-6">
       <button
         type="button"
         onClick={() => setIsOpen((v) => !v)}
         className="flex items-center justify-between w-full text-left"
       >
         <div className="flex items-center gap-2">
-          <PencilIcon className="h-4 w-4 text-zinc-500" />
-          <span className="font-semibold text-zinc-100">Edit Details</span>
+          <PencilIcon className="h-4 w-4 text-[var(--color-fg-subtle)]" />
+          <span className="font-semibold text-[var(--color-fg)]">Edit Details</span>
         </div>
         <ChevronDownIcon
-          className={`h-4 w-4 text-zinc-500 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+          className={`h-4 w-4 text-[var(--color-fg-subtle)] transition-transform ${isOpen ? 'rotate-180' : ''}`}
         />
       </button>
 
@@ -111,7 +111,7 @@ export function EditDetailsForm({ candidate, agencies, audience = 'recruiter' }:
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <label htmlFor="firstName" className="block text-sm font-medium text-zinc-300 mb-1">
+              <label htmlFor="firstName" className="block text-sm font-medium text-[var(--color-fg)] mb-1">
                 First name <span className="text-red-500">*</span>
               </label>
               <input
@@ -122,7 +122,7 @@ export function EditDetailsForm({ candidate, agencies, audience = 'recruiter' }:
                 disabled={pending}
                 value={fields.firstName}
                 onChange={(e) => setFields((f) => ({ ...f, firstName: e.target.value }))}
-                className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
+                className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
                            focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
                            disabled:opacity-50"
               />
@@ -132,7 +132,7 @@ export function EditDetailsForm({ candidate, agencies, audience = 'recruiter' }:
             </div>
 
             <div>
-              <label htmlFor="lastName" className="block text-sm font-medium text-zinc-300 mb-1">
+              <label htmlFor="lastName" className="block text-sm font-medium text-[var(--color-fg)] mb-1">
                 Last name <span className="text-red-500">*</span>
               </label>
               <input
@@ -143,7 +143,7 @@ export function EditDetailsForm({ candidate, agencies, audience = 'recruiter' }:
                 disabled={pending}
                 value={fields.lastName}
                 onChange={(e) => setFields((f) => ({ ...f, lastName: e.target.value }))}
-                className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
+                className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
                            focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
                            disabled:opacity-50"
               />
@@ -154,8 +154,8 @@ export function EditDetailsForm({ candidate, agencies, audience = 'recruiter' }:
           </div>
 
           <div>
-            <label htmlFor="email" className="block text-sm font-medium text-zinc-300 mb-1">
-              Email <span className="text-zinc-500 font-normal">(optional)</span>
+            <label htmlFor="email" className="block text-sm font-medium text-[var(--color-fg)] mb-1">
+              Email <span className="text-[var(--color-fg-subtle)] font-normal">(optional)</span>
             </label>
             <input
               id="email"
@@ -165,8 +165,8 @@ export function EditDetailsForm({ candidate, agencies, audience = 'recruiter' }:
               value={fields.email}
               onChange={(e) => setFields((f) => ({ ...f, email: e.target.value }))}
               placeholder="candidate@example.com"
-              className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                         placeholder:text-zinc-500
+              className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                         placeholder:text-[var(--color-fg-subtle)]
                          focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
                          disabled:opacity-50"
             />
@@ -176,8 +176,8 @@ export function EditDetailsForm({ candidate, agencies, audience = 'recruiter' }:
           </div>
 
           <div>
-            <label htmlFor="phone" className="block text-sm font-medium text-zinc-300 mb-1">
-              Phone <span className="text-zinc-500 font-normal">(optional)</span>
+            <label htmlFor="phone" className="block text-sm font-medium text-[var(--color-fg)] mb-1">
+              Phone <span className="text-[var(--color-fg-subtle)] font-normal">(optional)</span>
             </label>
             <input
               id="phone"
@@ -187,8 +187,8 @@ export function EditDetailsForm({ candidate, agencies, audience = 'recruiter' }:
               value={fields.phone}
               onChange={(e) => setFields((f) => ({ ...f, phone: e.target.value }))}
               placeholder="+44 7700 900000"
-              className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                         placeholder:text-zinc-500
+              className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                         placeholder:text-[var(--color-fg-subtle)]
                          focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
                          disabled:opacity-50"
             />
@@ -196,8 +196,8 @@ export function EditDetailsForm({ candidate, agencies, audience = 'recruiter' }:
 
           {agencies.length > 0 && (
             <div>
-              <label htmlFor="agencyId" className="block text-sm font-medium text-zinc-300 mb-1">
-                Agency <span className="text-zinc-500 font-normal">(optional)</span>
+              <label htmlFor="agencyId" className="block text-sm font-medium text-[var(--color-fg)] mb-1">
+                Agency <span className="text-[var(--color-fg-subtle)] font-normal">(optional)</span>
               </label>
               <select
                 id="agencyId"
@@ -205,7 +205,7 @@ export function EditDetailsForm({ candidate, agencies, audience = 'recruiter' }:
                 disabled={pending}
                 value={fields.agencyId}
                 onChange={(e) => setFields((f) => ({ ...f, agencyId: e.target.value }))}
-                className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
+                className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
                            focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
                            disabled:opacity-50"
               >
@@ -220,39 +220,39 @@ export function EditDetailsForm({ candidate, agencies, audience = 'recruiter' }:
           )}
 
           {/* Location & Language */}
-          <div className="border-t border-zinc-800 pt-3 mt-1 col-span-2">
-            <p className="text-sm font-medium text-zinc-400 mb-2">Location & Language</p>
+          <div className="border-t border-[var(--color-bg-input)] pt-3 mt-1 col-span-2">
+            <p className="text-sm font-medium text-[var(--color-fg-muted)] mb-2">Location & Language</p>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-3">
               <div>
-                <label htmlFor="edit-country" className="block text-xs font-medium text-zinc-400 mb-1">Country</label>
+                <label htmlFor="edit-country" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">Country</label>
                 <input id="edit-country" name="country" type="text" disabled={pending}
                   value={fields.country} onChange={(e) => setFields((f) => ({ ...f, country: e.target.value }))}
                   placeholder="United Kingdom"
-                  className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50" />
+                  className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm placeholder:text-[var(--color-fg-subtle)] focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50" />
               </div>
               <div>
-                <label htmlFor="edit-city" className="block text-xs font-medium text-zinc-400 mb-1">City</label>
+                <label htmlFor="edit-city" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">City</label>
                 <input id="edit-city" name="city" type="text" disabled={pending}
                   value={fields.city} onChange={(e) => setFields((f) => ({ ...f, city: e.target.value }))}
                   placeholder="London"
-                  className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50" />
+                  className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm placeholder:text-[var(--color-fg-subtle)] focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50" />
               </div>
             </div>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
               <div>
-                <label htmlFor="edit-languages" className="block text-xs font-medium text-zinc-400 mb-1">
-                  Languages <span className="text-zinc-600">(comma-separated)</span>
+                <label htmlFor="edit-languages" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">
+                  Languages <span className="text-[var(--color-fg-subtle)]">(comma-separated)</span>
                 </label>
                 <input id="edit-languages" name="languagesSpoken" type="text" disabled={pending}
                   value={fields.languagesSpoken} onChange={(e) => setFields((f) => ({ ...f, languagesSpoken: e.target.value }))}
                   placeholder="English, German"
-                  className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50" />
+                  className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm placeholder:text-[var(--color-fg-subtle)] focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50" />
               </div>
               <div>
-                <label htmlFor="edit-relocate" className="block text-xs font-medium text-zinc-400 mb-1">Willing to Relocate</label>
+                <label htmlFor="edit-relocate" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">Willing to Relocate</label>
                 <select id="edit-relocate" name="willingToRelocate" disabled={pending}
                   value={fields.willingToRelocate} onChange={(e) => setFields((f) => ({ ...f, willingToRelocate: e.target.value }))}
-                  className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50">
+                  className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50">
                   <option value="">— Not specified —</option>
                   <option value="true">Yes</option>
                   <option value="false">No</option>
@@ -262,11 +262,11 @@ export function EditDetailsForm({ candidate, agencies, audience = 'recruiter' }:
           </div>
 
           {/* Commercial Details */}
-          <div className="border-t border-zinc-800 pt-3 mt-1 col-span-2">
-            <p className="text-sm font-medium text-zinc-400 mb-2">Commercial Details</p>
+          <div className="border-t border-[var(--color-bg-input)] pt-3 mt-1 col-span-2">
+            <p className="text-sm font-medium text-[var(--color-fg-muted)] mb-2">Commercial Details</p>
             <div className="grid grid-cols-1 xs:grid-cols-2 md:grid-cols-3 gap-3">
               <div>
-                <label htmlFor="candidateRate" className="block text-xs font-medium text-zinc-400 mb-1">
+                <label htmlFor="candidateRate" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">
                   Candidate Rate/day
                 </label>
                 <input
@@ -279,13 +279,13 @@ export function EditDetailsForm({ candidate, agencies, audience = 'recruiter' }:
                   value={fields.candidateRate}
                   onChange={(e) => setFields((f) => ({ ...f, candidateRate: e.target.value }))}
                   placeholder="650.00"
-                  className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                             placeholder:text-zinc-500
+                  className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                             placeholder:text-[var(--color-fg-subtle)]
                              focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
                 />
               </div>
               <div>
-                <label htmlFor="customerRate" className="block text-xs font-medium text-zinc-400 mb-1">
+                <label htmlFor="customerRate" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">
                   Customer Rate/day
                 </label>
                 <input
@@ -298,13 +298,13 @@ export function EditDetailsForm({ candidate, agencies, audience = 'recruiter' }:
                   value={fields.customerRate}
                   onChange={(e) => setFields((f) => ({ ...f, customerRate: e.target.value }))}
                   placeholder="850.00"
-                  className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                             placeholder:text-zinc-500
+                  className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                             placeholder:text-[var(--color-fg-subtle)]
                              focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
                 />
               </div>
               <div>
-                <label htmlFor="rateCurrency" className="block text-xs font-medium text-zinc-400 mb-1">
+                <label htmlFor="rateCurrency" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">
                   Currency
                 </label>
                 <select
@@ -313,7 +313,7 @@ export function EditDetailsForm({ candidate, agencies, audience = 'recruiter' }:
                   disabled={pending}
                   value={fields.rateCurrency}
                   onChange={(e) => setFields((f) => ({ ...f, rateCurrency: e.target.value }))}
-                  className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
+                  className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
                              focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
                 >
                   <option value="GBP">GBP</option>
@@ -329,11 +329,11 @@ export function EditDetailsForm({ candidate, agencies, audience = 'recruiter' }:
           </div>
 
           {/* Availability */}
-          <div className="border-t border-zinc-800 pt-3 mt-1 col-span-2">
-            <p className="text-sm font-medium text-zinc-400 mb-2">Availability</p>
+          <div className="border-t border-[var(--color-bg-input)] pt-3 mt-1 col-span-2">
+            <p className="text-sm font-medium text-[var(--color-fg-muted)] mb-2">Availability</p>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
               <div>
-                <label htmlFor="availabilityStatus" className="block text-xs font-medium text-zinc-400 mb-1">
+                <label htmlFor="availabilityStatus" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">
                   Availability status
                 </label>
                 <select
@@ -349,7 +349,7 @@ export function EditDetailsForm({ candidate, agencies, audience = 'recruiter' }:
                       availableFrom: e.target.value === 'on_project' ? f.availableFrom : '',
                     }))
                   }
-                  className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
+                  className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
                              focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
                 >
                   <option value="available">Available</option>
@@ -358,8 +358,8 @@ export function EditDetailsForm({ candidate, agencies, audience = 'recruiter' }:
                 </select>
               </div>
               <div>
-                <label htmlFor="availableFrom" className="block text-xs font-medium text-zinc-400 mb-1">
-                  Available from <span className="text-zinc-600">(when on project)</span>
+                <label htmlFor="availableFrom" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">
+                  Available from <span className="text-[var(--color-fg-subtle)]">(when on project)</span>
                 </label>
                 <input
                   id="availableFrom"
@@ -368,7 +368,7 @@ export function EditDetailsForm({ candidate, agencies, audience = 'recruiter' }:
                   disabled={pending || fields.availabilityStatus !== 'on_project'}
                   value={fields.availableFrom}
                   onChange={(e) => setFields((f) => ({ ...f, availableFrom: e.target.value }))}
-                  className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
+                  className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
                              focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
                 />
               </div>
@@ -388,7 +388,7 @@ export function EditDetailsForm({ candidate, agencies, audience = 'recruiter' }:
             <button
               type="button"
               onClick={() => setIsOpen(false)}
-              className="text-sm text-zinc-500 hover:text-zinc-300"
+              className="text-sm text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)]"
             >
               Cancel
             </button>

--- a/src/components/candidates/enrichment-panel.tsx
+++ b/src/components/candidates/enrichment-panel.tsx
@@ -41,14 +41,14 @@ interface Props {
 
 const SOURCE_ICONS: Record<string, React.ReactNode> = {
   linkedin:     <Link2 className="h-3.5 w-3.5 text-blue-400" />,
-  github:       <GitBranch className="h-3.5 w-3.5 text-zinc-400" />,
+  github:       <GitBranch className="h-3.5 w-3.5 text-[var(--color-fg-muted)]" />,
   reddit:       <MessageSquare className="h-3.5 w-3.5 text-orange-400" />,
   twitter:      <Globe className="h-3.5 w-3.5 text-sky-400" />,
   facebook:     <Globe className="h-3.5 w-3.5 text-blue-400" />,
   stackoverflow:<Globe className="h-3.5 w-3.5 text-orange-400" />,
-  medium:       <BookOpen className="h-3.5 w-3.5 text-zinc-400" />,
-  devto:        <Code2 className="h-3.5 w-3.5 text-zinc-400" />,
-  web:          <Globe className="h-3.5 w-3.5 text-zinc-500" />,
+  medium:       <BookOpen className="h-3.5 w-3.5 text-[var(--color-fg-muted)]" />,
+  devto:        <Code2 className="h-3.5 w-3.5 text-[var(--color-fg-muted)]" />,
+  web:          <Globe className="h-3.5 w-3.5 text-[var(--color-fg-subtle)]" />,
 }
 
 const SOURCE_LABELS: Record<string, string> = {
@@ -118,20 +118,20 @@ export function EnrichmentPanel({ candidateId, initialLinkedinUrl, initialGithub
       {/* Controls */}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <div>
-          <label className="block text-xs font-medium text-zinc-500 mb-1">LinkedIn URL</label>
+          <label className="block text-xs font-medium text-[var(--color-fg-subtle)] mb-1">LinkedIn URL</label>
           <input
             type="url"
             value={linkedinUrl}
             onChange={(e) => setLinkedinUrl(e.target.value)}
             placeholder="https://linkedin.com/in/username"
             disabled={isPending}
-            className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                       placeholder:text-zinc-500
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                       placeholder:text-[var(--color-fg-subtle)]
                        focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
           />
         </div>
         <div>
-          <label className="block text-xs font-medium text-zinc-500 mb-1">GitHub username</label>
+          <label className="block text-xs font-medium text-[var(--color-fg-subtle)] mb-1">GitHub username</label>
           <div className="flex gap-2">
             <input
               type="text"
@@ -139,8 +139,8 @@ export function EnrichmentPanel({ candidateId, initialLinkedinUrl, initialGithub
               onChange={(e) => setGithubUsername(e.target.value)}
               placeholder="octocat"
               disabled={isPending}
-              className="flex-1 rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                         placeholder:text-zinc-500
+              className="flex-1 rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                         placeholder:text-[var(--color-fg-subtle)]
                          focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
             />
             <button
@@ -177,29 +177,29 @@ export function EnrichmentPanel({ candidateId, initialLinkedinUrl, initialGithub
 
       {/* GitHub profile card */}
       {github && (
-        <div className="rounded-xl border border-zinc-700 bg-zinc-800 p-4">
+        <div className="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-input)] p-4">
           <div className="flex items-start gap-4">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
               src={github.avatarUrl}
               alt={github.login}
-              className="h-14 w-14 rounded-full border border-zinc-600 shrink-0"
+              className="h-14 w-14 rounded-full border border-[var(--color-border)] shrink-0"
             />
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2">
-                <GitBranch className="h-4 w-4 text-zinc-400" />
+                <GitBranch className="h-4 w-4 text-[var(--color-fg-muted)]" />
                 <a
                   href={github.profileUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="font-semibold text-zinc-100 hover:text-blue-400"
+                  className="font-semibold text-[var(--color-fg)] hover:text-blue-400"
                 >
                   {github.name ?? github.login}
                 </a>
-                <span className="text-zinc-500 text-sm">@{github.login}</span>
+                <span className="text-[var(--color-fg-subtle)] text-sm">@{github.login}</span>
               </div>
-              {github.bio && <p className="text-sm text-zinc-400 mt-1">{github.bio}</p>}
-              <div className="flex gap-4 mt-2 text-xs text-zinc-500">
+              {github.bio && <p className="text-sm text-[var(--color-fg-muted)] mt-1">{github.bio}</p>}
+              <div className="flex gap-4 mt-2 text-xs text-[var(--color-fg-subtle)]">
                 <span className="flex items-center gap-1">
                   <BookOpen className="h-3.5 w-3.5" /> {github.publicRepos} repos
                 </span>
@@ -212,28 +212,28 @@ export function EnrichmentPanel({ candidateId, initialLinkedinUrl, initialGithub
 
           {github.topRepos.length > 0 && (
             <div className="mt-4 space-y-2">
-              <p className="text-xs font-medium text-zinc-500 uppercase tracking-wide">Top repositories</p>
+              <p className="text-xs font-medium text-[var(--color-fg-subtle)] uppercase tracking-wide">Top repositories</p>
               {github.topRepos.map((repo) => (
                 <a
                   key={repo.name}
                   href={repo.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-start justify-between rounded-lg border border-zinc-700 bg-zinc-900
+                  className="flex items-start justify-between rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-elevated)]
                              px-3 py-2 hover:border-blue-500 hover:bg-blue-950/40 transition-colors"
                 >
                   <div className="min-w-0">
                     <span className="text-sm font-medium text-blue-400">{repo.name}</span>
                     {repo.language && (
-                      <span className="ml-2 text-xs text-zinc-500 bg-zinc-700 rounded px-1.5 py-0.5">
+                      <span className="ml-2 text-xs text-[var(--color-fg-subtle)] bg-[var(--color-border)] rounded px-1.5 py-0.5">
                         {repo.language}
                       </span>
                     )}
                     {repo.description && (
-                      <p className="text-xs text-zinc-500 mt-0.5 truncate">{repo.description}</p>
+                      <p className="text-xs text-[var(--color-fg-subtle)] mt-0.5 truncate">{repo.description}</p>
                     )}
                   </div>
-                  <span className="flex items-center gap-1 text-xs text-zinc-500 ml-3 shrink-0">
+                  <span className="flex items-center gap-1 text-xs text-[var(--color-fg-subtle)] ml-3 shrink-0">
                     <Star className="h-3 w-3" /> {repo.stars}
                   </span>
                 </a>
@@ -246,7 +246,7 @@ export function EnrichmentPanel({ candidateId, initialLinkedinUrl, initialGithub
       {/* Confirmed profiles (Wave 2 enrichment) */}
       {enrichment?.verifiedProfiles && enrichment.verifiedProfiles.length > 0 && (
         <section>
-          <h4 className="text-sm font-medium text-zinc-200 mb-2">
+          <h4 className="text-sm font-medium text-[var(--color-fg)] mb-2">
             Confirmed profiles ({enrichment.verifiedProfiles.length})
           </h4>
           <div className="flex flex-col gap-1.5">
@@ -269,24 +269,24 @@ export function EnrichmentPanel({ candidateId, initialLinkedinUrl, initialGithub
 
       {/* Stack Overflow card */}
       {enrichment?.stackOverflowProfile && (
-        <section className="rounded-md border border-zinc-700 bg-zinc-900/50 p-3">
+        <section className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-elevated)]/50 p-3">
           <div className="flex items-start gap-2">
-            <div className="text-xs text-zinc-400">Stack Overflow</div>
+            <div className="text-xs text-[var(--color-fg-muted)]">Stack Overflow</div>
             <div className="flex-1">
               <a
                 href={enrichment.stackOverflowProfile.profileUrl}
                 target="_blank" rel="noopener noreferrer"
-                className="text-sm text-zinc-200 hover:text-white"
+                className="text-sm text-[var(--color-fg)] hover:text-white"
               >
                 {enrichment.stackOverflowProfile.username}
               </a>
-              <div className="mt-1 text-xs text-zinc-500">
-                Reputation: <span className="text-zinc-300">{enrichment.stackOverflowProfile.reputation.toLocaleString('en-GB')}</span>
+              <div className="mt-1 text-xs text-[var(--color-fg-subtle)]">
+                Reputation: <span className="text-[var(--color-fg)]">{enrichment.stackOverflowProfile.reputation.toLocaleString('en-GB')}</span>
               </div>
               {enrichment.stackOverflowProfile.topTags?.length > 0 && (
                 <div className="mt-1 flex flex-wrap gap-1">
                   {enrichment.stackOverflowProfile.topTags.slice(0, 5).map((tag) => (
-                    <span key={tag} className="rounded bg-zinc-800 px-1.5 py-0.5 text-[10px] text-zinc-300">
+                    <span key={tag} className="rounded bg-[var(--color-bg-input)] px-1.5 py-0.5 text-[10px] text-[var(--color-fg)]">
                       {tag}
                     </span>
                   ))}
@@ -299,17 +299,17 @@ export function EnrichmentPanel({ candidateId, initialLinkedinUrl, initialGithub
 
       {/* Personal site summary card */}
       {enrichment?.personalSiteSummary && (
-        <section className="rounded-md border border-zinc-700 bg-zinc-900/50 p-3">
-          <div className="text-xs text-zinc-400 mb-1">Personal site</div>
+        <section className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-elevated)]/50 p-3">
+          <div className="text-xs text-[var(--color-fg-muted)] mb-1">Personal site</div>
           <a
             href={enrichment.personalSiteSummary.url}
             target="_blank" rel="noopener noreferrer"
-            className="text-sm font-medium text-zinc-200 hover:text-white"
+            className="text-sm font-medium text-[var(--color-fg)] hover:text-white"
           >
             {enrichment.personalSiteSummary.title || enrichment.personalSiteSummary.url}
           </a>
           {enrichment.personalSiteSummary.aiSummary && (
-            <p className="mt-1.5 text-xs text-zinc-400 leading-relaxed">
+            <p className="mt-1.5 text-xs text-[var(--color-fg-muted)] leading-relaxed">
               {enrichment.personalSiteSummary.aiSummary}
             </p>
           )}
@@ -324,8 +324,8 @@ export function EnrichmentPanel({ candidateId, initialLinkedinUrl, initialGithub
             {Object.entries(sourceCounts).map(([source, count]) => (
               <span
                 key={source}
-                className="flex items-center gap-1.5 rounded-full border border-zinc-700 bg-zinc-800
-                           px-2.5 py-1 text-xs text-zinc-400"
+                className="flex items-center gap-1.5 rounded-full border border-[var(--color-border)] bg-[var(--color-bg-input)]
+                           px-2.5 py-1 text-xs text-[var(--color-fg-muted)]"
               >
                 {SOURCE_ICONS[source] ?? SOURCE_ICONS.web}
                 {SOURCE_LABELS[source] ?? source} ({count})
@@ -339,20 +339,20 @@ export function EnrichmentPanel({ candidateId, initialLinkedinUrl, initialGithub
               href={hit.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex gap-3 rounded-lg border border-zinc-700 bg-zinc-800 px-4 py-3
+              className="flex gap-3 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-input)] px-4 py-3
                          hover:border-blue-500 hover:shadow-sm transition-all group"
             >
               <div className="mt-0.5 shrink-0">
                 {SOURCE_ICONS[hit.source] ?? SOURCE_ICONS.web}
               </div>
               <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-zinc-100 group-hover:text-blue-400 truncate">
+                <p className="text-sm font-medium text-[var(--color-fg)] group-hover:text-blue-400 truncate">
                   {hit.title}
                 </p>
-                <p className="text-xs text-zinc-500 mt-0.5 line-clamp-2">{hit.description}</p>
-                <p className="text-xs text-zinc-600 mt-1 truncate">{hit.url}</p>
+                <p className="text-xs text-[var(--color-fg-subtle)] mt-0.5 line-clamp-2">{hit.description}</p>
+                <p className="text-xs text-[var(--color-fg-subtle)] mt-1 truncate">{hit.url}</p>
               </div>
-              <ExternalLink className="h-3.5 w-3.5 text-zinc-600 group-hover:text-blue-400 shrink-0 mt-0.5" />
+              <ExternalLink className="h-3.5 w-3.5 text-[var(--color-fg-subtle)] group-hover:text-blue-400 shrink-0 mt-0.5" />
             </a>
           ))}
 
@@ -371,7 +371,7 @@ export function EnrichmentPanel({ candidateId, initialLinkedinUrl, initialGithub
           )}
 
           {enrichment?.searchedAt && (
-            <p className="text-xs text-zinc-500 mt-2" suppressHydrationWarning>
+            <p className="text-xs text-[var(--color-fg-subtle)] mt-2" suppressHydrationWarning>
               Last searched {new Date(enrichment.searchedAt).toLocaleString('en-GB')}
             </p>
           )}
@@ -379,7 +379,7 @@ export function EnrichmentPanel({ candidateId, initialLinkedinUrl, initialGithub
       )}
 
       {enrichment && hits.length === 0 && !github && !isPending && (
-        <p className="text-sm text-zinc-500 text-center py-4">
+        <p className="text-sm text-[var(--color-fg-subtle)] text-center py-4">
           No results found. Try adding a LinkedIn URL or GitHub username for better results.
         </p>
       )}

--- a/src/components/candidates/gdpr-actions-panel.tsx
+++ b/src/components/candidates/gdpr-actions-panel.tsx
@@ -68,13 +68,13 @@ export function GdprActionsPanel({ candidateId, candidateName }: Props) {
   return (
     <>
       {/* Panel card */}
-      <div className="bg-zinc-900 rounded-xl border border-red-900/50 p-6 mb-6">
+      <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-red-900/50 p-6 mb-6">
         <div className="flex items-center gap-2 mb-4">
           <ShieldIcon className="h-4 w-4 text-red-400" />
           <h2 className="font-semibold text-red-400">GDPR Actions (Admin only)</h2>
         </div>
 
-        <p className="text-xs text-zinc-500 mb-5">
+        <p className="text-xs text-[var(--color-fg-subtle)] mb-5">
           These actions are irreversible and are provided to fulfil data subject rights
           under the General Data Protection Regulation (GDPR).
         </p>
@@ -84,9 +84,9 @@ export function GdprActionsPanel({ candidateId, candidateName }: Props) {
           <a
             href={`/api/export/dsar/${candidateId}`}
             download
-            className="inline-flex items-center gap-1.5 rounded-md border border-zinc-700
-                       bg-zinc-800 text-zinc-300 text-xs font-medium px-3 py-1.5
-                       hover:bg-zinc-700 transition-colors"
+            className="inline-flex items-center gap-1.5 rounded-md border border-[var(--color-border)]
+                       bg-[var(--color-bg-input)] text-[var(--color-fg)] text-xs font-medium px-3 py-1.5
+                       hover:bg-[var(--color-border)] transition-colors"
           >
             <DownloadIcon className="h-3.5 w-3.5" />
             Export all data (GDPR)
@@ -123,7 +123,7 @@ export function GdprActionsPanel({ candidateId, candidateName }: Props) {
             role="dialog"
             aria-modal="true"
             aria-labelledby="gdpr-delete-title"
-            className="relative z-10 w-[calc(100vw-2rem)] max-w-md bg-zinc-900 border border-red-900
+            className="relative z-10 w-[calc(100vw-2rem)] max-w-md bg-[var(--color-bg-elevated)] border border-red-900
                        rounded-xl shadow-2xl p-6"
           >
             {/* Header */}
@@ -138,7 +138,7 @@ export function GdprActionsPanel({ candidateId, candidateName }: Props) {
                 type="button"
                 onClick={closeModal}
                 disabled={isPending}
-                className="p-2 md:p-1 rounded text-zinc-500 hover:text-zinc-300 ml-4 shrink-0 disabled:opacity-50"
+                className="p-2 md:p-1 rounded text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)] ml-4 shrink-0 disabled:opacity-50"
                 aria-label="Close dialog"
               >
                 <XIcon className="h-4 w-4" />
@@ -146,15 +146,15 @@ export function GdprActionsPanel({ candidateId, candidateName }: Props) {
             </div>
 
             {/* Description */}
-            <div className="text-sm text-zinc-400 space-y-2 mb-5">
+            <div className="text-sm text-[var(--color-fg-muted)] space-y-2 mb-5">
               <p>
-                This will <strong className="text-zinc-200">permanently and irreversibly</strong> delete
+                This will <strong className="text-[var(--color-fg)]">permanently and irreversibly</strong> delete
                 this candidate and all associated data including scores, notes, interview packs,
                 transcripts, and the uploaded CV file.
               </p>
               <p>
                 Audit log entries will be{' '}
-                <strong className="text-zinc-200">retained</strong> but personal
+                <strong className="text-[var(--color-fg)]">retained</strong> but personal
                 identifiers will be redacted to comply with GDPR Article 17 while
                 preserving the system audit trail.
               </p>
@@ -165,10 +165,10 @@ export function GdprActionsPanel({ candidateId, candidateName }: Props) {
             <div className="mb-5">
               <label
                 htmlFor="gdpr-confirm-name"
-                className="block text-xs text-zinc-400 mb-1.5"
+                className="block text-xs text-[var(--color-fg-muted)] mb-1.5"
               >
                 Type the candidate&apos;s full name to confirm:{' '}
-                <span className="font-semibold text-zinc-200">{candidateName}</span>
+                <span className="font-semibold text-[var(--color-fg)]">{candidateName}</span>
               </label>
               <input
                 id="gdpr-confirm-name"
@@ -181,8 +181,8 @@ export function GdprActionsPanel({ candidateId, candidateName }: Props) {
                 disabled={isPending || deleteSuccess}
                 placeholder={candidateName}
                 autoComplete="off"
-                className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2
-                           text-sm text-zinc-100 placeholder-zinc-600
+                className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] px-3 py-2
+                           text-sm text-[var(--color-fg)] placeholder-[var(--color-fg-subtle)]
                            focus:border-red-700 focus:outline-none focus:ring-1 focus:ring-red-700
                            disabled:opacity-50"
               />
@@ -206,9 +206,9 @@ export function GdprActionsPanel({ candidateId, candidateName }: Props) {
                 type="button"
                 onClick={closeModal}
                 disabled={isPending}
-                className="rounded-md border border-zinc-700 bg-zinc-800 text-zinc-300
+                className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)]
                            text-sm font-medium px-4 py-2
-                           hover:bg-zinc-700 transition-colors
+                           hover:bg-[var(--color-border)] transition-colors
                            disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 Cancel

--- a/src/components/candidates/ics-import-button.tsx
+++ b/src/components/candidates/ics-import-button.tsx
@@ -83,8 +83,8 @@ export function IcsImportButton({ candidateId, roleId }: Props) {
       <button
         onClick={handleClick}
         disabled={isPending}
-        className="flex items-center gap-1.5 px-3 py-1 text-xs font-medium text-zinc-400
-                   border border-zinc-700 rounded-md hover:text-zinc-200 hover:border-zinc-600
+        className="flex items-center gap-1.5 px-3 py-1 text-xs font-medium text-[var(--color-fg-muted)]
+                   border border-[var(--color-border)] rounded-md hover:text-[var(--color-fg)] hover:border-[var(--color-border)]
                    transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
       >
         {isPending ? (

--- a/src/components/candidates/interview-calendar.tsx
+++ b/src/components/candidates/interview-calendar.tsx
@@ -85,30 +85,30 @@ function SlotPopover({ slot, candidateId, canSchedule, onCancelled, onEdit, onCl
   }
 
   return (
-    <div className="absolute z-30 left-0 top-full mt-1 w-64 bg-zinc-800 border border-zinc-700
+    <div className="absolute z-30 left-0 top-full mt-1 w-64 bg-[var(--color-bg-input)] border border-[var(--color-border)]
                     rounded-lg shadow-xl p-4 text-sm">
       <div className="flex items-start justify-between gap-2 mb-2">
-        <p className="font-semibold text-zinc-100 leading-tight">{slot.title}</p>
-        <button onClick={onClose} className="p-1 rounded text-zinc-500 hover:text-zinc-300 flex-shrink-0">
+        <p className="font-semibold text-[var(--color-fg)] leading-tight">{slot.title}</p>
+        <button onClick={onClose} className="p-1 rounded text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)] flex-shrink-0">
           <XCircleIcon className="h-4 w-4" />
         </button>
       </div>
-      <p className="text-zinc-400 text-xs mb-1">
+      <p className="text-[var(--color-fg-muted)] text-xs mb-1">
         {start.toLocaleDateString('en-GB', { weekday: 'long', day: 'numeric', month: 'short', timeZone: 'UTC' })}
       </p>
-      <p className="text-zinc-300 text-xs mb-3">
+      <p className="text-[var(--color-fg)] text-xs mb-3">
         {formatTime(start)} – {formatTime(end)} UTC ({slot.durationMinutes} min)
       </p>
 
       {slot.location && (
-        <div className="flex items-center gap-1.5 text-xs text-zinc-400 mb-1">
+        <div className="flex items-center gap-1.5 text-xs text-[var(--color-fg-muted)] mb-1">
           <MapPinIcon className="h-3 w-3 flex-shrink-0" />
           <span>{slot.location}</span>
         </div>
       )}
       {slot.meetingUrl && (
         <div className="flex items-center gap-1.5 text-xs mb-3">
-          <VideoIcon className="h-3 w-3 flex-shrink-0 text-zinc-400" />
+          <VideoIcon className="h-3 w-3 flex-shrink-0 text-[var(--color-fg-muted)]" />
           <a
             href={slot.meetingUrl}
             target="_blank"
@@ -233,26 +233,26 @@ export function InterviewCalendar({
         <div className="flex items-center gap-2">
           <button
             onClick={prevWeek}
-            className="p-1.5 rounded-md border border-zinc-700 text-zinc-400 hover:text-zinc-200
-                       hover:border-zinc-600 transition-colors"
+            className="p-1.5 rounded-md border border-[var(--color-border)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg)]
+                       hover:border-[var(--color-border)] transition-colors"
           >
             <ChevronLeftIcon className="h-4 w-4" />
           </button>
           <button
             onClick={goToday}
-            className="px-3 py-1 text-xs font-medium text-zinc-400 border border-zinc-700 rounded-md
-                       hover:text-zinc-200 hover:border-zinc-600 transition-colors"
+            className="px-3 py-1 text-xs font-medium text-[var(--color-fg-muted)] border border-[var(--color-border)] rounded-md
+                       hover:text-[var(--color-fg)] hover:border-[var(--color-border)] transition-colors"
           >
             Today
           </button>
           <button
             onClick={nextWeek}
-            className="p-1.5 rounded-md border border-zinc-700 text-zinc-400 hover:text-zinc-200
-                       hover:border-zinc-600 transition-colors"
+            className="p-1.5 rounded-md border border-[var(--color-border)] text-[var(--color-fg-muted)] hover:text-[var(--color-fg)]
+                       hover:border-[var(--color-border)] transition-colors"
           >
             <ChevronRightIcon className="h-4 w-4" />
           </button>
-          <span className="text-xs text-zinc-500 ml-1">
+          <span className="text-xs text-[var(--color-fg-subtle)] ml-1">
             {formatDate(weekStart)} – {formatDate(addDays(weekStart, 6))}
           </span>
         </div>
@@ -278,21 +278,21 @@ export function InterviewCalendar({
       <div className="overflow-x-auto">
         <div className="min-w-[640px]">
           {/* Day headers */}
-          <div className="grid grid-cols-8 border-b border-zinc-700 mb-0">
+          <div className="grid grid-cols-8 border-b border-[var(--color-border)] mb-0">
             {/* Time label column header */}
             <div className="col-span-1" />
             {weekDays.map((day, i) => (
               <div
                 key={i}
                 className={`col-span-1 text-center py-2 text-xs font-medium
-                  ${isToday(day) ? 'text-violet-400' : 'text-zinc-400'}`}
+                  ${isToday(day) ? 'text-violet-400' : 'text-[var(--color-fg-muted)]'}`}
               >
                 <div>{DAY_LABELS[i]}</div>
                 <div
                   className={`text-lg font-bold leading-tight
                     ${isToday(day)
                       ? 'text-violet-300 bg-violet-900/50 rounded-full w-8 h-8 flex items-center justify-center mx-auto'
-                      : 'text-zinc-300'
+                      : 'text-[var(--color-fg)]'
                     }`}
                 >
                   {day.getDate()}
@@ -304,13 +304,13 @@ export function InterviewCalendar({
           {/* Time rows + slot blocks */}
           <div className="grid grid-cols-8" style={{ height: `${GRID_HEIGHT}px` }}>
             {/* Hour labels */}
-            <div className="col-span-1 flex flex-col border-r border-zinc-800">
+            <div className="col-span-1 flex flex-col border-r border-[var(--color-border)]">
               {Array.from({ length: TOTAL_HOURS }, (_, i) => START_HOUR + i).map((hour) => (
                 <div
                   key={hour}
-                  className="flex-1 border-b border-zinc-800 pr-2 flex items-start justify-end"
+                  className="flex-1 border-b border-[var(--color-border)] pr-2 flex items-start justify-end"
                 >
-                  <span className="text-[10px] text-zinc-600 mt-1">
+                  <span className="text-[10px] text-[var(--color-fg-subtle)] mt-1">
                     {hour.toString().padStart(2, '0')}:00
                   </span>
                 </div>
@@ -323,14 +323,14 @@ export function InterviewCalendar({
               return (
                 <div
                   key={dayIndex}
-                  className={`col-span-1 relative border-r border-zinc-800
+                  className={`col-span-1 relative border-r border-[var(--color-border)]
                     ${isToday(day) ? 'bg-violet-950/20' : ''}`}
                 >
                   {/* Hour grid lines */}
                   {Array.from({ length: TOTAL_HOURS }, (_, i) => (
                     <div
                       key={i}
-                      className="absolute w-full border-b border-zinc-800"
+                      className="absolute w-full border-b border-[var(--color-border)]"
                       style={{ top: `${(i / TOTAL_HOURS) * 100}%` }}
                     />
                   ))}
@@ -347,18 +347,18 @@ export function InterviewCalendar({
                                    hover:opacity-90 relative"
                         style={{
                           ...slotStyle(slot),
-                          backgroundColor: isCancelled ? '#3f3f46' : '#6d28d9',
+                          backgroundColor: isCancelled ? 'var(--color-bg-input)' : '#6d28d9',
                           opacity: isCancelled ? 0.6 : 1,
                         }}
                         onClick={() => setOpenPopoverId(isOpen ? null : slot.id)}
                       >
                         <p
                           className={`font-semibold text-white truncate
-                            ${isCancelled ? 'line-through text-zinc-400' : ''}`}
+                            ${isCancelled ? 'line-through text-[var(--color-fg-muted)]' : ''}`}
                         >
                           {slot.title}
                         </p>
-                        <p className={`text-[9px] ${isCancelled ? 'text-zinc-500' : 'text-violet-200'}`}>
+                        <p className={`text-[9px] ${isCancelled ? 'text-[var(--color-fg-subtle)]' : 'text-violet-200'}`}>
                           {formatSlotTime(slot.scheduledAt)}
                         </p>
 
@@ -384,8 +384,8 @@ export function InterviewCalendar({
 
       {/* Upcoming slots list (for slots outside the visible week) */}
       {slots.length > 0 && (
-        <div className="mt-4 border-t border-zinc-700 pt-4">
-          <p className="text-xs font-medium text-zinc-500 uppercase tracking-wide mb-2">
+        <div className="mt-4 border-t border-[var(--color-border)] pt-4">
+          <p className="text-xs font-medium text-[var(--color-fg-subtle)] uppercase tracking-wide mb-2">
             All scheduled interviews
           </p>
           <div className="space-y-1.5">
@@ -396,16 +396,16 @@ export function InterviewCalendar({
                 <div
                   key={slot.id}
                   className={`flex items-center gap-3 rounded-lg px-3 py-2 text-xs
-                    ${isCancelled ? 'bg-zinc-800/50' : 'bg-zinc-800'}`}
+                    ${isCancelled ? 'bg-[var(--color-bg-input)]/50' : 'bg-[var(--color-bg-input)]'}`}
                 >
                   <div className={`w-2 h-2 rounded-full flex-shrink-0
-                    ${isCancelled ? 'bg-zinc-600' : 'bg-violet-500'}`} />
+                    ${isCancelled ? 'bg-[var(--color-border)]' : 'bg-violet-500'}`} />
                   <div className="flex-1 min-w-0">
                     <p className={`font-medium truncate
-                      ${isCancelled ? 'text-zinc-500 line-through' : 'text-zinc-200'}`}>
+                      ${isCancelled ? 'text-[var(--color-fg-subtle)] line-through' : 'text-[var(--color-fg)]'}`}>
                       {slot.title}
                     </p>
-                    <p className="text-zinc-500">
+                    <p className="text-[var(--color-fg-subtle)]">
                       {d.toLocaleDateString('en-GB', {
                         weekday: 'short', day: 'numeric', month: 'short', year: 'numeric', timeZone: 'UTC',
                       })}{' '}
@@ -414,7 +414,7 @@ export function InterviewCalendar({
                     </p>
                   </div>
                   {isCancelled ? (
-                    <span className="text-[10px] text-zinc-500 bg-zinc-700 px-2 py-0.5 rounded">
+                    <span className="text-[10px] text-[var(--color-fg-subtle)] bg-[var(--color-bg-input)] px-2 py-0.5 rounded">
                       Cancelled
                     </span>
                   ) : canSchedule && (

--- a/src/components/candidates/matching-roles-panel.tsx
+++ b/src/components/candidates/matching-roles-panel.tsx
@@ -23,7 +23,7 @@ function FitScoreBadge({ score }: { score: number }) {
       ? 'bg-green-900 border-green-700 text-green-300'
       : score >= 50
         ? 'bg-blue-900 border-blue-700 text-blue-300'
-        : 'bg-zinc-800 border-zinc-600 text-zinc-400'
+        : 'bg-[var(--color-bg-input)] border-[var(--color-border)] text-[var(--color-fg-muted)]'
 
   return (
     <span
@@ -54,13 +54,13 @@ function RoleFitCard({
   }
 
   return (
-    <div className="rounded-lg bg-zinc-800/60 border border-zinc-700 px-4 py-4">
+    <div className="rounded-lg bg-[var(--color-bg-input)]/60 border border-[var(--color-border)] px-4 py-4">
       {/* Card header: title + score + add button */}
       <div className="flex flex-wrap items-center justify-between gap-3 mb-2">
         <div className="flex items-center gap-2 min-w-0">
           <Link
             href={`/dashboard/roles/${suggestion.role.id}`}
-            className="text-sm font-semibold text-zinc-100 hover:text-blue-300 transition-colors truncate"
+            className="text-sm font-semibold text-[var(--color-fg)] hover:text-blue-300 transition-colors truncate"
           >
             {suggestion.role.title}
           </Link>
@@ -74,8 +74,8 @@ function RoleFitCard({
             <button
               onClick={handleAdd}
               disabled={addedState === 'pending'}
-              className="flex items-center gap-1.5 rounded-md bg-zinc-700 text-zinc-200 text-xs
-                         font-medium px-3 py-1.5 hover:bg-zinc-600 transition-colors
+              className="flex items-center gap-1.5 rounded-md bg-[var(--color-bg-input)] text-[var(--color-fg)] text-xs
+                         font-medium px-3 py-1.5 hover:bg-[var(--color-border)] transition-colors
                          disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {addedState === 'pending' ? (
@@ -90,13 +90,13 @@ function RoleFitCard({
       </div>
 
       {/* Headline */}
-      <p className="text-xs italic text-zinc-400 mb-3">{suggestion.fit.headline}</p>
+      <p className="text-xs italic text-[var(--color-fg-muted)] mb-3">{suggestion.fit.headline}</p>
 
       {/* Pros */}
       {suggestion.fit.pros.length > 0 && (
         <ul className="mb-2 space-y-1">
           {suggestion.fit.pros.map((pro, i) => (
-            <li key={i} className="flex items-start gap-1.5 text-xs text-zinc-300">
+            <li key={i} className="flex items-start gap-1.5 text-xs text-[var(--color-fg)]">
               <span className="mt-px text-emerald-400 flex-shrink-0">&#10003;</span>
               {pro}
             </li>
@@ -108,7 +108,7 @@ function RoleFitCard({
       {suggestion.fit.cons.length > 0 && (
         <ul className="space-y-1">
           {suggestion.fit.cons.map((con, i) => (
-            <li key={i} className="flex items-start gap-1.5 text-xs text-zinc-400">
+            <li key={i} className="flex items-start gap-1.5 text-xs text-[var(--color-fg-muted)]">
               <span className="mt-px text-amber-400 flex-shrink-0">&#9888;</span>
               {con}
             </li>
@@ -142,30 +142,30 @@ export function MatchingRolesPanel({ candidateId }: Props) {
   }
 
   return (
-    <div className="bg-zinc-900 border border-zinc-700 rounded-xl mb-6 overflow-hidden">
+    <div className="bg-[var(--color-bg-elevated)] border border-[var(--color-border)] rounded-xl mb-6 overflow-hidden">
       {/* Collapsible toggle */}
       <button
         type="button"
         onClick={() => setIsOpen((prev) => !prev)}
         className="w-full flex items-center justify-between px-4 py-4 text-left
-                   hover:bg-zinc-800/50 transition-colors"
+                   hover:bg-[var(--color-bg-input)]/50 transition-colors"
       >
         <div className="flex items-center gap-2">
           <BriefcaseIcon className="h-4 w-4 text-violet-400 flex-shrink-0" />
-          <span className="font-semibold text-zinc-100">Matching Roles</span>
+          <span className="font-semibold text-[var(--color-fg)]">Matching Roles</span>
         </div>
         {isOpen ? (
-          <ChevronUpIcon className="h-4 w-4 text-zinc-500" />
+          <ChevronUpIcon className="h-4 w-4 text-[var(--color-fg-subtle)]" />
         ) : (
-          <ChevronDownIcon className="h-4 w-4 text-zinc-500" />
+          <ChevronDownIcon className="h-4 w-4 text-[var(--color-fg-subtle)]" />
         )}
       </button>
 
       {isOpen && (
-        <div className="px-4 pb-5 border-t border-zinc-800">
+        <div className="px-4 pb-5 border-t border-[var(--color-border)]">
           {/* Analyse button */}
           <div className="flex items-center justify-between py-4">
-            <p className="text-sm text-zinc-500">
+            <p className="text-sm text-[var(--color-fg-subtle)]">
               {hasSearched
                 ? suggestions && suggestions.length > 0
                   ? `${suggestions.length} role${suggestions.length !== 1 ? 's' : ''} analysed`
@@ -190,14 +190,14 @@ export function MatchingRolesPanel({ candidateId }: Props) {
 
           {/* Loading state */}
           {isPending && (
-            <p className="text-sm text-zinc-500 mb-4">
+            <p className="text-sm text-[var(--color-fg-subtle)] mb-4">
               Analysing candidate against active roles…
             </p>
           )}
 
           {/* Empty state after search */}
           {!isPending && hasSearched && suggestions !== null && suggestions.length === 0 && (
-            <p className="text-sm text-zinc-500">
+            <p className="text-sm text-[var(--color-fg-subtle)]">
               No active roles found, or candidate profile needs more data.
             </p>
           )}

--- a/src/components/candidates/notes-panel.tsx
+++ b/src/components/candidates/notes-panel.tsx
@@ -149,8 +149,8 @@ export function NotesPanel({ candidateId, currentUserId, canEdit, initialNotes, 
     canEdit || note.authorId === currentUserId
 
   return (
-    <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-6">
-      <h2 className="font-semibold text-zinc-100 mb-4">
+    <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-6">
+      <h2 className="font-semibold text-[var(--color-fg)] mb-4">
         Notes ({notesList.length})
       </h2>
 
@@ -163,8 +163,8 @@ export function NotesPanel({ candidateId, currentUserId, canEdit, initialNotes, 
             placeholder="Add a note…"
             rows={3}
             disabled={isAdding}
-            className="w-full rounded-md bg-zinc-800 border border-zinc-700
-                       text-sm text-zinc-200 placeholder-zinc-500 px-3 py-2
+            className="w-full rounded-md bg-[var(--color-bg-input)] border border-[var(--color-border)]
+                       text-sm text-[var(--color-fg)] placeholder:text-[var(--color-fg-subtle)] px-3 py-2
                        focus:outline-none focus:ring-1 focus:ring-violet-600
                        resize-none disabled:opacity-50"
           />
@@ -189,13 +189,13 @@ export function NotesPanel({ candidateId, currentUserId, canEdit, initialNotes, 
 
       {/* Notes list */}
       {notesList.length === 0 ? (
-        <p className="text-sm text-zinc-500">No notes yet.</p>
+        <p className="text-sm text-[var(--color-fg-subtle)]">No notes yet.</p>
       ) : (
         <div className="space-y-3">
           {notesList.map((note) => (
             <div
               key={note.id}
-              className="rounded-md bg-zinc-800 border border-zinc-700 px-4 py-3"
+              className="rounded-md bg-[var(--color-bg-input)] border border-[var(--color-border)] px-4 py-3"
             >
               {editingId === note.id ? (
                 /* Inline edit mode */
@@ -205,8 +205,8 @@ export function NotesPanel({ candidateId, currentUserId, canEdit, initialNotes, 
                     onChange={(e) => setEditBody(e.target.value)}
                     rows={3}
                     disabled={isEditing}
-                    className="w-full rounded-md bg-zinc-900 border border-zinc-600
-                               text-sm text-zinc-200 px-3 py-2
+                    className="w-full rounded-md bg-[var(--color-bg-elevated)] border border-[var(--color-border)]
+                               text-sm text-[var(--color-fg)] px-3 py-2
                                focus:outline-none focus:ring-1 focus:ring-violet-600
                                resize-none disabled:opacity-50"
                   />
@@ -229,8 +229,8 @@ export function NotesPanel({ candidateId, currentUserId, canEdit, initialNotes, 
                       type="button"
                       onClick={cancelEditing}
                       disabled={isEditing}
-                      className="inline-flex items-center gap-1 rounded-md border border-zinc-600
-                                 text-zinc-400 hover:text-zinc-200 text-xs font-medium px-2.5 py-1.5
+                      className="inline-flex items-center gap-1 rounded-md border border-[var(--color-border)]
+                                 text-[var(--color-fg-muted)] hover:text-[var(--color-fg)] text-xs font-medium px-2.5 py-1.5
                                  transition-colors disabled:opacity-50"
                     >
                       <XIcon className="h-3 w-3" />
@@ -241,12 +241,12 @@ export function NotesPanel({ candidateId, currentUserId, canEdit, initialNotes, 
               ) : (
                 /* Display mode */
                 <div>
-                  <p className="text-sm text-zinc-300 whitespace-pre-wrap">{note.body}</p>
+                  <p className="text-sm text-[var(--color-fg)] whitespace-pre-wrap">{note.body}</p>
                   <div className="flex items-center justify-between mt-2">
-                    <p className="text-xs text-zinc-500">
+                    <p className="text-xs text-[var(--color-fg-subtle)]">
                       {formatTimestamp(note.createdAt)}
                       {note.isEdited && (
-                        <span className="ml-1.5 text-zinc-600">(edited)</span>
+                        <span className="ml-1.5 text-[var(--color-fg-subtle)]">(edited)</span>
                       )}
                     </p>
 
@@ -271,8 +271,8 @@ export function NotesPanel({ candidateId, currentUserId, canEdit, initialNotes, 
                               type="button"
                               onClick={() => setConfirmDeleteId(null)}
                               disabled={isDeleting}
-                              className="inline-flex items-center gap-1 rounded-md border border-zinc-600
-                                         text-zinc-400 hover:text-zinc-200 text-xs font-medium px-2 py-1
+                              className="inline-flex items-center gap-1 rounded-md border border-[var(--color-border)]
+                                         text-[var(--color-fg-muted)] hover:text-[var(--color-fg)] text-xs font-medium px-2 py-1
                                          transition-colors disabled:opacity-50"
                             >
                               <XIcon className="h-3 w-3" />
@@ -285,8 +285,8 @@ export function NotesPanel({ candidateId, currentUserId, canEdit, initialNotes, 
                               type="button"
                               onClick={() => startEditing(note)}
                               aria-label="Edit note"
-                              className="rounded p-2 md:p-1 text-zinc-500 hover:text-zinc-200
-                                         hover:bg-zinc-700 transition-colors"
+                              className="rounded p-2 md:p-1 text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)]
+                                         hover:bg-[var(--color-bg-input)] transition-colors"
                             >
                               <PencilIcon className="h-3.5 w-3.5" />
                             </button>
@@ -294,8 +294,8 @@ export function NotesPanel({ candidateId, currentUserId, canEdit, initialNotes, 
                               type="button"
                               onClick={() => setConfirmDeleteId(note.id)}
                               aria-label="Delete note"
-                              className="rounded p-2 md:p-1 text-zinc-500 hover:text-red-400
-                                         hover:bg-zinc-700 transition-colors"
+                              className="rounded p-2 md:p-1 text-[var(--color-fg-subtle)] hover:text-red-400
+                                         hover:bg-[var(--color-bg-input)] transition-colors"
                             >
                               <Trash2Icon className="h-3.5 w-3.5" />
                             </button>

--- a/src/components/candidates/rescore-button.tsx
+++ b/src/components/candidates/rescore-button.tsx
@@ -33,9 +33,9 @@ export function RescoreButton({ candidateId, currentRoleId, allRoles }: Props) {
       <button
         onClick={() => setOpen(!open)}
         disabled={isPending}
-        className="flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-800
-                   text-zinc-400 text-xs font-medium px-3 py-1.5
-                   hover:bg-zinc-700 transition-colors
+        className="flex items-center gap-1.5 rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)]
+                   text-[var(--color-fg-muted)] text-xs font-medium px-3 py-1.5
+                   hover:bg-[var(--color-bg-input)] transition-colors
                    disabled:opacity-50 disabled:cursor-not-allowed"
       >
         <RefreshCwIcon className={`h-3.5 w-3.5 ${isPending ? 'animate-spin' : ''}`} />
@@ -50,22 +50,22 @@ export function RescoreButton({ candidateId, currentRoleId, allRoles }: Props) {
             className="fixed inset-0 z-[9]"
             onClick={() => setOpen(false)}
           />
-          <div className="absolute right-0 top-full mt-1 z-10 bg-zinc-900 border border-zinc-700 rounded-lg shadow-xl min-w-48">
+          <div className="absolute right-0 top-full mt-1 z-10 bg-[var(--color-bg-elevated)] border border-[var(--color-border)] rounded-lg shadow-xl min-w-48">
             {allRoles.length === 0 ? (
-              <p className="px-4 py-2 text-sm text-zinc-500">No active roles</p>
+              <p className="px-4 py-2 text-sm text-[var(--color-fg-subtle)]">No active roles</p>
             ) : (
               allRoles.map((role) => (
                 <button
                   key={role.id}
                   onClick={() => handleRescore(role.id)}
-                  className="w-full text-left px-4 py-2 text-sm text-zinc-300
-                             hover:bg-zinc-800
+                  className="w-full text-left px-4 py-2 text-sm text-[var(--color-fg)]
+                             hover:bg-[var(--color-bg-input)]
                              first:rounded-t-lg last:rounded-b-lg
                              flex items-center justify-between gap-2"
                 >
                   <span className="truncate">{role.title}</span>
                   {role.id === currentRoleId && (
-                    <span className="text-xs text-zinc-500 shrink-0">current</span>
+                    <span className="text-xs text-[var(--color-fg-subtle)] shrink-0">current</span>
                   )}
                 </button>
               ))

--- a/src/components/candidates/role-history-panel.tsx
+++ b/src/components/candidates/role-history-panel.tsx
@@ -20,7 +20,7 @@ type Props = {
 function scoreBadgeClass(score: number): string {
   if (score >= 75) return 'bg-emerald-100 dark:bg-green-900 text-emerald-700 dark:text-green-300 border-emerald-300 dark:border-green-700'
   if (score >= 50) return 'bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 border-blue-300 dark:border-blue-700'
-  return 'bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-400 border-zinc-300 dark:border-zinc-600'
+  return 'bg-zinc-100 dark:bg-[var(--color-bg-input)] text-zinc-700 dark:text-[var(--color-fg-muted)] border-zinc-300 dark:border-[var(--color-border)]'
 }
 
 function DimensionPill({ label, score }: { label: string; score: number | null }) {
@@ -30,7 +30,7 @@ function DimensionPill({ label, score }: { label: string; score: number | null }
       ? 'bg-emerald-100 dark:bg-green-900/50 text-emerald-700 dark:text-green-300'
       : score >= 50
         ? 'bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300'
-        : 'bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-400'
+        : 'bg-zinc-100 dark:bg-[var(--color-bg-input)] text-zinc-700 dark:text-[var(--color-fg-muted)]'
   return (
     <span className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium ${colorClass}`}>
       {label} {score}
@@ -40,11 +40,11 @@ function DimensionPill({ label, score }: { label: string; score: number | null }
 
 export function RoleHistoryPanel({ roleHistory }: Props) {
   return (
-    <div className="bg-zinc-900 border border-zinc-700 rounded-xl px-4 py-5 mb-6">
-      <h2 className="font-semibold text-zinc-100 mb-4">Role History</h2>
+    <div className="bg-[var(--color-bg-elevated)] border border-[var(--color-border)] rounded-xl px-4 py-5 mb-6">
+      <h2 className="font-semibold text-[var(--color-fg)] mb-4">Role History</h2>
 
       {roleHistory.length === 0 ? (
-        <p className="text-sm text-zinc-500">No roles scored yet.</p>
+        <p className="text-sm text-[var(--color-fg-subtle)]">No roles scored yet.</p>
       ) : (
         <ul className="space-y-3">
           {roleHistory.map((entry) => {
@@ -62,16 +62,16 @@ export function RoleHistoryPanel({ roleHistory }: Props) {
             return (
               <li
                 key={entry.scoreId}
-                className="flex flex-wrap items-start justify-between gap-3 rounded-lg bg-zinc-800/60 border border-zinc-700 px-4 py-3"
+                className="flex flex-wrap items-start justify-between gap-3 rounded-lg bg-[var(--color-bg-input)]/60 border border-[var(--color-border)] px-4 py-3"
               >
                 <div className="flex flex-col gap-1">
                   <Link
                     href={`/dashboard/roles/${entry.roleId}`}
-                    className="text-sm font-medium text-zinc-100 hover:text-blue-300 transition-colors"
+                    className="text-sm font-medium text-[var(--color-fg)] hover:text-blue-300 transition-colors"
                   >
                     {entry.roleTitle}
                   </Link>
-                  <span className="text-xs text-zinc-500">{date}</span>
+                  <span className="text-xs text-[var(--color-fg-subtle)]">{date}</span>
                   {isComplete && (
                     <div className="flex flex-wrap gap-1.5 mt-1">
                       <DimensionPill label="Tech" score={entry.technicalScore} />

--- a/src/components/candidates/schedule-interview-modal.tsx
+++ b/src/components/candidates/schedule-interview-modal.tsx
@@ -126,19 +126,19 @@ export function ScheduleInterviewModal({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60">
-      <div className="bg-zinc-900 border border-zinc-700 rounded-xl w-[calc(100vw-2rem)] max-w-lg shadow-2xl">
+      <div className="bg-[var(--color-bg-elevated)] border border-[var(--color-border)] rounded-xl w-[calc(100vw-2rem)] max-w-lg shadow-2xl">
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-zinc-700">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-[var(--color-border)]">
           <div className="flex items-center gap-2">
             <CalendarIcon className="h-4 w-4 text-violet-400" />
-            <h2 className="font-semibold text-zinc-100 text-sm">
+            <h2 className="font-semibold text-[var(--color-fg)] text-sm">
               {isEditMode ? 'Edit Interview' : 'Schedule Interview'}
             </h2>
           </div>
           <button
             type="button"
             onClick={onClose}
-            className="text-zinc-500 hover:text-zinc-300 transition-colors"
+            className="text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)] transition-colors"
           >
             <XIcon className="h-4 w-4" />
           </button>
@@ -147,15 +147,15 @@ export function ScheduleInterviewModal({
         <form onSubmit={handleSubmit} className="px-6 py-5 space-y-4">
           {/* Title */}
           <div>
-            <label className="block text-xs font-medium text-zinc-400 mb-1">Title</label>
+            <label className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">Title</label>
             <input
               type="text"
               value={form.title}
               onChange={(e) => update('title', e.target.value)}
               required
               maxLength={300}
-              className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2
-                         text-sm text-zinc-100 placeholder-zinc-500
+              className="w-full bg-[var(--color-bg-input)] border border-[var(--color-border)] rounded-lg px-3 py-2
+                         text-sm text-[var(--color-fg)] placeholder:text-[var(--color-fg-subtle)]
                          focus:outline-none focus:border-violet-500 focus:ring-1 focus:ring-violet-500"
             />
           </div>
@@ -163,14 +163,14 @@ export function ScheduleInterviewModal({
           {/* Role (optional) */}
           {allRoles.length > 0 && (
             <div>
-              <label className="block text-xs font-medium text-zinc-400 mb-1">
-                Role <span className="text-zinc-600">(optional)</span>
+              <label className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">
+                Role <span className="text-[var(--color-fg-subtle)]">(optional)</span>
               </label>
               <select
                 value={form.selectedRoleId}
                 onChange={(e) => update('selectedRoleId', e.target.value)}
-                className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2
-                           text-sm text-zinc-100
+                className="w-full bg-[var(--color-bg-input)] border border-[var(--color-border)] rounded-lg px-3 py-2
+                           text-sm text-[var(--color-fg)]
                            focus:outline-none focus:border-violet-500 focus:ring-1 focus:ring-violet-500"
               >
                 <option value="">No specific role</option>
@@ -186,26 +186,26 @@ export function ScheduleInterviewModal({
           {/* Date + Time */}
           <div className="grid grid-cols-1 xs:grid-cols-2 gap-3">
             <div>
-              <label className="block text-xs font-medium text-zinc-400 mb-1">Date</label>
+              <label className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">Date</label>
               <input
                 type="date"
                 value={form.date}
                 onChange={(e) => update('date', e.target.value)}
                 required
-                className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2
-                           text-sm text-zinc-100
+                className="w-full bg-[var(--color-bg-input)] border border-[var(--color-border)] rounded-lg px-3 py-2
+                           text-sm text-[var(--color-fg)]
                            focus:outline-none focus:border-violet-500 focus:ring-1 focus:ring-violet-500"
               />
             </div>
             <div>
-              <label className="block text-xs font-medium text-zinc-400 mb-1">Time (UTC)</label>
+              <label className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">Time (UTC)</label>
               <input
                 type="time"
                 value={form.time}
                 onChange={(e) => update('time', e.target.value)}
                 required
-                className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2
-                           text-sm text-zinc-100
+                className="w-full bg-[var(--color-bg-input)] border border-[var(--color-border)] rounded-lg px-3 py-2
+                           text-sm text-[var(--color-fg)]
                            focus:outline-none focus:border-violet-500 focus:ring-1 focus:ring-violet-500"
               />
             </div>
@@ -213,12 +213,12 @@ export function ScheduleInterviewModal({
 
           {/* Duration */}
           <div>
-            <label className="block text-xs font-medium text-zinc-400 mb-1">Duration</label>
+            <label className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">Duration</label>
             <select
               value={form.durationMinutes}
               onChange={(e) => update('durationMinutes', Number(e.target.value))}
-              className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2
-                         text-sm text-zinc-100
+              className="w-full bg-[var(--color-bg-input)] border border-[var(--color-border)] rounded-lg px-3 py-2
+                         text-sm text-[var(--color-fg)]
                          focus:outline-none focus:border-violet-500 focus:ring-1 focus:ring-violet-500"
             >
               {DURATION_OPTIONS.map((opt) => (
@@ -231,8 +231,8 @@ export function ScheduleInterviewModal({
 
           {/* Location */}
           <div>
-            <label className="block text-xs font-medium text-zinc-400 mb-1">
-              Location <span className="text-zinc-600">(optional)</span>
+            <label className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">
+              Location <span className="text-[var(--color-fg-subtle)]">(optional)</span>
             </label>
             <input
               type="text"
@@ -240,32 +240,32 @@ export function ScheduleInterviewModal({
               onChange={(e) => update('location', e.target.value)}
               maxLength={500}
               placeholder="e.g. Conference Room A, or remote"
-              className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2
-                         text-sm text-zinc-100 placeholder-zinc-500
+              className="w-full bg-[var(--color-bg-input)] border border-[var(--color-border)] rounded-lg px-3 py-2
+                         text-sm text-[var(--color-fg)] placeholder:text-[var(--color-fg-subtle)]
                          focus:outline-none focus:border-violet-500 focus:ring-1 focus:ring-violet-500"
             />
           </div>
 
           {/* Meeting URL */}
           <div>
-            <label className="block text-xs font-medium text-zinc-400 mb-1">
-              Meeting URL <span className="text-zinc-600">(optional)</span>
+            <label className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">
+              Meeting URL <span className="text-[var(--color-fg-subtle)]">(optional)</span>
             </label>
             <input
               type="url"
               value={form.meetingUrl}
               onChange={(e) => update('meetingUrl', e.target.value)}
               placeholder="https://meet.google.com/..."
-              className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2
-                         text-sm text-zinc-100 placeholder-zinc-500
+              className="w-full bg-[var(--color-bg-input)] border border-[var(--color-border)] rounded-lg px-3 py-2
+                         text-sm text-[var(--color-fg)] placeholder:text-[var(--color-fg-subtle)]
                          focus:outline-none focus:border-violet-500 focus:ring-1 focus:ring-violet-500"
             />
           </div>
 
           {/* Notes */}
           <div>
-            <label className="block text-xs font-medium text-zinc-400 mb-1">
-              Notes <span className="text-zinc-600">(optional)</span>
+            <label className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">
+              Notes <span className="text-[var(--color-fg-subtle)]">(optional)</span>
             </label>
             <textarea
               value={form.slotNotes}
@@ -273,26 +273,26 @@ export function ScheduleInterviewModal({
               rows={2}
               maxLength={2000}
               placeholder="Any preparation notes or context..."
-              className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2
-                         text-sm text-zinc-100 placeholder-zinc-500 resize-none
+              className="w-full bg-[var(--color-bg-input)] border border-[var(--color-border)] rounded-lg px-3 py-2
+                         text-sm text-[var(--color-fg)] placeholder:text-[var(--color-fg-subtle)] resize-none
                          focus:outline-none focus:border-violet-500 focus:ring-1 focus:ring-violet-500"
             />
           </div>
 
           {/* Calendar sync options */}
           {(hasGoogleCalendar || hasMicrosoftCalendar) && (
-            <div className="rounded-lg bg-zinc-800 border border-zinc-700 px-4 py-3 space-y-2">
-              <p className="text-xs font-medium text-zinc-400">Sync to calendar</p>
+            <div className="rounded-lg bg-[var(--color-bg-input)] border border-[var(--color-border)] px-4 py-3 space-y-2">
+              <p className="text-xs font-medium text-[var(--color-fg-muted)]">Sync to calendar</p>
               {hasGoogleCalendar && (
                 <label className="flex items-center gap-2 cursor-pointer">
                   <input
                     type="checkbox"
                     checked={form.syncGoogle}
                     onChange={(e) => update('syncGoogle', e.target.checked)}
-                    className="rounded border-zinc-600 bg-zinc-700 text-violet-500
-                               focus:ring-violet-500 focus:ring-offset-zinc-900"
+                    className="rounded border-[var(--color-border)] bg-[var(--color-bg-input)] text-violet-500
+                               focus:ring-violet-500 focus:ring-offset-[var(--color-bg-elevated)]"
                   />
-                  <span className="text-sm text-zinc-300">Add to Google Calendar</span>
+                  <span className="text-sm text-[var(--color-fg)]">Add to Google Calendar</span>
                 </label>
               )}
               {hasMicrosoftCalendar && (
@@ -301,10 +301,10 @@ export function ScheduleInterviewModal({
                     type="checkbox"
                     checked={form.syncMicrosoft}
                     onChange={(e) => update('syncMicrosoft', e.target.checked)}
-                    className="rounded border-zinc-600 bg-zinc-700 text-violet-500
-                               focus:ring-violet-500 focus:ring-offset-zinc-900"
+                    className="rounded border-[var(--color-border)] bg-[var(--color-bg-input)] text-violet-500
+                               focus:ring-violet-500 focus:ring-offset-[var(--color-bg-elevated)]"
                   />
-                  <span className="text-sm text-zinc-300">Add to Microsoft O365 Calendar</span>
+                  <span className="text-sm text-[var(--color-fg)]">Add to Microsoft O365 Calendar</span>
                 </label>
               )}
             </div>
@@ -322,7 +322,7 @@ export function ScheduleInterviewModal({
               type="button"
               onClick={onClose}
               disabled={isPending}
-              className="px-4 py-2 text-sm text-zinc-400 hover:text-zinc-200 transition-colors disabled:opacity-50"
+              className="px-4 py-2 text-sm text-[var(--color-fg-muted)] hover:text-[var(--color-fg)] transition-colors disabled:opacity-50"
             >
               Cancel
             </button>

--- a/src/components/candidates/score-chart.tsx
+++ b/src/components/candidates/score-chart.tsx
@@ -45,12 +45,12 @@ export function ScoreChart({ score }: Props) {
       {dimensions.map((dim) => (
         <div key={dim.label}>
           <div className="flex items-center justify-between mb-1.5">
-            <span className="text-sm font-medium text-zinc-300">{dim.label}</span>
-            <span className="text-sm font-bold text-zinc-100">
+            <span className="text-sm font-medium text-[var(--color-fg)]">{dim.label}</span>
+            <span className="text-sm font-bold text-[var(--color-fg)]">
               {dim.score !== null ? `${dim.score}/100` : '—'}
             </span>
           </div>
-          <div className="h-2 rounded-full bg-zinc-700 overflow-hidden">
+          <div className="h-2 rounded-full bg-[var(--color-bg-input)] overflow-hidden">
             <div
               className={`h-full rounded-full transition-all ${dim.color}`}
               style={{ width: `${dim.score ?? 0}%` }}
@@ -63,7 +63,7 @@ export function ScoreChart({ score }: Props) {
               reasoning={dim.reasoning}
             />
           ) : dim.reasoning ? (
-            <p className="mt-1.5 text-xs text-zinc-500">{dim.reasoning}</p>
+            <p className="mt-1.5 text-xs text-[var(--color-fg-subtle)]">{dim.reasoning}</p>
           ) : null}
         </div>
       ))}

--- a/src/components/candidates/score-expand-modal.tsx
+++ b/src/components/candidates/score-expand-modal.tsx
@@ -30,12 +30,12 @@ export function ScoreExpandModal({ dimension, score, reasoning }: Props) {
   const preview = isLong ? reasoning.slice(0, PREVIEW_LENGTH).trimEnd() + '…' : reasoning
 
   if (!isLong) {
-    return <p className="mt-1.5 text-xs text-zinc-500">{reasoning}</p>
+    return <p className="mt-1.5 text-xs text-[var(--color-fg-subtle)]">{reasoning}</p>
   }
 
   return (
     <>
-      <p className="mt-1.5 text-xs text-zinc-500">
+      <p className="mt-1.5 text-xs text-[var(--color-fg-subtle)]">
         {preview}{' '}
         <button
           onClick={() => setOpen(true)}
@@ -51,18 +51,18 @@ export function ScoreExpandModal({ dimension, score, reasoning }: Props) {
           onClick={close}
         >
           <div
-            className="relative bg-zinc-950 border border-zinc-700 rounded-xl p-6 max-w-xl w-[calc(100vw-2rem)] shadow-xl"
+            className="relative bg-[var(--color-bg-app)] border border-[var(--color-border)] rounded-xl p-6 max-w-xl w-[calc(100vw-2rem)] shadow-xl"
             onClick={(e) => e.stopPropagation()}
           >
             {/* Header */}
             <div className="flex items-center justify-between mb-4">
               <div>
-                <h3 className="text-sm font-semibold text-zinc-100">{dimension}</h3>
-                <p className="text-xs text-zinc-500 mt-0.5">Score: {score}/100</p>
+                <h3 className="text-sm font-semibold text-[var(--color-fg)]">{dimension}</h3>
+                <p className="text-xs text-[var(--color-fg-subtle)] mt-0.5">Score: {score}/100</p>
               </div>
               <button
                 onClick={close}
-                className="text-zinc-500 hover:text-zinc-300 transition-colors rounded-md p-2 md:p-1 hover:bg-zinc-800"
+                className="text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)] transition-colors rounded-md p-2 md:p-1 hover:bg-[var(--color-bg-input)]"
                 aria-label="Close"
               >
                 <XIcon className="h-4 w-4" />
@@ -70,7 +70,7 @@ export function ScoreExpandModal({ dimension, score, reasoning }: Props) {
             </div>
 
             {/* Full reasoning */}
-            <p className="text-sm text-zinc-300 leading-relaxed whitespace-pre-wrap">{reasoning}</p>
+            <p className="text-sm text-[var(--color-fg)] leading-relaxed whitespace-pre-wrap">{reasoning}</p>
           </div>
         </div>
       )}

--- a/src/components/candidates/status-selector.tsx
+++ b/src/components/candidates/status-selector.tsx
@@ -15,7 +15,7 @@ const STATUS_OPTIONS: Array<{ value: CandidateStatus; label: string }> = [
 ]
 
 const STATUS_BADGE: Record<CandidateStatus, string> = {
-  new: 'bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300 border-zinc-300 dark:border-zinc-600',
+  new: 'bg-zinc-100 dark:bg-[var(--color-bg-input)] text-zinc-700 dark:text-[var(--color-fg)] border-zinc-300 dark:border-[var(--color-border)]',
   shortlisted: 'bg-blue-100 dark:bg-blue-950 text-blue-700 dark:text-blue-300 border-blue-300 dark:border-blue-700',
   interviewing: 'bg-amber-100 dark:bg-amber-950 text-amber-700 dark:text-amber-300 border-amber-300 dark:border-amber-700',
   offered: 'bg-violet-100 dark:bg-violet-950 text-violet-700 dark:text-violet-300 border-violet-300 dark:border-violet-700',
@@ -52,7 +52,7 @@ export function StatusSelector({ candidateId, currentStatus }: StatusSelectorPro
           onChange={handleChange}
           disabled={isPending}
           aria-label="Change candidate status"
-          className="appearance-none rounded-md border border-zinc-600 bg-zinc-800 text-zinc-300
+          className="appearance-none rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)]
                      text-xs px-3 py-1.5 pr-7 focus:outline-none focus:ring-2 focus:ring-blue-500
                      focus:border-transparent disabled:opacity-50 cursor-pointer"
         >
@@ -63,11 +63,11 @@ export function StatusSelector({ candidateId, currentStatus }: StatusSelectorPro
           ))}
         </select>
         {isPending && (
-          <Loader2 className="absolute right-1.5 h-3.5 w-3.5 animate-spin text-zinc-400 pointer-events-none" />
+          <Loader2 className="absolute right-1.5 h-3.5 w-3.5 animate-spin text-[var(--color-fg-muted)] pointer-events-none" />
         )}
         {!isPending && (
           <svg
-            className="absolute right-1.5 h-3.5 w-3.5 text-zinc-500 pointer-events-none"
+            className="absolute right-1.5 h-3.5 w-3.5 text-[var(--color-fg-subtle)] pointer-events-none"
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"

--- a/src/components/candidates/synechron-id-input.tsx
+++ b/src/components/candidates/synechron-id-input.tsx
@@ -91,9 +91,9 @@ export function SynechronIdInput({ candidateId, value }: SynechronIdInputProps) 
       <button
         type="button"
         onClick={() => setOpen((prev) => !prev)}
-        className="inline-flex items-center rounded-md border border-zinc-700 bg-zinc-800
-                   px-2 py-0.5 text-xs font-medium text-zinc-300
-                   hover:border-zinc-500 hover:text-zinc-100 transition-colors"
+        className="inline-flex items-center rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)]
+                   px-2 py-0.5 text-xs font-medium text-[var(--color-fg)]
+                   hover:border-[var(--color-border)] hover:text-[var(--color-fg)] transition-colors"
         aria-haspopup="dialog"
         aria-expanded={open}
       >
@@ -104,11 +104,11 @@ export function SynechronIdInput({ candidateId, value }: SynechronIdInputProps) 
         <div
           role="dialog"
           aria-label="Edit Synechron candidate ID"
-          className="absolute left-0 top-full mt-2 z-20 w-72 rounded-md border border-zinc-700
-                     bg-zinc-900 p-3 shadow-lg"
+          className="absolute left-0 top-full mt-2 z-20 w-72 rounded-md border border-[var(--color-border)]
+                     bg-[var(--color-bg-elevated)] p-3 shadow-lg"
         >
           <form onSubmit={handleSubmit} className="flex flex-col gap-2">
-            <label className="text-xs font-medium text-zinc-300" htmlFor="synechron-id-field">
+            <label className="text-xs font-medium text-[var(--color-fg)]" htmlFor="synechron-id-field">
               Synechron Candidate ID
             </label>
             <input
@@ -120,20 +120,20 @@ export function SynechronIdInput({ candidateId, value }: SynechronIdInputProps) 
               placeholder="SYNE-1234"
               maxLength={64}
               disabled={pending}
-              className="rounded-md border border-zinc-600 bg-zinc-800 px-2 py-1.5 text-sm
-                         text-zinc-100 placeholder-zinc-500 focus:outline-none
+              className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] px-2 py-1.5 text-sm
+                         text-[var(--color-fg)] placeholder:text-[var(--color-fg-subtle)] focus:outline-none
                          focus:ring-2 focus:ring-blue-500 focus:border-transparent
                          disabled:opacity-50"
             />
-            <p className="text-[10px] text-zinc-500">Letters, digits and hyphens only. Max 64 characters.</p>
+            <p className="text-[10px] text-[var(--color-fg-subtle)]">Letters, digits and hyphens only. Max 64 characters.</p>
             {error && <p className="text-xs text-red-400">{error}</p>}
             <div className="flex justify-end gap-2 pt-1">
               <button
                 type="button"
                 onClick={handleCancel}
                 disabled={pending}
-                className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1
-                           text-xs text-zinc-300 hover:bg-zinc-700 disabled:opacity-50"
+                className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] px-3 py-1
+                           text-xs text-[var(--color-fg)] hover:bg-[var(--color-border)] disabled:opacity-50"
               >
                 Cancel
               </button>

--- a/src/components/candidates/verified-profile-chip.tsx
+++ b/src/components/candidates/verified-profile-chip.tsx
@@ -69,17 +69,17 @@ export function VerifiedProfileChip({
   }
 
   return (
-    <div className="flex items-center gap-2 rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1.5 text-sm">
+    <div className="flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] px-2 py-1.5 text-sm">
       <a
         href={url}
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-flex items-center gap-1.5 text-zinc-200 hover:text-white truncate"
+        className="inline-flex items-center gap-1.5 text-[var(--color-fg)] hover:text-[var(--color-fg)] truncate"
         title={url}
       >
         <ExternalLinkIcon className="h-3.5 w-3.5 shrink-0" />
         <span className="truncate">
-          <span className="text-zinc-400">{SOURCE_LABEL[source] ?? source}:</span> {displayUrl}
+          <span className="text-[var(--color-fg-muted)]">{SOURCE_LABEL[source] ?? source}:</span> {displayUrl}
         </span>
       </a>
 
@@ -102,7 +102,7 @@ export function VerifiedProfileChip({
           type="button"
           onClick={handle(onDismiss)}
           disabled={isPending}
-          className="rounded-md border border-zinc-700 bg-zinc-900 px-1.5 py-0.5 text-xs text-zinc-400 hover:text-zinc-200 disabled:opacity-50"
+          className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-elevated)] px-1.5 py-0.5 text-xs text-[var(--color-fg-muted)] hover:text-[var(--color-fg)] disabled:opacity-50"
           aria-label="Dismiss this profile"
         >
           <XIcon className="h-3 w-3" />

--- a/src/components/candidates/welcome-letter-button.tsx
+++ b/src/components/candidates/welcome-letter-button.tsx
@@ -146,9 +146,9 @@ function WelcomeLetterButtonInner({
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="inline-flex items-center gap-1.5 rounded-md border border-zinc-600
-                   text-sm text-zinc-400 px-3 py-1.5
-                   hover:bg-zinc-800 hover:text-zinc-200 transition-colors"
+        className="inline-flex items-center gap-1.5 rounded-md border border-[var(--color-border)]
+                   text-sm text-[var(--color-fg-muted)] px-3 py-1.5
+                   hover:bg-[var(--color-bg-input)] hover:text-[var(--color-fg)] transition-colors"
       >
         <MailIcon className="h-3.5 w-3.5" />
         Welcome letter
@@ -163,15 +163,15 @@ function WelcomeLetterButtonInner({
           aria-label="Generate candidate welcome letter"
         >
           <div
-            className="relative bg-zinc-950 border border-zinc-700 rounded-xl p-6
+            className="relative bg-[var(--color-bg-app)] border border-[var(--color-border)] rounded-xl p-6
                         max-w-md w-[calc(100vw-2rem)] shadow-xl"
             onClick={(e) => e.stopPropagation()}
           >
             {/* Header */}
             <div className="flex items-center justify-between mb-5">
               <div>
-                <h2 className="text-base font-semibold text-zinc-100">Welcome letter</h2>
-                <p className="text-xs text-zinc-500 mt-0.5">
+                <h2 className="text-base font-semibold text-[var(--color-fg)]">Welcome letter</h2>
+                <p className="text-xs text-[var(--color-fg-subtle)] mt-0.5">
                   Generate a personalised interview prep letter for the candidate.
                 </p>
               </div>
@@ -179,7 +179,7 @@ function WelcomeLetterButtonInner({
                 type="button"
                 onClick={handleClose}
                 disabled={generating}
-                className="p-2 md:p-1 rounded text-zinc-500 hover:text-zinc-300 disabled:opacity-40 transition-colors"
+                className="p-2 md:p-1 rounded text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)] disabled:opacity-40 transition-colors"
                 aria-label="Close"
               >
                 <XIcon className="h-4 w-4" />
@@ -188,7 +188,7 @@ function WelcomeLetterButtonInner({
 
             {/* Language */}
             <div className="mb-4">
-              <label htmlFor="wl-lang" className="block text-xs font-medium text-zinc-400 mb-1.5">
+              <label htmlFor="wl-lang" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1.5">
                 Language
               </label>
               <select
@@ -196,7 +196,7 @@ function WelcomeLetterButtonInner({
                 value={lang}
                 onChange={(e) => setLang(e.target.value as SupportedLanguage)}
                 disabled={generating}
-                className="w-full rounded-md border border-zinc-700 bg-zinc-900 text-zinc-100
+                className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-elevated)] text-[var(--color-fg)]
                            text-sm px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-500
                            disabled:opacity-50"
               >
@@ -210,7 +210,7 @@ function WelcomeLetterButtonInner({
 
             {/* Interview type */}
             <div className="mb-4">
-              <p className="text-xs font-medium text-zinc-400 mb-1.5">Interview type</p>
+              <p className="text-xs font-medium text-[var(--color-fg-muted)] mb-1.5">Interview type</p>
               <div className="flex flex-col gap-1.5">
                 {INTERVIEW_TYPES.map((t) => {
                   const labels: Record<InterviewType, string> = {
@@ -221,7 +221,7 @@ function WelcomeLetterButtonInner({
                   return (
                     <label
                       key={t}
-                      className="flex items-center gap-2 text-sm text-zinc-300 cursor-pointer"
+                      className="flex items-center gap-2 text-sm text-[var(--color-fg)] cursor-pointer"
                     >
                       <input
                         type="radio"
@@ -241,7 +241,7 @@ function WelcomeLetterButtonInner({
 
             {/* Role context */}
             <div className="mb-5">
-              <label htmlFor="wl-role" className="block text-xs font-medium text-zinc-400 mb-1.5">
+              <label htmlFor="wl-role" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1.5">
                 Role context
               </label>
               <select
@@ -249,7 +249,7 @@ function WelcomeLetterButtonInner({
                 value={roleId}
                 onChange={(e) => setRoleId(e.target.value)}
                 disabled={generating}
-                className="w-full rounded-md border border-zinc-700 bg-zinc-900 text-zinc-100
+                className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-elevated)] text-[var(--color-fg)]
                            text-sm px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-500
                            disabled:opacity-50"
               >
@@ -274,9 +274,9 @@ function WelcomeLetterButtonInner({
                 type="button"
                 onClick={handleClose}
                 disabled={generating}
-                className="rounded-md border border-zinc-700 bg-zinc-800 text-zinc-300
+                className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)]
                            text-sm font-medium px-4 py-2
-                           hover:bg-zinc-700 hover:text-zinc-100 disabled:opacity-50
+                           hover:bg-[var(--color-border)] hover:text-[var(--color-fg)] disabled:opacity-50
                            transition-colors"
               >
                 Cancel


### PR DESCRIPTION
Second of 5 phased PRs for [Epic #103](https://github.com/olafkfreund/SkillAi/issues/103).

## Summary

All 25 files in `src/components/candidates/` converted to CSS-token classes. ~338 individual replacements via 2 parallel agents (alphabetical halves).

**Agent A** (12 files, ~186 hits): bulk-status-bar, bulk-upload-zone, candidate-cv-profile, candidate-upload-form, comparison-checkbox, comparison-tray, confidence-pill, cv-display, cv-file-panel, edit-details-form, enrichment-panel, gdpr-actions-panel.

**Agent B** (13 files, ~152 hits): ics-import-button, interview-calendar, matching-roles-panel, notes-panel, rescore-button, role-history-panel, schedule-interview-modal, score-chart, score-expand-modal, status-selector, synechron-id-input, verified-profile-chip, welcome-letter-button.

Light-mode-side `bg-zinc-100 text-zinc-700 border-zinc-300` values inside existing `dark:` pill patterns are intentionally retained — they provide the light-mode half of the dual-mode badges set up in PR1.

Saturated solid buttons (`bg-blue-600`, `bg-emerald-700`, `bg-violet-700`) left untouched — already light-mode-friendly.

## Test plan

- [x] Typecheck clean
- [x] No NEW lint errors (4 pre-existing errors in `candidate-filters.tsx`, `comparison-tray.tsx`, `edit-details-form.tsx`, `pack-generator.tsx` from earlier commits — out of scope)
- [x] Dev server compiled cleanly
- [ ] Toggle light mode → candidate detail, candidate list, comparison tray, all dialogs (welcome letter, schedule interview, score expand, GDPR actions, CV file, edit details) render correctly in both modes
- [ ] Status pills (status selector "new" badge, level pills, role-history score badges) readable in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)