### PR TITLE
refactor(theme): PR3 — roles + manager domains converted (part of #103)

### DIFF
--- a/src/components/manager/approval-controls.tsx
+++ b/src/components/manager/approval-controls.tsx
@@ -96,10 +96,10 @@ export function ApprovalControls({
   const badge = decisionLabel[decision]
 
   return (
-    <div className="rounded-xl bg-zinc-900 border border-zinc-700 p-5 space-y-4">
+    <div className="rounded-xl bg-[var(--color-bg-elevated)] border border-[var(--color-border)] p-5 space-y-4">
       {/* Current decision badge */}
       <div className="flex items-center gap-3">
-        <span className="text-sm font-medium text-zinc-400">Decision:</span>
+        <span className="text-sm font-medium text-[var(--color-fg-muted)]">Decision:</span>
         <span
           className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${badge.classes}`}
         >
@@ -109,7 +109,7 @@ export function ApprovalControls({
 
       {/* Previously saved comment (read-only display when decided) */}
       {decision !== 'pending' && savedComment && (
-        <p className="text-sm text-zinc-400 bg-zinc-800 rounded-md px-3 py-2 border border-zinc-700">
+        <p className="text-sm text-[var(--color-fg-muted)] bg-[var(--color-bg-input)] rounded-md px-3 py-2 border border-[var(--color-border)]">
           {savedComment}
         </p>
       )}
@@ -118,7 +118,7 @@ export function ApprovalControls({
       <div>
         <label
           htmlFor={`approval-comment-${candidateId}`}
-          className="block text-xs font-medium text-zinc-500 mb-1"
+          className="block text-xs font-medium text-[var(--color-fg-subtle)] mb-1"
         >
           Comment (optional)
         </label>
@@ -129,8 +129,8 @@ export function ApprovalControls({
           placeholder="Add a comment for this decision…"
           rows={3}
           disabled={isPending}
-          className="w-full rounded-md bg-zinc-800 border border-zinc-700
-                     text-sm text-zinc-200 placeholder-zinc-500 px-3 py-2
+          className="w-full rounded-md bg-[var(--color-bg-input)] border border-[var(--color-border)]
+                     text-sm text-[var(--color-fg)] placeholder-[var(--color-fg-subtle)] px-3 py-2
                      focus:outline-none focus:ring-1 focus:ring-violet-600
                      resize-none disabled:opacity-50"
         />
@@ -170,8 +170,8 @@ export function ApprovalControls({
             onClick={handleClear}
             disabled={isPending}
             aria-label="Clear decision"
-            className="inline-flex items-center gap-1.5 rounded-md border border-zinc-600
-                       text-zinc-400 hover:text-zinc-200 text-sm font-medium px-3 py-1.5
+            className="inline-flex items-center gap-1.5 rounded-md border border-[var(--color-border)]
+                       text-[var(--color-fg-muted)] hover:text-[var(--color-fg)] text-sm font-medium px-3 py-1.5
                        transition-colors disabled:opacity-40"
           >
             <RotateCcwIcon className="h-3.5 w-3.5" />
@@ -261,8 +261,8 @@ export function ApproveAllRemainingButton({
           type="button"
           onClick={handleCancel}
           disabled={isPending}
-          className="inline-flex items-center gap-1 rounded-md border border-zinc-600
-                     text-zinc-400 hover:text-zinc-200 text-xs font-medium px-2.5 py-1.5
+          className="inline-flex items-center gap-1 rounded-md border border-[var(--color-border)]
+                     text-[var(--color-fg-muted)] hover:text-[var(--color-fg)] text-xs font-medium px-2.5 py-1.5
                      transition-colors disabled:opacity-50"
         >
           <XIcon className="h-3 w-3" />
@@ -280,8 +280,8 @@ export function ApproveAllRemainingButton({
         onClick={handleInitialClick}
         disabled={pendingCount === 0 || isPending}
         aria-label={`Approve all remaining ${pendingCount} candidates`}
-        className="inline-flex items-center gap-1.5 rounded-md bg-zinc-700
-                   hover:bg-zinc-600 text-zinc-100 text-sm font-medium px-3 py-1.5
+        className="inline-flex items-center gap-1.5 rounded-md bg-[var(--color-bg-input)]
+                   hover:bg-[var(--color-border)] text-[var(--color-fg)] text-sm font-medium px-3 py-1.5
                    transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
       >
         <CheckCheckIcon className="h-4 w-4" />

--- a/src/components/manager/shortlist-status-pill.tsx
+++ b/src/components/manager/shortlist-status-pill.tsx
@@ -30,8 +30,8 @@ export function ShortlistStatusPill({
   if (!sentAt) {
     return (
       <span
-        className="inline-flex items-center rounded-full border border-zinc-300 dark:border-zinc-700
-                   bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-400 text-xs font-medium px-3 py-1"
+        className="inline-flex items-center rounded-full border border-zinc-300 dark:border-[var(--color-border)]
+                   bg-zinc-100 dark:bg-[var(--color-bg-input)] text-zinc-700 dark:text-[var(--color-fg-muted)] text-xs font-medium px-3 py-1"
         aria-label="Shortlist not yet sent for approval"
       >
         Not sent for approval
@@ -47,7 +47,7 @@ export function ShortlistStatusPill({
   // Colour logic
   let colourClasses: string
   if (total === 0) {
-    colourClasses = 'border-zinc-300 dark:border-zinc-700 bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-400'
+    colourClasses = 'border-zinc-300 dark:border-[var(--color-border)] bg-zinc-100 dark:bg-[var(--color-bg-input)] text-zinc-700 dark:text-[var(--color-fg-muted)]'
   } else if (allApproved) {
     colourClasses = 'border-emerald-300 dark:border-emerald-800 bg-emerald-100 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-300'
   } else if (allRejected) {

--- a/src/components/roles/add-candidate-panel.tsx
+++ b/src/components/roles/add-candidate-panel.tsx
@@ -64,22 +64,22 @@ export function AddCandidatePanel({ roleId, canEdit }: Props) {
   if (!canEdit) return null
 
   return (
-    <div className="bg-zinc-900 rounded-xl border border-zinc-700 mb-6">
+    <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] mb-6">
       {/* Toggle header */}
       <button
         type="button"
         onClick={() => setExpanded((v) => !v)}
         className="w-full flex items-center justify-between px-6 py-4 text-left
-                   hover:bg-zinc-800 transition-colors rounded-xl"
+                   hover:bg-[var(--color-bg-input)] transition-colors rounded-xl"
       >
         <div className="flex items-center gap-2">
           <UserPlusIcon className="h-4 w-4 text-blue-400" />
-          <span className="font-semibold text-zinc-100">Add from archive</span>
+          <span className="font-semibold text-[var(--color-fg)]">Add from archive</span>
         </div>
         {expanded ? (
-          <ChevronUpIcon className="h-4 w-4 text-zinc-500" />
+          <ChevronUpIcon className="h-4 w-4 text-[var(--color-fg-subtle)]" />
         ) : (
-          <ChevronDownIcon className="h-4 w-4 text-zinc-500" />
+          <ChevronDownIcon className="h-4 w-4 text-[var(--color-fg-subtle)]" />
         )}
       </button>
 
@@ -91,14 +91,14 @@ export function AddCandidatePanel({ roleId, canEdit }: Props) {
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Search by name or email…"
-            className="w-full rounded-lg bg-zinc-800 border border-zinc-700 text-zinc-100
-                       placeholder:text-zinc-500 text-sm px-4 py-2.5 mb-3
+            className="w-full rounded-lg bg-[var(--color-bg-input)] border border-[var(--color-border)] text-[var(--color-fg)]
+                       placeholder:text-[var(--color-fg-subtle)] text-sm px-4 py-2.5 mb-3
                        focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent"
           />
 
           {/* Results */}
           {searched && results.length === 0 && (
-            <p className="text-zinc-500 text-sm">No candidates found.</p>
+            <p className="text-[var(--color-fg-subtle)] text-sm">No candidates found.</p>
           )}
 
           {results.length > 0 && (
@@ -108,15 +108,15 @@ export function AddCandidatePanel({ roleId, canEdit }: Props) {
                 return (
                   <div
                     key={c.id}
-                    className="flex items-center justify-between rounded-lg bg-zinc-800
-                               border border-zinc-700 px-4 py-3 gap-3"
+                    className="flex items-center justify-between rounded-lg bg-[var(--color-bg-input)]
+                               border border-[var(--color-border)] px-4 py-3 gap-3"
                   >
                     <div className="min-w-0">
-                      <p className="text-sm font-medium text-zinc-100 truncate">
+                      <p className="text-sm font-medium text-[var(--color-fg)] truncate">
                         {c.firstName} {c.lastName}
                       </p>
                       {c.email && (
-                        <p className="text-xs text-zinc-500 truncate">{c.email}</p>
+                        <p className="text-xs text-[var(--color-fg-subtle)] truncate">{c.email}</p>
                       )}
                     </div>
 

--- a/src/components/roles/download-cvs-button.tsx
+++ b/src/components/roles/download-cvs-button.tsx
@@ -32,8 +32,8 @@ export function DownloadCvsButton({ roleId }: Props) {
         value={status}
         onChange={(e) => setStatus(e.target.value)}
         disabled={loading}
-        className="bg-zinc-800 border border-zinc-700 rounded-md px-2 py-1.5
-                   text-sm text-zinc-300
+        className="bg-[var(--color-bg-input)] border border-[var(--color-border)] rounded-md px-2 py-1.5
+                   text-sm text-[var(--color-fg)]
                    focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
                    transition-colors cursor-pointer disabled:opacity-50"
         aria-label="Candidate status filter for CV download"
@@ -47,9 +47,9 @@ export function DownloadCvsButton({ roleId }: Props) {
       <button
         onClick={handleDownload}
         disabled={loading}
-        className="inline-flex items-center gap-1.5 rounded-md border border-zinc-600
-                   text-sm text-zinc-400 px-3 py-1.5
-                   hover:bg-zinc-800 disabled:opacity-50 transition-colors"
+        className="inline-flex items-center gap-1.5 rounded-md border border-[var(--color-border)]
+                   text-sm text-[var(--color-fg-muted)] px-3 py-1.5
+                   hover:bg-[var(--color-bg-input)] disabled:opacity-50 transition-colors"
       >
         {loading ? (
           <Loader2Icon className="h-3.5 w-3.5 animate-spin" />

--- a/src/components/roles/framework-level-field.tsx
+++ b/src/components/roles/framework-level-field.tsx
@@ -40,17 +40,17 @@ export function FrameworkLevelField({
   if (sortedLevels.length === 0) {
     return (
       <div>
-        <label className="block text-sm font-medium text-zinc-300 mb-1">
-          Framework Level <span className="text-zinc-500 font-normal">(optional)</span>
+        <label className="block text-sm font-medium text-[var(--color-fg)] mb-1">
+          Framework Level <span className="text-[var(--color-fg-subtle)] font-normal">(optional)</span>
         </label>
-        <div className="rounded-md border border-dashed border-zinc-700 bg-zinc-900/50 px-3 py-3 text-sm text-zinc-400">
+        <div className="rounded-md border border-dashed border-[var(--color-border)] bg-[var(--color-bg-elevated)]/50 px-3 py-3 text-sm text-[var(--color-fg-muted)]">
           {value.label ? (
             <div className="flex items-start justify-between gap-3">
               <div>
-                <p className="text-zinc-300">
+                <p className="text-[var(--color-fg)]">
                   Current value: <span className="font-medium">{value.label}</span>
                 </p>
-                <p className="text-xs text-zinc-500 mt-1">
+                <p className="text-xs text-[var(--color-fg-subtle)] mt-1">
                   This level is no longer in the customer&apos;s framework.{' '}
                   <Link
                     href={`/dashboard/customers/${customerId}`}
@@ -64,8 +64,8 @@ export function FrameworkLevelField({
                 type="button"
                 onClick={() => onChange({ id: '', label: '' })}
                 disabled={disabled}
-                className="rounded-md border border-zinc-600 bg-zinc-800 px-2.5 py-1 text-xs text-zinc-300
-                           hover:bg-zinc-700 hover:text-zinc-100 disabled:opacity-50 transition-colors flex-shrink-0"
+                className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] px-2.5 py-1 text-xs text-[var(--color-fg)]
+                           hover:bg-[var(--color-border)] hover:text-[var(--color-fg)] disabled:opacity-50 transition-colors flex-shrink-0"
               >
                 Clear
               </button>
@@ -88,8 +88,8 @@ export function FrameworkLevelField({
 
   return (
     <div>
-      <label htmlFor="frameworkLevelId" className="block text-sm font-medium text-zinc-300 mb-1">
-        Framework Level <span className="text-zinc-500 font-normal">(optional)</span>
+      <label htmlFor="frameworkLevelId" className="block text-sm font-medium text-[var(--color-fg)] mb-1">
+        Framework Level <span className="text-[var(--color-fg-subtle)] font-normal">(optional)</span>
       </label>
       <select
         id="frameworkLevelId"
@@ -103,7 +103,7 @@ export function FrameworkLevelField({
             label: level ? `${level.code} — ${level.title}` : '',
           })
         }}
-        className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
+        className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
                    focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
                    disabled:opacity-50"
       >
@@ -115,7 +115,7 @@ export function FrameworkLevelField({
         ))}
       </select>
       {selected && (
-        <p className="text-xs text-zinc-500 mt-1">{selected.description}</p>
+        <p className="text-xs text-[var(--color-fg-subtle)] mt-1">{selected.description}</p>
       )}
     </div>
   )

--- a/src/components/roles/manager-assignment-dialog.tsx
+++ b/src/components/roles/manager-assignment-dialog.tsx
@@ -120,9 +120,9 @@ export function ManagerAssignmentDialog({
       <button
         type="button"
         onClick={handleOpen}
-        className="inline-flex items-center gap-1.5 rounded-md border border-zinc-600
-                   bg-zinc-800 text-zinc-200 text-sm font-medium px-3 py-1.5
-                   hover:bg-zinc-700 hover:border-zinc-500 transition-colors"
+        className="inline-flex items-center gap-1.5 rounded-md border border-[var(--color-border)]
+                   bg-[var(--color-bg-input)] text-[var(--color-fg)] text-sm font-medium px-3 py-1.5
+                   hover:bg-[var(--color-border)] hover:border-[var(--color-border)] transition-colors"
         aria-label={`Assign managers — ${assignedCount} currently assigned`}
       >
         <UsersIcon className="h-3.5 w-3.5" />
@@ -139,17 +139,17 @@ export function ManagerAssignmentDialog({
           aria-label="Assign hiring managers to role"
         >
           <div
-            className="relative bg-zinc-950 border border-zinc-700 rounded-xl p-6
+            className="relative bg-[var(--color-bg-app)] border border-[var(--color-border)] rounded-xl p-6
                         max-w-md w-[calc(100vw-2rem)] shadow-xl"
             onClick={(e) => e.stopPropagation()}
           >
             {/* Header */}
             <div className="flex items-center justify-between mb-5">
               <div>
-                <h2 className="text-base font-semibold text-zinc-100">
+                <h2 className="text-base font-semibold text-[var(--color-fg)]">
                   Assign hiring managers
                 </h2>
-                <p className="text-xs text-zinc-500 mt-0.5">
+                <p className="text-xs text-[var(--color-fg-subtle)] mt-0.5">
                   Select one or more managers who will review this role&apos;s shortlist.
                 </p>
               </div>
@@ -157,8 +157,8 @@ export function ManagerAssignmentDialog({
                 type="button"
                 onClick={handleClose}
                 disabled={isPending}
-                className="text-zinc-500 hover:text-zinc-300 transition-colors rounded-md p-2 md:p-1
-                           hover:bg-zinc-800 disabled:opacity-40"
+                className="text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)] transition-colors rounded-md p-2 md:p-1
+                           hover:bg-[var(--color-bg-input)] disabled:opacity-40"
                 aria-label="Close dialog"
               >
                 <XIcon className="h-4 w-4" />
@@ -167,7 +167,7 @@ export function ManagerAssignmentDialog({
 
             {/* Manager checklist */}
             {tenantUsers.length === 0 ? (
-              <p className="text-sm text-zinc-500 mb-5">
+              <p className="text-sm text-[var(--color-fg-subtle)] mb-5">
                 No hiring manager accounts found in this tenant.
               </p>
             ) : (
@@ -183,8 +183,8 @@ export function ManagerAssignmentDialog({
                         className={`flex items-center gap-3 rounded-lg border px-3 py-2.5 cursor-pointer
                                     transition-colors
                                     ${isChecked
-                                      ? 'border-violet-600 bg-violet-950/40 text-zinc-100'
-                                      : 'border-zinc-700 bg-zinc-900 text-zinc-300 hover:border-zinc-600 hover:bg-zinc-800'
+                                      ? 'border-violet-600 bg-violet-950/40 text-[var(--color-fg)]'
+                                      : 'border-[var(--color-border)] bg-[var(--color-bg-elevated)] text-[var(--color-fg)] hover:border-[var(--color-border)] hover:bg-[var(--color-bg-input)]'
                                     }`}
                       >
                         <input
@@ -200,7 +200,7 @@ export function ManagerAssignmentDialog({
                           className={`flex-shrink-0 h-4 w-4 rounded border flex items-center justify-center
                                       ${isChecked
                                         ? 'bg-violet-600 border-violet-600'
-                                        : 'border-zinc-600 bg-zinc-800'
+                                        : 'border-[var(--color-border)] bg-[var(--color-bg-input)]'
                                       }`}
                           aria-hidden="true"
                         >
@@ -211,7 +211,7 @@ export function ManagerAssignmentDialog({
                             {user.name ?? user.email}
                           </p>
                           {user.name && (
-                            <p className="text-xs text-zinc-500 truncate">{user.email}</p>
+                            <p className="text-xs text-[var(--color-fg-subtle)] truncate">{user.email}</p>
                           )}
                         </div>
                       </label>
@@ -235,8 +235,8 @@ export function ManagerAssignmentDialog({
                 type="button"
                 onClick={handleClose}
                 disabled={isPending}
-                className="inline-flex items-center rounded-md border border-zinc-600
-                           text-zinc-400 hover:text-zinc-200 text-sm font-medium px-3 py-1.5
+                className="inline-flex items-center rounded-md border border-[var(--color-border)]
+                           text-[var(--color-fg-muted)] hover:text-[var(--color-fg)] text-sm font-medium px-3 py-1.5
                            transition-colors disabled:opacity-40"
               >
                 Cancel

--- a/src/components/roles/priority-keywords-panel.tsx
+++ b/src/components/roles/priority-keywords-panel.tsx
@@ -27,17 +27,17 @@ export function PriorityKeywordsPanel({
   const empty = items.length === 0
 
   return (
-    <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-6 mb-6">
+    <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-6 mb-6">
       <div className="flex items-center justify-between mb-3">
-        <h2 className="font-semibold text-zinc-100 flex items-center gap-2">
+        <h2 className="font-semibold text-[var(--color-fg)] flex items-center gap-2">
           <SparklesIcon className="h-4 w-4 text-yellow-400" />
           Manager Priorities
         </h2>
         {canEdit && !isManagerView && (
           <a
             href={roleEditHref}
-            className="text-xs text-zinc-400 border border-zinc-600 rounded-md px-3 py-1.5
-                       hover:bg-zinc-800 transition-colors"
+            className="text-xs text-[var(--color-fg-muted)] border border-[var(--color-border)] rounded-md px-3 py-1.5
+                       hover:bg-[var(--color-bg-input)] transition-colors"
           >
             {empty ? 'Add priorities' : 'Edit'}
           </a>
@@ -45,7 +45,7 @@ export function PriorityKeywordsPanel({
       </div>
 
       {empty ? (
-        <p className="text-sm text-zinc-500">
+        <p className="text-sm text-[var(--color-fg-subtle)]">
           {canEdit
             ? 'No manager priorities recorded for this role. Click "Add priorities" to record what the hiring manager cares about most.'
             : 'No manager priorities recorded for this role.'}
@@ -64,7 +64,7 @@ export function PriorityKeywordsPanel({
         </div>
       )}
 
-      <p className="mt-3 text-[11px] text-zinc-500">
+      <p className="mt-3 text-[11px] text-[var(--color-fg-subtle)]">
         Soft-signal priorities surfaced in AI scoring summaries. Not a numeric dimension.
       </p>
     </div>

--- a/src/components/roles/role-candidate-card.tsx
+++ b/src/components/roles/role-candidate-card.tsx
@@ -11,10 +11,10 @@ function ScorePill({ label, score }: ScorePillProps) {
   const color =
     score >= 75 ? 'bg-emerald-100 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-400 border-emerald-300 dark:border-emerald-800' :
     score >= 50 ? 'bg-blue-100 dark:bg-blue-950 text-blue-700 dark:text-blue-400 border-blue-300 dark:border-blue-800' :
-    'bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-400 border-zinc-300 dark:border-zinc-600'
+    'bg-zinc-100 dark:bg-[var(--color-bg-input)] text-zinc-700 dark:text-[var(--color-fg-muted)] border-zinc-300 dark:border-[var(--color-border)]'
   return (
     <span className={`inline-flex items-center gap-1 text-xs border rounded px-1.5 py-0.5 ${color}`}>
-      <span className="text-zinc-500">{label}</span>
+      <span className="text-[var(--color-fg-subtle)]">{label}</span>
       <span className="font-medium">{score}</span>
     </span>
   )
@@ -34,7 +34,7 @@ function MarginPill({
       className={`inline-flex items-center gap-1 text-xs border rounded-full px-2 py-0.5 ${color}`}
       title={mismatch ? `Currency mismatch: role ${roleCurrency} vs candidate ${candCurrency}` : undefined}
     >
-      <span className="text-zinc-400">Margin</span>
+      <span className="text-[var(--color-fg-muted)]">Margin</span>
       <span className="font-medium">{margin >= 0 ? '+' : ''}{roleCurrency ?? ''} {margin.toFixed(0)}/day</span>
       {mismatch && <span className="text-amber-400">⚠</span>}
     </span>
@@ -125,12 +125,12 @@ export function RoleCandidateCard({
   return (
     <Link
       href={`/dashboard/candidates/${candidateId}?roleId=${roleId}`}
-      className={`flex items-center justify-between rounded-xl bg-zinc-900 border px-5 py-4
+      className={`flex items-center justify-between rounded-xl bg-[var(--color-bg-elevated)] border px-5 py-4
                   hover:border-blue-500 hover:shadow-sm transition-all
-                  ${isPending ? 'opacity-40 pointer-events-none border-zinc-700' : 'border-zinc-700'}`}
+                  ${isPending ? 'opacity-40 pointer-events-none border-[var(--color-border)]' : 'border-[var(--color-border)]'}`}
     >
       <div className="flex-1 min-w-0">
-        <p className="font-medium text-zinc-100 flex items-center gap-2 flex-wrap">
+        <p className="font-medium text-[var(--color-fg)] flex items-center gap-2 flex-wrap">
           <span>
             {firstName} {lastName}
           </span>
@@ -147,7 +147,7 @@ export function RoleCandidateCard({
               Submitted
             </span>
           )}
-          {email && <span className="font-normal text-zinc-500 text-sm ml-1">{email}</span>}
+          {email && <span className="font-normal text-[var(--color-fg-subtle)] text-sm ml-1">{email}</span>}
         </p>
         {scoreStatus === 'complete' && technicalScore !== null && (
           <div className="flex items-center gap-2 mt-1.5 flex-wrap">
@@ -174,19 +174,19 @@ export function RoleCandidateCard({
                 width={20}
                 height={20}
                 style={{ width: 20, height: 20 }}
-                className="rounded-full border border-zinc-700 bg-zinc-800 object-contain shrink-0"
+                className="rounded-full border border-[var(--color-border)] bg-[var(--color-bg-input)] object-contain shrink-0"
               />
             ) : (
               <div
-                className="flex items-center justify-center rounded-full bg-zinc-800
-                           text-zinc-400 text-xs font-semibold shrink-0"
+                className="flex items-center justify-center rounded-full bg-[var(--color-bg-input)]
+                           text-[var(--color-fg-muted)] text-xs font-semibold shrink-0"
                 style={{ width: 20, height: 20 }}
                 aria-hidden="true"
               >
                 {agencyName.charAt(0).toUpperCase()}
               </div>
             )}
-            <span className="text-xs text-zinc-500">{agencyName}</span>
+            <span className="text-xs text-[var(--color-fg-subtle)]">{agencyName}</span>
           </div>
         )}
       </div>
@@ -198,8 +198,8 @@ export function RoleCandidateCard({
           </span>
         ) : scoreStatus === 'complete' && overallScore !== null ? (
           <div className="text-center">
-            <p className="text-xl font-bold text-zinc-100">{overallScore}</p>
-            <p className="text-xs text-zinc-500">/ 100</p>
+            <p className="text-xl font-bold text-[var(--color-fg)]">{overallScore}</p>
+            <p className="text-xs text-[var(--color-fg-subtle)]">/ 100</p>
           </div>
         ) : (
           <span className="text-xs text-red-400">Failed</span>
@@ -210,7 +210,7 @@ export function RoleCandidateCard({
             type="button"
             onClick={handleDownloadCv}
             title="Download original CV"
-            className="p-1.5 rounded-md text-zinc-600 hover:text-blue-400 hover:bg-blue-950/40
+            className="p-1.5 rounded-md text-[var(--color-fg-subtle)] hover:text-blue-400 hover:bg-blue-950/40
                        border border-transparent hover:border-blue-800 transition-colors"
           >
             <Download className="h-4 w-4" />
@@ -221,7 +221,7 @@ export function RoleCandidateCard({
           <button
             onClick={handleRemove}
             title="Remove from role"
-            className="p-1.5 rounded-md text-zinc-600 hover:text-red-400 hover:bg-red-950/40
+            className="p-1.5 rounded-md text-[var(--color-fg-subtle)] hover:text-red-400 hover:bg-red-950/40
                        border border-transparent hover:border-red-800 transition-colors"
           >
             <XIcon className="h-4 w-4" />

--- a/src/components/roles/role-content.tsx
+++ b/src/components/roles/role-content.tsx
@@ -16,33 +16,33 @@ type Props = {
  */
 export function RoleContent({ text }: Props) {
   if (!text || text.trim().length === 0) {
-    return <p className="text-sm text-zinc-500 italic">No content yet.</p>
+    return <p className="text-sm text-[var(--color-fg-subtle)] italic">No content yet.</p>
   }
 
   return (
-    <div className="text-sm text-zinc-300 leading-relaxed space-y-3">
+    <div className="text-sm text-[var(--color-fg)] leading-relaxed space-y-3">
       <ReactMarkdown
         components={{
           h1: ({ children }) => (
-            <h3 className="text-base font-semibold text-zinc-100 mt-4 mb-2">{children}</h3>
+            <h3 className="text-base font-semibold text-[var(--color-fg)] mt-4 mb-2">{children}</h3>
           ),
           h2: ({ children }) => (
-            <h3 className="text-sm font-semibold text-zinc-100 mt-4 mb-2 uppercase tracking-wide">{children}</h3>
+            <h3 className="text-sm font-semibold text-[var(--color-fg)] mt-4 mb-2 uppercase tracking-wide">{children}</h3>
           ),
           h3: ({ children }) => (
-            <h4 className="text-sm font-semibold text-zinc-200 mt-3 mb-1.5">{children}</h4>
+            <h4 className="text-sm font-semibold text-[var(--color-fg)] mt-3 mb-1.5">{children}</h4>
           ),
           h4: ({ children }) => (
-            <h5 className="text-xs font-semibold text-zinc-200 mt-2 mb-1 uppercase tracking-wide">{children}</h5>
+            <h5 className="text-xs font-semibold text-[var(--color-fg)] mt-2 mb-1 uppercase tracking-wide">{children}</h5>
           ),
-          p: ({ children }) => <p className="text-zinc-300">{children}</p>,
-          ul: ({ children }) => <ul className="list-disc pl-5 space-y-1 text-zinc-300">{children}</ul>,
-          ol: ({ children }) => <ol className="list-decimal pl-5 space-y-1 text-zinc-300">{children}</ol>,
-          li: ({ children }) => <li className="text-zinc-300">{children}</li>,
-          strong: ({ children }) => <strong className="font-semibold text-zinc-100">{children}</strong>,
-          em: ({ children }) => <em className="italic text-zinc-200">{children}</em>,
+          p: ({ children }) => <p className="text-[var(--color-fg)]">{children}</p>,
+          ul: ({ children }) => <ul className="list-disc pl-5 space-y-1 text-[var(--color-fg)]">{children}</ul>,
+          ol: ({ children }) => <ol className="list-decimal pl-5 space-y-1 text-[var(--color-fg)]">{children}</ol>,
+          li: ({ children }) => <li className="text-[var(--color-fg)]">{children}</li>,
+          strong: ({ children }) => <strong className="font-semibold text-[var(--color-fg)]">{children}</strong>,
+          em: ({ children }) => <em className="italic text-[var(--color-fg)]">{children}</em>,
           code: ({ children }) => (
-            <code className="rounded bg-zinc-800 border border-zinc-700 px-1.5 py-0.5 text-xs font-mono text-violet-300">
+            <code className="rounded bg-[var(--color-bg-input)] border border-[var(--color-border)] px-1.5 py-0.5 text-xs font-mono text-violet-300">
               {children}
             </code>
           ),
@@ -57,7 +57,7 @@ export function RoleContent({ text }: Props) {
             </a>
           ),
           blockquote: ({ children }) => (
-            <blockquote className="border-l-2 border-zinc-700 pl-3 italic text-zinc-400">{children}</blockquote>
+            <blockquote className="border-l-2 border-[var(--color-border)] pl-3 italic text-[var(--color-fg-muted)]">{children}</blockquote>
           ),
         }}
       >

--- a/src/components/roles/role-edit-form.tsx
+++ b/src/components/roles/role-edit-form.tsx
@@ -135,7 +135,7 @@ export function RoleEditForm({ role, customers = [], frameworks = {}, customerRo
 
       {customers.length > 0 && (
         <div>
-          <label htmlFor="customerId" className="block text-sm font-medium text-zinc-300 mb-1">
+          <label htmlFor="customerId" className="block text-sm font-medium text-[var(--color-fg)] mb-1">
             Customer
           </label>
           <select
@@ -155,7 +155,7 @@ export function RoleEditForm({ role, customers = [], frameworks = {}, customerRo
                 customerRoleId: '',
               }))
             }}
-            className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
                        focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
                        disabled:opacity-50"
           >
@@ -171,9 +171,9 @@ export function RoleEditForm({ role, customers = [], frameworks = {}, customerRo
 
       {fields.customerId && (
         <div>
-          <label htmlFor="customerRoleId" className="block text-sm font-medium text-zinc-300 mb-1">
+          <label htmlFor="customerRoleId" className="block text-sm font-medium text-[var(--color-fg)] mb-1">
             {customerRoleIdLabels[fields.customerId] ?? 'Customer Role ID'}{' '}
-            <span className="text-zinc-500 font-normal">(optional)</span>
+            <span className="text-[var(--color-fg-subtle)] font-normal">(optional)</span>
           </label>
           <input
             id="customerRoleId"
@@ -184,12 +184,12 @@ export function RoleEditForm({ role, customers = [], frameworks = {}, customerRo
             value={fields.customerRoleId}
             onChange={(e) => setFields((f) => ({ ...f, customerRoleId: e.target.value }))}
             placeholder="e.g. JOB-12345"
-            className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                       placeholder:text-zinc-500
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                       placeholder:text-[var(--color-fg-subtle)]
                        focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
                        disabled:opacity-50"
           />
-          <p className="mt-1 text-xs text-zinc-500">
+          <p className="mt-1 text-xs text-[var(--color-fg-subtle)]">
             The customer&apos;s identifier for this role.
           </p>
           {fieldErrors?.customerRoleId && (
@@ -213,7 +213,7 @@ export function RoleEditForm({ role, customers = [], frameworks = {}, customerRo
       />
 
       <div>
-        <label htmlFor="title" className="block text-sm font-medium text-zinc-300 mb-1">
+        <label htmlFor="title" className="block text-sm font-medium text-[var(--color-fg)] mb-1">
           Role title <span className="text-red-500">*</span>
         </label>
         <input
@@ -224,8 +224,8 @@ export function RoleEditForm({ role, customers = [], frameworks = {}, customerRo
           disabled={pending}
           value={fields.title}
           onChange={(e) => setFields((f) => ({ ...f, title: e.target.value }))}
-          className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                     placeholder:text-zinc-500
+          className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                     placeholder:text-[var(--color-fg-subtle)]
                      focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
                      disabled:opacity-50"
         />
@@ -235,7 +235,7 @@ export function RoleEditForm({ role, customers = [], frameworks = {}, customerRo
       </div>
 
       <div>
-        <label htmlFor="description" className="block text-sm font-medium text-zinc-300 mb-1">
+        <label htmlFor="description" className="block text-sm font-medium text-[var(--color-fg)] mb-1">
           Description <span className="text-red-500">*</span>
         </label>
         <textarea
@@ -246,8 +246,8 @@ export function RoleEditForm({ role, customers = [], frameworks = {}, customerRo
           disabled={pending}
           value={fields.description}
           onChange={(e) => setFields((f) => ({ ...f, description: e.target.value }))}
-          className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                     placeholder:text-zinc-500
+          className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                     placeholder:text-[var(--color-fg-subtle)]
                      focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
                      disabled:opacity-50 resize-y"
         />
@@ -257,7 +257,7 @@ export function RoleEditForm({ role, customers = [], frameworks = {}, customerRo
       </div>
 
       <div>
-        <label htmlFor="requirements" className="block text-sm font-medium text-zinc-300 mb-1">
+        <label htmlFor="requirements" className="block text-sm font-medium text-[var(--color-fg)] mb-1">
           Requirements <span className="text-red-500">*</span>
         </label>
         <textarea
@@ -268,8 +268,8 @@ export function RoleEditForm({ role, customers = [], frameworks = {}, customerRo
           disabled={pending}
           value={fields.requirements}
           onChange={(e) => setFields((f) => ({ ...f, requirements: e.target.value }))}
-          className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                     placeholder:text-zinc-500
+          className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                     placeholder:text-[var(--color-fg-subtle)]
                      focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
                      disabled:opacity-50 resize-y"
         />
@@ -279,14 +279,14 @@ export function RoleEditForm({ role, customers = [], frameworks = {}, customerRo
       </div>
 
       {/* Manager Priorities */}
-      <div className="border-t border-zinc-800 pt-4 mt-2">
-        <label htmlFor="priorityKeywords" className="block text-sm font-medium text-zinc-300 mb-1">
-          Manager Priorities <span className="text-zinc-500 font-normal">(optional)</span>
+      <div className="border-t border-[var(--color-border)] pt-4 mt-2">
+        <label htmlFor="priorityKeywords" className="block text-sm font-medium text-[var(--color-fg)] mb-1">
+          Manager Priorities <span className="text-[var(--color-fg-subtle)] font-normal">(optional)</span>
         </label>
-        <p id="priorityKeywords-help" className="text-xs text-zinc-500 mb-2">
+        <p id="priorityKeywords-help" className="text-xs text-[var(--color-fg-subtle)] mb-2">
           Soft-signal phrases the hiring manager wants prioritised. E.g.{' '}
-          <span className="text-zinc-400">&quot;Self-starting&quot;</span>,{' '}
-          <span className="text-zinc-400">&quot;Engineer who codes&quot;</span>.
+          <span className="text-[var(--color-fg-muted)]">&quot;Self-starting&quot;</span>,{' '}
+          <span className="text-[var(--color-fg-muted)]">&quot;Engineer who codes&quot;</span>.
         </p>
         <ChipInput
           id="priorityKeywords"
@@ -304,11 +304,11 @@ export function RoleEditForm({ role, customers = [], frameworks = {}, customerRo
       </div>
 
       {/* Location & Language */}
-      <div className="border-t border-zinc-800 pt-4 mt-2">
-        <p className="text-sm font-medium text-zinc-400 mb-3">Location & Language</p>
+      <div className="border-t border-[var(--color-border)] pt-4 mt-2">
+        <p className="text-sm font-medium text-[var(--color-fg-muted)] mb-3">Location & Language</p>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-3">
           <div>
-            <label htmlFor="country" className="block text-xs font-medium text-zinc-400 mb-1">Country</label>
+            <label htmlFor="country" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">Country</label>
             <input
               id="country"
               name="country"
@@ -317,12 +317,12 @@ export function RoleEditForm({ role, customers = [], frameworks = {}, customerRo
               value={fields.country}
               onChange={(e) => setFields((f) => ({ ...f, country: e.target.value }))}
               placeholder="United Kingdom"
-              className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                         placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+              className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                         placeholder:text-[var(--color-fg-subtle)] focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
             />
           </div>
           <div>
-            <label htmlFor="city" className="block text-xs font-medium text-zinc-400 mb-1">City</label>
+            <label htmlFor="city" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">City</label>
             <input
               id="city"
               name="city"
@@ -331,21 +331,21 @@ export function RoleEditForm({ role, customers = [], frameworks = {}, customerRo
               value={fields.city}
               onChange={(e) => setFields((f) => ({ ...f, city: e.target.value }))}
               placeholder="London"
-              className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                         placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+              className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                         placeholder:text-[var(--color-fg-subtle)] focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
             />
           </div>
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           <div>
-            <label htmlFor="workMode" className="block text-xs font-medium text-zinc-400 mb-1">Work Mode</label>
+            <label htmlFor="workMode" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">Work Mode</label>
             <select
               id="workMode"
               name="workMode"
               disabled={pending}
               value={fields.workMode}
               onChange={(e) => setFields((f) => ({ ...f, workMode: e.target.value }))}
-              className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
+              className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
                          focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
             >
               <option value="">— Not specified —</option>
@@ -355,8 +355,8 @@ export function RoleEditForm({ role, customers = [], frameworks = {}, customerRo
             </select>
           </div>
           <div>
-            <label htmlFor="languageRequirements" className="block text-xs font-medium text-zinc-400 mb-1">
-              Language Requirements <span className="text-zinc-600">(comma-separated)</span>
+            <label htmlFor="languageRequirements" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">
+              Language Requirements <span className="text-[var(--color-fg-subtle)]">(comma-separated)</span>
             </label>
             <input
               id="languageRequirements"
@@ -366,19 +366,19 @@ export function RoleEditForm({ role, customers = [], frameworks = {}, customerRo
               value={fields.languageRequirements}
               onChange={(e) => setFields((f) => ({ ...f, languageRequirements: e.target.value }))}
               placeholder="English, German"
-              className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                         placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+              className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                         placeholder:text-[var(--color-fg-subtle)] focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
             />
           </div>
         </div>
       </div>
 
       {/* Budget */}
-      <div className="border-t border-zinc-800 pt-4 mt-2">
-        <p className="text-sm font-medium text-zinc-400 mb-3">Budget</p>
+      <div className="border-t border-[var(--color-border)] pt-4 mt-2">
+        <p className="text-sm font-medium text-[var(--color-fg-muted)] mb-3">Budget</p>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           <div>
-            <label htmlFor="customerDayRate" className="block text-sm font-medium text-zinc-300 mb-1">
+            <label htmlFor="customerDayRate" className="block text-sm font-medium text-[var(--color-fg)] mb-1">
               Customer Day Rate
             </label>
             <input
@@ -391,12 +391,12 @@ export function RoleEditForm({ role, customers = [], frameworks = {}, customerRo
               value={fields.customerDayRate}
               onChange={(e) => setFields((f) => ({ ...f, customerDayRate: e.target.value }))}
               placeholder="850.00"
-              className="w-full rounded-md bg-zinc-950 border border-zinc-700 px-3 py-2 text-sm text-zinc-100 focus:border-blue-500 focus:outline-none disabled:opacity-50"
+              className="w-full rounded-md bg-[var(--color-bg-app)] border border-[var(--color-border)] px-3 py-2 text-sm text-[var(--color-fg)] focus:border-blue-500 focus:outline-none disabled:opacity-50"
             />
-            <p className="mt-1 text-xs text-zinc-500">Budget the client pays per day for this role.</p>
+            <p className="mt-1 text-xs text-[var(--color-fg-subtle)]">Budget the client pays per day for this role.</p>
           </div>
           <div>
-            <label htmlFor="rateCurrency" className="block text-sm font-medium text-zinc-300 mb-1">
+            <label htmlFor="rateCurrency" className="block text-sm font-medium text-[var(--color-fg)] mb-1">
               Currency
             </label>
             <select
@@ -405,7 +405,7 @@ export function RoleEditForm({ role, customers = [], frameworks = {}, customerRo
               disabled={pending}
               value={fields.rateCurrency}
               onChange={(e) => setFields((f) => ({ ...f, rateCurrency: e.target.value }))}
-              className="w-full rounded-md bg-zinc-950 border border-zinc-700 px-3 py-2 text-sm text-zinc-100 focus:border-blue-500 focus:outline-none disabled:opacity-50"
+              className="w-full rounded-md bg-[var(--color-bg-app)] border border-[var(--color-border)] px-3 py-2 text-sm text-[var(--color-fg)] focus:border-blue-500 focus:outline-none disabled:opacity-50"
             >
               <option value="">—</option>
               <option value="GBP">GBP</option>
@@ -420,12 +420,12 @@ export function RoleEditForm({ role, customers = [], frameworks = {}, customerRo
       </div>
 
       {/* Deadlines & Customer Portal */}
-      <div className="border-t border-zinc-800 pt-4 mt-2">
-        <p className="text-sm font-medium text-zinc-300 mb-3">Deadlines & Customer Portal</p>
+      <div className="border-t border-[var(--color-border)] pt-4 mt-2">
+        <p className="text-sm font-medium text-[var(--color-fg)] mb-3">Deadlines & Customer Portal</p>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-3">
           <div>
-            <label htmlFor="targetFillDate" className="block text-xs font-medium text-zinc-400 mb-1">
-              Target Fill Date <span className="text-zinc-600">(optional)</span>
+            <label htmlFor="targetFillDate" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">
+              Target Fill Date <span className="text-[var(--color-fg-subtle)]">(optional)</span>
             </label>
             <input
               id="targetFillDate"
@@ -434,13 +434,13 @@ export function RoleEditForm({ role, customers = [], frameworks = {}, customerRo
               disabled={pending}
               value={fields.targetFillDate}
               onChange={(e) => setFields((f) => ({ ...f, targetFillDate: e.target.value }))}
-              className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
+              className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
                          focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
             />
           </div>
           <div>
-            <label htmlFor="cutoffDate" className="block text-xs font-medium text-zinc-400 mb-1">
-              Cut-off Date <span className="text-zinc-600">(absolute deadline)</span>
+            <label htmlFor="cutoffDate" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">
+              Cut-off Date <span className="text-[var(--color-fg-subtle)]">(absolute deadline)</span>
             </label>
             <input
               id="cutoffDate"
@@ -449,15 +449,15 @@ export function RoleEditForm({ role, customers = [], frameworks = {}, customerRo
               disabled={pending}
               value={fields.cutoffDate}
               onChange={(e) => setFields((f) => ({ ...f, cutoffDate: e.target.value }))}
-              className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
+              className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
                          focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
             />
           </div>
         </div>
         {fields.customerId && (
           <div>
-            <label htmlFor="customerPortalPath" className="block text-xs font-medium text-zinc-400 mb-1">
-              Customer Portal Path <span className="text-zinc-600">(optional)</span>
+            <label htmlFor="customerPortalPath" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">
+              Customer Portal Path <span className="text-[var(--color-fg-subtle)]">(optional)</span>
             </label>
             <input
               id="customerPortalPath"
@@ -467,10 +467,10 @@ export function RoleEditForm({ role, customers = [], frameworks = {}, customerRo
               value={fields.customerPortalPath}
               onChange={(e) => setFields((f) => ({ ...f, customerPortalPath: e.target.value }))}
               placeholder="/jobs/12345"
-              className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                         placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+              className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                         placeholder:text-[var(--color-fg-subtle)] focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
             />
-            <p className="mt-1 text-xs text-zinc-500">
+            <p className="mt-1 text-xs text-[var(--color-fg-subtle)]">
               Path on the customer&apos;s portal for this role. Combined with the customer&apos;s base URL.
             </p>
           </div>
@@ -489,7 +489,7 @@ export function RoleEditForm({ role, customers = [], frameworks = {}, customerRo
         </button>
         <a
           href={`/dashboard/roles/${role.id}`}
-          className="text-sm text-zinc-500 hover:text-zinc-300"
+          className="text-sm text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)]"
         >
           Cancel
         </a>

--- a/src/components/roles/role-form.tsx
+++ b/src/components/roles/role-form.tsx
@@ -142,7 +142,7 @@ export function RoleForm({ customers = [], frameworks = {}, customerRoleIdLabels
         onDragOver={(e) => e.preventDefault()}
         onDrop={handleFileDrop}
         className={`relative rounded-xl border-2 border-dashed px-6 py-5 transition-colors
-          ${importing ? 'border-blue-500 bg-blue-950' : imported ? 'border-emerald-600 bg-emerald-950' : 'border-zinc-600 bg-zinc-800 hover:border-blue-500 hover:bg-blue-950/40'}`}
+          ${importing ? 'border-blue-500 bg-blue-950' : imported ? 'border-emerald-600 bg-emerald-950' : 'border-[var(--color-border)] bg-[var(--color-bg-input)] hover:border-blue-500 hover:bg-blue-950/40'}`}
       >
         <input
           ref={fileInputRef}
@@ -166,7 +166,7 @@ export function RoleForm({ customers = [], frameworks = {}, customerRoleIdLabels
             <button
               type="button"
               onClick={clearImport}
-              className="text-zinc-500 hover:text-zinc-300 ml-3"
+              className="text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)] ml-3"
               title="Clear import"
             >
               <X className="h-4 w-4" />
@@ -174,13 +174,13 @@ export function RoleForm({ customers = [], frameworks = {}, customerRoleIdLabels
           </div>
         ) : (
           <div className="flex items-center gap-4">
-            <UploadCloud className="h-6 w-6 text-zinc-500 shrink-0" />
+            <UploadCloud className="h-6 w-6 text-[var(--color-fg-subtle)] shrink-0" />
             <div>
-              <p className="text-sm font-medium text-zinc-300">
+              <p className="text-sm font-medium text-[var(--color-fg)]">
                 Import from document{' '}
-                <span className="font-normal text-zinc-500">(optional)</span>
+                <span className="font-normal text-[var(--color-fg-subtle)]">(optional)</span>
               </p>
-              <p className="text-xs text-zinc-500 mt-0.5">
+              <p className="text-xs text-[var(--color-fg-subtle)] mt-0.5">
                 Drop a PDF or DOCX job description here, or{' '}
                 <button
                   type="button"
@@ -221,7 +221,7 @@ export function RoleForm({ customers = [], frameworks = {}, customerRoleIdLabels
 
         {customers.length > 0 && (
           <div>
-            <label htmlFor="customerId" className="block text-sm font-medium text-zinc-300 mb-1">
+            <label htmlFor="customerId" className="block text-sm font-medium text-[var(--color-fg)] mb-1">
               Customer
             </label>
             <select
@@ -241,7 +241,7 @@ export function RoleForm({ customers = [], frameworks = {}, customerRoleIdLabels
                   customerRoleId: '',
                 }))
               }}
-              className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
+              className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
                          focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
                          disabled:opacity-50"
             >
@@ -257,9 +257,9 @@ export function RoleForm({ customers = [], frameworks = {}, customerRoleIdLabels
 
         {fields.customerId && (
           <div>
-            <label htmlFor="customerRoleId" className="block text-sm font-medium text-zinc-300 mb-1">
+            <label htmlFor="customerRoleId" className="block text-sm font-medium text-[var(--color-fg)] mb-1">
               {customerRoleIdLabels[fields.customerId] ?? 'Customer Role ID'}{' '}
-              <span className="text-zinc-500 font-normal">(optional)</span>
+              <span className="text-[var(--color-fg-subtle)] font-normal">(optional)</span>
             </label>
             <input
               id="customerRoleId"
@@ -270,12 +270,12 @@ export function RoleForm({ customers = [], frameworks = {}, customerRoleIdLabels
               value={fields.customerRoleId}
               onChange={(e) => setFields((f) => ({ ...f, customerRoleId: e.target.value }))}
               placeholder="e.g. JOB-12345"
-              className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                         placeholder:text-zinc-500
+              className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                         placeholder:text-[var(--color-fg-subtle)]
                          focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
                          disabled:opacity-50"
             />
-            <p className="mt-1 text-xs text-zinc-500">
+            <p className="mt-1 text-xs text-[var(--color-fg-subtle)]">
               The customer&apos;s identifier for this role.
             </p>
             {fieldErrors?.customerRoleId && (
@@ -299,7 +299,7 @@ export function RoleForm({ customers = [], frameworks = {}, customerRoleIdLabels
         />
 
         <div>
-          <label htmlFor="title" className="block text-sm font-medium text-zinc-300 mb-1">
+          <label htmlFor="title" className="block text-sm font-medium text-[var(--color-fg)] mb-1">
             Role title <span className="text-red-500">*</span>
           </label>
           <input
@@ -311,8 +311,8 @@ export function RoleForm({ customers = [], frameworks = {}, customerRoleIdLabels
             value={fields.title}
             onChange={(e) => setFields((f) => ({ ...f, title: e.target.value }))}
             placeholder="e.g. Senior TypeScript Engineer"
-            className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                       placeholder:text-zinc-500
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                       placeholder:text-[var(--color-fg-subtle)]
                        focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
                        disabled:opacity-50"
           />
@@ -322,7 +322,7 @@ export function RoleForm({ customers = [], frameworks = {}, customerRoleIdLabels
         </div>
 
         <div>
-          <label htmlFor="description" className="block text-sm font-medium text-zinc-300 mb-1">
+          <label htmlFor="description" className="block text-sm font-medium text-[var(--color-fg)] mb-1">
             Description <span className="text-red-500">*</span>
           </label>
           <textarea
@@ -334,8 +334,8 @@ export function RoleForm({ customers = [], frameworks = {}, customerRoleIdLabels
             value={fields.description}
             onChange={(e) => setFields((f) => ({ ...f, description: e.target.value }))}
             placeholder="Describe the role and responsibilities…"
-            className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                       placeholder:text-zinc-500
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                       placeholder:text-[var(--color-fg-subtle)]
                        focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
                        disabled:opacity-50 resize-y"
           />
@@ -345,7 +345,7 @@ export function RoleForm({ customers = [], frameworks = {}, customerRoleIdLabels
         </div>
 
         <div>
-          <label htmlFor="requirements" className="block text-sm font-medium text-zinc-300 mb-1">
+          <label htmlFor="requirements" className="block text-sm font-medium text-[var(--color-fg)] mb-1">
             Requirements <span className="text-red-500">*</span>
           </label>
           <textarea
@@ -357,8 +357,8 @@ export function RoleForm({ customers = [], frameworks = {}, customerRoleIdLabels
             value={fields.requirements}
             onChange={(e) => setFields((f) => ({ ...f, requirements: e.target.value }))}
             placeholder="List the key requirements, one per line…"
-            className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                       placeholder:text-zinc-500
+            className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                       placeholder:text-[var(--color-fg-subtle)]
                        focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
                        disabled:opacity-50 resize-y"
           />
@@ -368,14 +368,14 @@ export function RoleForm({ customers = [], frameworks = {}, customerRoleIdLabels
         </div>
 
         {/* Manager Priorities */}
-        <div className="border-t border-zinc-800 pt-4 mt-2">
-          <label htmlFor="priorityKeywords" className="block text-sm font-medium text-zinc-300 mb-1">
-            Manager Priorities <span className="text-zinc-500 font-normal">(optional)</span>
+        <div className="border-t border-[var(--color-border)] pt-4 mt-2">
+          <label htmlFor="priorityKeywords" className="block text-sm font-medium text-[var(--color-fg)] mb-1">
+            Manager Priorities <span className="text-[var(--color-fg-subtle)] font-normal">(optional)</span>
           </label>
-          <p id="priorityKeywords-help" className="text-xs text-zinc-500 mb-2">
+          <p id="priorityKeywords-help" className="text-xs text-[var(--color-fg-subtle)] mb-2">
             Soft-signal phrases the hiring manager wants prioritised. E.g.{' '}
-            <span className="text-zinc-400">&quot;Self-starting&quot;</span>,{' '}
-            <span className="text-zinc-400">&quot;Engineer who codes&quot;</span>.
+            <span className="text-[var(--color-fg-muted)]">&quot;Self-starting&quot;</span>,{' '}
+            <span className="text-[var(--color-fg-muted)]">&quot;Engineer who codes&quot;</span>.
           </p>
           <ChipInput
             id="priorityKeywords"
@@ -393,11 +393,11 @@ export function RoleForm({ customers = [], frameworks = {}, customerRoleIdLabels
         </div>
 
         {/* Location & Language */}
-        <div className="border-t border-zinc-800 pt-4 mt-2">
-          <p className="text-sm font-medium text-zinc-400 mb-3">Location & Language</p>
+        <div className="border-t border-[var(--color-border)] pt-4 mt-2">
+          <p className="text-sm font-medium text-[var(--color-fg-muted)] mb-3">Location & Language</p>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-3">
             <div>
-              <label htmlFor="country" className="block text-xs font-medium text-zinc-400 mb-1">Country</label>
+              <label htmlFor="country" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">Country</label>
               <input
                 id="country"
                 name="country"
@@ -406,12 +406,12 @@ export function RoleForm({ customers = [], frameworks = {}, customerRoleIdLabels
                 value={fields.country}
                 onChange={(e) => setFields((f) => ({ ...f, country: e.target.value }))}
                 placeholder="United Kingdom"
-                className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                           placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+                className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                           placeholder:text-[var(--color-fg-subtle)] focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
               />
             </div>
             <div>
-              <label htmlFor="city" className="block text-xs font-medium text-zinc-400 mb-1">City</label>
+              <label htmlFor="city" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">City</label>
               <input
                 id="city"
                 name="city"
@@ -420,21 +420,21 @@ export function RoleForm({ customers = [], frameworks = {}, customerRoleIdLabels
                 value={fields.city}
                 onChange={(e) => setFields((f) => ({ ...f, city: e.target.value }))}
                 placeholder="London"
-                className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                           placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+                className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                           placeholder:text-[var(--color-fg-subtle)] focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
               />
             </div>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             <div>
-              <label htmlFor="workMode" className="block text-xs font-medium text-zinc-400 mb-1">Work Mode</label>
+              <label htmlFor="workMode" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">Work Mode</label>
               <select
                 id="workMode"
                 name="workMode"
                 disabled={pending}
                 value={fields.workMode}
                 onChange={(e) => setFields((f) => ({ ...f, workMode: e.target.value }))}
-                className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
+                className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
                            focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
               >
                 <option value="">— Not specified —</option>
@@ -444,8 +444,8 @@ export function RoleForm({ customers = [], frameworks = {}, customerRoleIdLabels
               </select>
             </div>
             <div>
-              <label htmlFor="languageRequirements" className="block text-xs font-medium text-zinc-400 mb-1">
-                Language Requirements <span className="text-zinc-600">(comma-separated)</span>
+              <label htmlFor="languageRequirements" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">
+                Language Requirements <span className="text-[var(--color-fg-subtle)]">(comma-separated)</span>
               </label>
               <input
                 id="languageRequirements"
@@ -455,19 +455,19 @@ export function RoleForm({ customers = [], frameworks = {}, customerRoleIdLabels
                 value={fields.languageRequirements}
                 onChange={(e) => setFields((f) => ({ ...f, languageRequirements: e.target.value }))}
                 placeholder="English, German"
-                className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                           placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+                className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                           placeholder:text-[var(--color-fg-subtle)] focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
               />
             </div>
           </div>
         </div>
 
         {/* Budget */}
-        <div className="border-t border-zinc-800 pt-4 mt-2">
-          <p className="text-sm font-medium text-zinc-400 mb-3">Budget</p>
+        <div className="border-t border-[var(--color-border)] pt-4 mt-2">
+          <p className="text-sm font-medium text-[var(--color-fg-muted)] mb-3">Budget</p>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             <div>
-              <label htmlFor="customerDayRate" className="block text-sm font-medium text-zinc-300 mb-1">
+              <label htmlFor="customerDayRate" className="block text-sm font-medium text-[var(--color-fg)] mb-1">
                 Customer Day Rate
               </label>
               <input
@@ -479,12 +479,12 @@ export function RoleForm({ customers = [], frameworks = {}, customerRoleIdLabels
                 value={fields.customerDayRate}
                 onChange={(e) => setFields((f) => ({ ...f, customerDayRate: e.target.value }))}
                 placeholder="850.00"
-                className="w-full rounded-md bg-zinc-950 border border-zinc-700 px-3 py-2 text-sm text-zinc-100 focus:border-blue-500 focus:outline-none"
+                className="w-full rounded-md bg-[var(--color-bg-app)] border border-[var(--color-border)] px-3 py-2 text-sm text-[var(--color-fg)] focus:border-blue-500 focus:outline-none"
               />
-              <p className="mt-1 text-xs text-zinc-500">Budget the client pays per day for this role.</p>
+              <p className="mt-1 text-xs text-[var(--color-fg-subtle)]">Budget the client pays per day for this role.</p>
             </div>
             <div>
-              <label htmlFor="rateCurrency" className="block text-sm font-medium text-zinc-300 mb-1">
+              <label htmlFor="rateCurrency" className="block text-sm font-medium text-[var(--color-fg)] mb-1">
                 Currency
               </label>
               <select
@@ -492,7 +492,7 @@ export function RoleForm({ customers = [], frameworks = {}, customerRoleIdLabels
                 name="rateCurrency"
                 value={fields.rateCurrency}
                 onChange={(e) => setFields((f) => ({ ...f, rateCurrency: e.target.value }))}
-                className="w-full rounded-md bg-zinc-950 border border-zinc-700 px-3 py-2 text-sm text-zinc-100 focus:border-blue-500 focus:outline-none"
+                className="w-full rounded-md bg-[var(--color-bg-app)] border border-[var(--color-border)] px-3 py-2 text-sm text-[var(--color-fg)] focus:border-blue-500 focus:outline-none"
               >
                 <option value="">—</option>
                 <option value="GBP">GBP</option>
@@ -507,12 +507,12 @@ export function RoleForm({ customers = [], frameworks = {}, customerRoleIdLabels
         </div>
 
         {/* Deadlines & Customer Portal */}
-        <div className="border-t border-zinc-800 pt-4 mt-2">
-          <p className="text-sm font-medium text-zinc-400 mb-3">Deadlines & Customer Portal</p>
+        <div className="border-t border-[var(--color-border)] pt-4 mt-2">
+          <p className="text-sm font-medium text-[var(--color-fg-muted)] mb-3">Deadlines & Customer Portal</p>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-3">
             <div>
-              <label htmlFor="targetFillDate" className="block text-xs font-medium text-zinc-400 mb-1">
-                Target Fill Date <span className="text-zinc-600">(optional)</span>
+              <label htmlFor="targetFillDate" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">
+                Target Fill Date <span className="text-[var(--color-fg-subtle)]">(optional)</span>
               </label>
               <input
                 id="targetFillDate"
@@ -521,13 +521,13 @@ export function RoleForm({ customers = [], frameworks = {}, customerRoleIdLabels
                 disabled={pending}
                 value={fields.targetFillDate}
                 onChange={(e) => setFields((f) => ({ ...f, targetFillDate: e.target.value }))}
-                className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
+                className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
                            focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
               />
             </div>
             <div>
-              <label htmlFor="cutoffDate" className="block text-xs font-medium text-zinc-400 mb-1">
-                Cut-off Date <span className="text-zinc-600">(absolute deadline)</span>
+              <label htmlFor="cutoffDate" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">
+                Cut-off Date <span className="text-[var(--color-fg-subtle)]">(absolute deadline)</span>
               </label>
               <input
                 id="cutoffDate"
@@ -536,15 +536,15 @@ export function RoleForm({ customers = [], frameworks = {}, customerRoleIdLabels
                 disabled={pending}
                 value={fields.cutoffDate}
                 onChange={(e) => setFields((f) => ({ ...f, cutoffDate: e.target.value }))}
-                className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
+                className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
                            focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
               />
             </div>
           </div>
           {fields.customerId && (
             <div>
-              <label htmlFor="customerPortalPath" className="block text-xs font-medium text-zinc-400 mb-1">
-                Customer Portal Path <span className="text-zinc-600">(optional)</span>
+              <label htmlFor="customerPortalPath" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1">
+                Customer Portal Path <span className="text-[var(--color-fg-subtle)]">(optional)</span>
               </label>
               <input
                 id="customerPortalPath"
@@ -554,10 +554,10 @@ export function RoleForm({ customers = [], frameworks = {}, customerRoleIdLabels
                 value={fields.customerPortalPath}
                 onChange={(e) => setFields((f) => ({ ...f, customerPortalPath: e.target.value }))}
                 placeholder="/jobs/12345"
-                className="w-full rounded-md border border-zinc-600 bg-zinc-800 text-zinc-100 px-3 py-2 text-sm
-                           placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+                className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
+                           placeholder:text-[var(--color-fg-subtle)] focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
               />
-              <p className="mt-1 text-xs text-zinc-500">
+              <p className="mt-1 text-xs text-[var(--color-fg-subtle)]">
                 Path on the customer&apos;s portal for this role. Combined with the customer&apos;s base URL.
               </p>
             </div>
@@ -574,7 +574,7 @@ export function RoleForm({ customers = [], frameworks = {}, customerRoleIdLabels
             {pending && <Loader2 className="h-4 w-4 animate-spin" />}
             {pending ? 'Creating…' : 'Create role'}
           </button>
-          <a href="/dashboard/roles" className="text-sm text-zinc-500 hover:text-zinc-300">
+          <a href="/dashboard/roles" className="text-sm text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)]">
             Cancel
           </a>
         </div>

--- a/src/components/roles/role-meta-bar.tsx
+++ b/src/components/roles/role-meta-bar.tsx
@@ -102,8 +102,8 @@ export function RoleMetaBar({ role, customer, portalUrl, customerRoleId, custome
       )}
 
       {location && (
-        <span className="inline-flex items-center gap-1.5 rounded-full border border-zinc-700 bg-zinc-800 text-zinc-300 text-xs font-medium px-2.5 py-1">
-          <MapPinIcon className="h-3 w-3 text-zinc-500" />
+        <span className="inline-flex items-center gap-1.5 rounded-full border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] text-xs font-medium px-2.5 py-1">
+          <MapPinIcon className="h-3 w-3 text-[var(--color-fg-subtle)]" />
           {location}
         </span>
       )}
@@ -121,9 +121,9 @@ export function RoleMetaBar({ role, customer, portalUrl, customerRoleId, custome
       {customer && (
         <Link
           href={`/dashboard/customers/${customer.id}`}
-          className="inline-flex items-center gap-1.5 rounded-full border border-zinc-700 bg-zinc-800 text-zinc-300 text-xs font-medium px-2.5 py-1 hover:bg-zinc-700 hover:text-zinc-100 transition-colors"
+          className="inline-flex items-center gap-1.5 rounded-full border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] text-xs font-medium px-2.5 py-1 hover:bg-[var(--color-border)] hover:text-[var(--color-fg)] transition-colors"
         >
-          <UsersIcon className="h-3 w-3 text-zinc-500" />
+          <UsersIcon className="h-3 w-3 text-[var(--color-fg-subtle)]" />
           {customer.name}
         </Link>
       )}
@@ -150,8 +150,8 @@ export function RoleMetaBar({ role, customer, portalUrl, customerRoleId, custome
       )}
 
       {role.targetFillDate && (
-        <span className="inline-flex items-center gap-1.5 rounded-full border border-zinc-700 bg-zinc-800 text-zinc-300 text-xs font-medium px-2.5 py-1">
-          <CalendarIcon className="h-3 w-3 text-zinc-500" />
+        <span className="inline-flex items-center gap-1.5 rounded-full border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] text-xs font-medium px-2.5 py-1">
+          <CalendarIcon className="h-3 w-3 text-[var(--color-fg-subtle)]" />
           Fill by {fmtDate(role.targetFillDate)}
         </span>
       )}

--- a/src/components/roles/role-tags-panel.tsx
+++ b/src/components/roles/role-tags-panel.tsx
@@ -27,16 +27,16 @@ export function RoleTagsPanel({ keySkills, topRequirements, canEdit, audience = 
   }
 
   return (
-    <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-6 mb-6">
+    <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-6 mb-6">
       <div className="flex items-center justify-between mb-4">
-        <h2 className="font-semibold text-zinc-100">Skills &amp; Requirements</h2>
+        <h2 className="font-semibold text-[var(--color-fg)]">Skills &amp; Requirements</h2>
         {canEdit && !isManagerView && (
           <button
             type="button"
             onClick={handleRegenerate}
             disabled={isPending}
-            className="flex items-center gap-1.5 text-xs text-zinc-400 border border-zinc-600
-                       rounded-md px-3 py-1.5 hover:bg-zinc-800 disabled:opacity-50 transition-colors"
+            className="flex items-center gap-1.5 text-xs text-[var(--color-fg-muted)] border border-[var(--color-border)]
+                       rounded-md px-3 py-1.5 hover:bg-[var(--color-bg-input)] disabled:opacity-50 transition-colors"
           >
             {isPending ? (
               <Loader2Icon className="h-3.5 w-3.5 animate-spin" />
@@ -49,7 +49,7 @@ export function RoleTagsPanel({ keySkills, topRequirements, canEdit, audience = 
       </div>
 
       {isPending && (
-        <p className="text-sm text-zinc-500 mb-4">
+        <p className="text-sm text-[var(--color-fg-subtle)] mb-4">
           AI is extracting tags — this page will refresh in a few seconds…
         </p>
       )}
@@ -61,7 +61,7 @@ export function RoleTagsPanel({ keySkills, topRequirements, canEdit, audience = 
       )}
 
       {hasNoTags && !isPending ? (
-        <p className="text-sm text-zinc-500">
+        <p className="text-sm text-[var(--color-fg-subtle)]">
           {canEdit
             ? 'No tags yet. Click "Generate tags" to extract skills and requirements using AI.'
             : 'No tags extracted yet.'}
@@ -70,7 +70,7 @@ export function RoleTagsPanel({ keySkills, topRequirements, canEdit, audience = 
         <div className="space-y-4">
           {keySkills.length > 0 && (
             <div>
-              <p className="text-xs font-medium text-zinc-500 uppercase tracking-wide mb-2">
+              <p className="text-xs font-medium text-[var(--color-fg-subtle)] uppercase tracking-wide mb-2">
                 Key Skills
               </p>
               <div className="flex flex-wrap gap-2">
@@ -89,7 +89,7 @@ export function RoleTagsPanel({ keySkills, topRequirements, canEdit, audience = 
 
           {topRequirements.length > 0 && (
             <div>
-              <p className="text-xs font-medium text-zinc-500 uppercase tracking-wide mb-2">
+              <p className="text-xs font-medium text-[var(--color-fg-subtle)] uppercase tracking-wide mb-2">
                 Top Requirements
               </p>
               <div className="flex flex-wrap gap-2">

--- a/src/components/roles/selectable-role-candidate-list.tsx
+++ b/src/components/roles/selectable-role-candidate-list.tsx
@@ -81,7 +81,7 @@ export function SelectableRoleCandidateList({
                   type="checkbox"
                   checked={selectedIds.has(c.candidateId)}
                   onChange={() => toggleOne(c.candidateId)}
-                  className="h-4 w-4 rounded border-zinc-600 bg-zinc-800 text-blue-600
+                  className="h-4 w-4 rounded border-[var(--color-border)] bg-[var(--color-bg-input)] text-blue-600
                              cursor-pointer focus:ring-blue-500 flex-shrink-0"
                   aria-label={`Select ${c.firstName} ${c.lastName}`}
                   title={selectedIds.has(c.candidateId) ? 'Deselect candidate' : 'Select candidate'}

--- a/src/components/roles/send-for-approval-button.tsx
+++ b/src/components/roles/send-for-approval-button.tsx
@@ -53,8 +53,8 @@ export function SendForApprovalButton({
           disabled
           aria-label="Shortlist already sent for approval"
           title="Shortlist already sent for manager approval"
-          className="inline-flex items-center gap-1.5 rounded-md border border-zinc-700
-                     bg-zinc-800 text-zinc-500 text-sm font-medium px-3 py-1.5
+          className="inline-flex items-center gap-1.5 rounded-md border border-[var(--color-border)]
+                     bg-[var(--color-bg-input)] text-[var(--color-fg-subtle)] text-sm font-medium px-3 py-1.5
                      cursor-not-allowed opacity-60"
         >
           <CheckIcon className="h-3.5 w-3.5" />
@@ -87,8 +87,8 @@ export function SendForApprovalButton({
             type="button"
             onClick={handleCancel}
             disabled={isPending}
-            className="inline-flex items-center gap-1 rounded-md border border-zinc-600
-                       text-zinc-400 hover:text-zinc-200 text-xs font-medium px-2.5 py-1.5
+            className="inline-flex items-center gap-1 rounded-md border border-[var(--color-border)]
+                       text-[var(--color-fg-muted)] hover:text-[var(--color-fg)] text-xs font-medium px-2.5 py-1.5
                        transition-colors disabled:opacity-50"
           >
             <XIcon className="h-3 w-3" />

--- a/src/components/roles/sent-to-customer-panel.tsx
+++ b/src/components/roles/sent-to-customer-panel.tsx
@@ -10,16 +10,16 @@ export function SentToCustomerPanel({ submissions, audience }: Props) {
   if (audience !== 'recruiter') return null
 
   return (
-    <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-6 mt-6">
+    <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-6 mt-6">
       <div className="flex items-center gap-2 mb-4">
-        <h2 className="text-sm font-semibold text-zinc-300 uppercase tracking-wide">
+        <h2 className="text-sm font-semibold text-[var(--color-fg)] uppercase tracking-wide">
           Sent to Customer
         </h2>
-        <span className="text-sm text-zinc-500">({submissions.length})</span>
+        <span className="text-sm text-[var(--color-fg-subtle)]">({submissions.length})</span>
       </div>
 
       {submissions.length === 0 ? (
-        <p className="text-sm text-zinc-500">
+        <p className="text-sm text-[var(--color-fg-subtle)]">
           No candidates submitted to the customer yet. Tick candidates above and click &ldquo;Submit to customer&rdquo;.
         </p>
       ) : (

--- a/src/components/roles/shortlist-summary-panel.tsx
+++ b/src/components/roles/shortlist-summary-panel.tsx
@@ -29,11 +29,11 @@ export function ShortlistSummaryPanel({ roleId }: Props) {
   }
 
   return (
-    <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-6 mt-6">
+    <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-6 mt-6">
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
           <SparklesIcon className="h-4 w-4 text-violet-400" />
-          <h2 className="font-semibold text-zinc-100">AI Hiring Recommendation</h2>
+          <h2 className="font-semibold text-[var(--color-fg)]">AI Hiring Recommendation</h2>
         </div>
         <button
           onClick={handleGenerate}
@@ -58,13 +58,13 @@ export function ShortlistSummaryPanel({ roleId }: Props) {
       </div>
 
       {!summary && !error && !isPending && (
-        <p className="text-zinc-500 text-sm">
+        <p className="text-[var(--color-fg-subtle)] text-sm">
           Generate an AI-powered narrative summary comparing the top candidates for this role.
         </p>
       )}
 
       {isPending && (
-        <div className="flex items-center gap-3 text-zinc-400 text-sm py-4">
+        <div className="flex items-center gap-3 text-[var(--color-fg-muted)] text-sm py-4">
           <Loader2Icon className="h-4 w-4 animate-spin flex-shrink-0" />
           <span>Analysing top candidates and generating hiring recommendation…</span>
         </div>
@@ -78,7 +78,7 @@ export function ShortlistSummaryPanel({ roleId }: Props) {
 
       {summary && (
         <div className="rounded-xl bg-violet-950/30 border border-violet-800 p-5">
-          <div className="text-sm text-zinc-300 leading-relaxed space-y-3 [&_h1]:text-base [&_h1]:font-semibold [&_h1]:text-zinc-100 [&_h1]:mb-1 [&_h2]:text-sm [&_h2]:font-semibold [&_h2]:text-zinc-100 [&_h2]:mb-1 [&_h3]:text-sm [&_h3]:font-semibold [&_h3]:text-zinc-200 [&_strong]:text-zinc-100 [&_strong]:font-semibold [&_ul]:space-y-1 [&_ul]:pl-4 [&_ul>li]:list-disc [&_ul>li]:marker:text-violet-400 [&_ol]:space-y-1 [&_ol]:pl-4 [&_ol>li]:list-decimal [&_ol>li]:marker:text-violet-400 [&_p]:leading-relaxed">
+          <div className="text-sm text-[var(--color-fg)] leading-relaxed space-y-3 [&_h1]:text-base [&_h1]:font-semibold [&_h1]:text-[var(--color-fg)] [&_h1]:mb-1 [&_h2]:text-sm [&_h2]:font-semibold [&_h2]:text-[var(--color-fg)] [&_h2]:mb-1 [&_h3]:text-sm [&_h3]:font-semibold [&_h3]:text-[var(--color-fg)] [&_strong]:text-[var(--color-fg)] [&_strong]:font-semibold [&_ul]:space-y-1 [&_ul]:pl-4 [&_ul>li]:list-disc [&_ul>li]:marker:text-violet-400 [&_ol]:space-y-1 [&_ol]:pl-4 [&_ol>li]:list-decimal [&_ol>li]:marker:text-violet-400 [&_p]:leading-relaxed">
             <ReactMarkdown>{summary}</ReactMarkdown>
           </div>
         </div>

--- a/src/components/roles/submission-row.tsx
+++ b/src/components/roles/submission-row.tsx
@@ -137,8 +137,8 @@ export function SubmissionRow({ submission }: Props) {
 
   return (
     <div
-      className={`flex items-start justify-between gap-4 px-4 py-3 rounded-lg bg-zinc-800/50
-                  border border-zinc-700/50 transition-opacity ${isPending ? 'opacity-60' : ''}`}
+      className={`flex items-start justify-between gap-4 px-4 py-3 rounded-lg bg-[var(--color-bg-input)]/50
+                  border border-[var(--color-border)]/50 transition-opacity ${isPending ? 'opacity-60' : ''}`}
     >
       {/* Left: candidate identity + agency */}
       <div className="flex-1 min-w-0">
@@ -151,12 +151,12 @@ export function SubmissionRow({ submission }: Props) {
                 width={20}
                 height={20}
                 style={{ width: 20, height: 20 }}
-                className="rounded-full border border-zinc-700 bg-zinc-800 object-contain shrink-0"
+                className="rounded-full border border-[var(--color-border)] bg-[var(--color-bg-input)] object-contain shrink-0"
               />
             ) : candidate.agencyName ? (
               <div
-                className="flex items-center justify-center rounded-full bg-zinc-800
-                           text-zinc-400 text-xs font-semibold shrink-0"
+                className="flex items-center justify-center rounded-full bg-[var(--color-bg-input)]
+                           text-[var(--color-fg-muted)] text-xs font-semibold shrink-0"
                 style={{ width: 20, height: 20 }}
                 aria-hidden="true"
               >
@@ -167,20 +167,20 @@ export function SubmissionRow({ submission }: Props) {
 
           <Link
             href={`/dashboard/candidates/${submission.candidateId}?roleId=${submission.roleId}`}
-            className="text-sm font-medium text-zinc-100 hover:text-blue-400 transition-colors"
+            className="text-sm font-medium text-[var(--color-fg)] hover:text-blue-400 transition-colors"
           >
             {candidate.firstName} {candidate.lastName}
           </Link>
 
           {candidate.agencyName && (
-            <span className="text-xs text-zinc-500">{candidate.agencyName}</span>
+            <span className="text-xs text-[var(--color-fg-subtle)]">{candidate.agencyName}</span>
           )}
         </div>
 
         {/* Middle: pill + timing */}
         <div className="flex items-center gap-2 mt-1.5 flex-wrap">
           <SubmissionStatusPill status={currentStatus} />
-          <span className="text-xs text-zinc-500">
+          <span className="text-xs text-[var(--color-fg-subtle)]">
             Sent {timeAgo(sentAt)}, last update {timeAgo(statusUpdatedAt)}
           </span>
         </div>
@@ -194,7 +194,7 @@ export function SubmissionRow({ submission }: Props) {
               rows={3}
               placeholder="Add notes (visible to recruiters only)"
               disabled={isPending}
-              className="w-full rounded-md border border-zinc-600 bg-zinc-900 text-zinc-200
+              className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-elevated)] text-[var(--color-fg)]
                          text-xs px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-500
                          disabled:opacity-50 resize-none"
             />
@@ -213,7 +213,7 @@ export function SubmissionRow({ submission }: Props) {
                 type="button"
                 onClick={() => setNotesOpen(false)}
                 disabled={isPending}
-                className="text-xs text-zinc-400 hover:text-zinc-200 transition-colors"
+                className="text-xs text-[var(--color-fg-muted)] hover:text-[var(--color-fg)] transition-colors"
               >
                 Cancel
               </button>
@@ -235,7 +235,7 @@ export function SubmissionRow({ submission }: Props) {
             onChange={handleStatusChange}
             disabled={isPending}
             aria-label={`Update status for ${candidate.firstName} ${candidate.lastName}`}
-            className="appearance-none rounded-md border border-zinc-600 bg-zinc-800 text-zinc-200
+            className="appearance-none rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)]
                        text-xs px-2.5 py-1.5 pr-6 focus:outline-none focus:ring-1 focus:ring-blue-500
                        focus:border-transparent disabled:opacity-50 cursor-pointer"
           >
@@ -246,7 +246,7 @@ export function SubmissionRow({ submission }: Props) {
             ))}
           </select>
           <svg
-            className="absolute right-1 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-zinc-500 pointer-events-none"
+            className="absolute right-1 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-[var(--color-fg-subtle)] pointer-events-none"
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
@@ -261,8 +261,8 @@ export function SubmissionRow({ submission }: Props) {
           type="button"
           onClick={() => setNotesOpen((v) => !v)}
           disabled={isPending}
-          className="text-xs text-zinc-400 hover:text-zinc-200 transition-colors px-1.5 py-1
-                     rounded border border-transparent hover:border-zinc-600"
+          className="text-xs text-[var(--color-fg-muted)] hover:text-[var(--color-fg)] transition-colors px-1.5 py-1
+                     rounded border border-transparent hover:border-[var(--color-border)]"
           aria-label="Toggle notes"
           title={submission.notes ? 'Edit notes' : 'Add notes'}
         >
@@ -278,8 +278,8 @@ export function SubmissionRow({ submission }: Props) {
               onClick={handleCopyLink}
               title="Copy customer share link"
               aria-label="Copy share link to clipboard"
-              className="inline-flex items-center gap-1 text-xs text-zinc-400 hover:text-zinc-200
-                         px-1.5 py-1 rounded border border-transparent hover:border-zinc-600
+              className="inline-flex items-center gap-1 text-xs text-[var(--color-fg-muted)] hover:text-[var(--color-fg)]
+                         px-1.5 py-1 rounded border border-transparent hover:border-[var(--color-border)]
                          transition-colors"
             >
               {copied ? (
@@ -311,7 +311,7 @@ export function SubmissionRow({ submission }: Props) {
                   type="button"
                   onClick={() => setRevokeConfirming(false)}
                   disabled={isPending}
-                  className="text-xs text-zinc-400 hover:text-zinc-200 transition-colors"
+                  className="text-xs text-[var(--color-fg-muted)] hover:text-[var(--color-fg)] transition-colors"
                 >
                   No
                 </button>
@@ -321,7 +321,7 @@ export function SubmissionRow({ submission }: Props) {
                 type="button"
                 onClick={() => setRevokeConfirming(true)}
                 disabled={isPending}
-                className="text-xs text-zinc-600 hover:text-amber-400 transition-colors"
+                className="text-xs text-[var(--color-fg-subtle)] hover:text-amber-400 transition-colors"
                 title="Revoke share link"
               >
                 Revoke
@@ -336,8 +336,8 @@ export function SubmissionRow({ submission }: Props) {
             disabled={isGenerating || isPending}
             title="Generate a share link for this submission"
             aria-label={`Share ${candidate.firstName} ${candidate.lastName}'s submission with customer`}
-            className="inline-flex items-center gap-1 text-xs text-zinc-400 hover:text-zinc-200
-                       px-1.5 py-1 rounded border border-transparent hover:border-zinc-600
+            className="inline-flex items-center gap-1 text-xs text-[var(--color-fg-muted)] hover:text-[var(--color-fg)]
+                       px-1.5 py-1 rounded border border-transparent hover:border-[var(--color-border)]
                        transition-colors disabled:opacity-50"
           >
             {isGenerating ? (
@@ -370,7 +370,7 @@ export function SubmissionRow({ submission }: Props) {
               type="button"
               onClick={() => setRemoveConfirming(false)}
               disabled={isPending}
-              className="text-xs text-zinc-400 hover:text-zinc-200 transition-colors"
+              className="text-xs text-[var(--color-fg-muted)] hover:text-[var(--color-fg)] transition-colors"
             >
               No
             </button>
@@ -382,7 +382,7 @@ export function SubmissionRow({ submission }: Props) {
             disabled={isPending}
             title="Remove from submitted"
             aria-label={`Remove ${candidate.firstName} ${candidate.lastName} from submitted`}
-            className="p-2 md:p-1 rounded-md text-zinc-600 hover:text-red-400 hover:bg-red-950/40
+            className="p-2 md:p-1 rounded-md text-[var(--color-fg-subtle)] hover:text-red-400 hover:bg-red-950/40
                        border border-transparent hover:border-red-800 transition-colors"
           >
             <Trash2Icon className="h-3.5 w-3.5" />

--- a/src/components/roles/submit-to-customer-button.tsx
+++ b/src/components/roles/submit-to-customer-button.tsx
@@ -76,15 +76,15 @@ export function SubmitToCustomerButton({ roleId, selectedCandidateIds, onSuccess
           aria-label="Submit candidates to customer"
         >
           <div
-            className="relative bg-zinc-950 border border-zinc-700 rounded-xl p-6
+            className="relative bg-[var(--color-bg-app)] border border-[var(--color-border)] rounded-xl p-6
                         max-w-md w-[calc(100vw-2rem)] shadow-xl"
             onClick={(e) => e.stopPropagation()}
           >
             {/* Header */}
             <div className="flex items-center justify-between mb-5">
               <div>
-                <h2 className="text-base font-semibold text-zinc-100">Submit to customer</h2>
-                <p className="text-xs text-zinc-500 mt-0.5">
+                <h2 className="text-base font-semibold text-[var(--color-fg)]">Submit to customer</h2>
+                <p className="text-xs text-[var(--color-fg-subtle)] mt-0.5">
                   Submit {selectedCandidateIds.length} candidate{selectedCandidateIds.length !== 1 ? 's' : ''} to the customer for this role.
                 </p>
               </div>
@@ -92,7 +92,7 @@ export function SubmitToCustomerButton({ roleId, selectedCandidateIds, onSuccess
                 type="button"
                 onClick={handleClose}
                 disabled={isPending}
-                className="p-2 md:p-1 rounded text-zinc-500 hover:text-zinc-300 disabled:opacity-40 transition-colors"
+                className="p-2 md:p-1 rounded text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)] disabled:opacity-40 transition-colors"
                 aria-label="Close"
               >
                 <XIcon className="h-4 w-4" />
@@ -101,8 +101,8 @@ export function SubmitToCustomerButton({ roleId, selectedCandidateIds, onSuccess
 
             {/* Optional notes */}
             <div className="mb-5">
-              <label htmlFor="stc-notes" className="block text-xs font-medium text-zinc-400 mb-1.5">
-                Notes <span className="text-zinc-600">(optional, visible to recruiters only)</span>
+              <label htmlFor="stc-notes" className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1.5">
+                Notes <span className="text-[var(--color-fg-subtle)]">(optional, visible to recruiters only)</span>
               </label>
               <textarea
                 id="stc-notes"
@@ -111,7 +111,7 @@ export function SubmitToCustomerButton({ roleId, selectedCandidateIds, onSuccess
                 rows={3}
                 placeholder="Optional notes (visible only to recruiters)"
                 disabled={isPending}
-                className="w-full rounded-md border border-zinc-700 bg-zinc-900 text-zinc-100
+                className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-elevated)] text-[var(--color-fg)]
                            text-sm px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-500
                            disabled:opacity-50 resize-none"
               />
@@ -130,9 +130,9 @@ export function SubmitToCustomerButton({ roleId, selectedCandidateIds, onSuccess
                 type="button"
                 onClick={handleClose}
                 disabled={isPending}
-                className="rounded-md border border-zinc-700 bg-zinc-800 text-zinc-300
+                className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)]
                            text-sm font-medium px-4 py-2
-                           hover:bg-zinc-700 hover:text-zinc-100 disabled:opacity-50
+                           hover:bg-[var(--color-border)] hover:text-[var(--color-fg)] disabled:opacity-50
                            transition-colors"
               >
                 Cancel

--- a/src/components/roles/suggest-candidates-panel.tsx
+++ b/src/components/roles/suggest-candidates-panel.tsx
@@ -26,7 +26,7 @@ function SimilarityBadge({ similarity }: { similarity: number }) {
       ? 'bg-green-950 border border-green-700 text-green-300'
       : similarity >= 50
         ? 'bg-blue-950 border border-blue-700 text-blue-300'
-        : 'bg-zinc-800 border border-zinc-600 text-zinc-400'
+        : 'bg-[var(--color-bg-input)] border border-[var(--color-border)] text-[var(--color-fg-muted)]'
 
   return (
     <span className={`inline-flex items-center rounded-full text-xs font-medium px-2.5 py-0.5 ${colorClass}`}>
@@ -65,11 +65,11 @@ export function SuggestCandidatesPanel({ roleId, roleText }: Props) {
   }
 
   return (
-    <div className="bg-zinc-900 rounded-xl border border-zinc-700 p-6 mb-6">
+    <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-6 mb-6">
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
           <SparklesIcon className="h-4 w-4 text-violet-400" />
-          <h2 className="font-semibold text-zinc-100">Matching candidates from archive</h2>
+          <h2 className="font-semibold text-[var(--color-fg)]">Matching candidates from archive</h2>
         </div>
         <button
           onClick={handleFind}
@@ -88,19 +88,19 @@ export function SuggestCandidatesPanel({ roleId, roleText }: Props) {
       </div>
 
       {candidates === null && !isPending && (
-        <p className="text-zinc-500 text-sm">
+        <p className="text-[var(--color-fg-subtle)] text-sm">
           Click the button above to find archived candidates who might be a good fit for this role.
         </p>
       )}
 
       {notEnoughData && candidates !== null && candidates.length === 0 && (
-        <p className="text-zinc-500 text-sm">
+        <p className="text-[var(--color-fg-subtle)] text-sm">
           Not enough candidate data yet. Upload more CVs to enable matching.
         </p>
       )}
 
       {candidates !== null && candidates.length === 0 && !notEnoughData && (
-        <p className="text-zinc-500 text-sm">No matching candidates found in archive.</p>
+        <p className="text-[var(--color-fg-subtle)] text-sm">No matching candidates found in archive.</p>
       )}
 
       {candidates !== null && candidates.length > 0 && (
@@ -108,19 +108,19 @@ export function SuggestCandidatesPanel({ roleId, roleText }: Props) {
           {candidates.map((c) => (
             <div
               key={c.id}
-              className="flex items-center justify-between rounded-lg bg-zinc-800 border border-zinc-700
+              className="flex items-center justify-between rounded-lg bg-[var(--color-bg-input)] border border-[var(--color-border)]
                          px-4 py-3 gap-3"
             >
               <div className="flex items-center gap-3 min-w-0">
                 <div className="min-w-0">
                   <Link
                     href={`/dashboard/candidates/${c.id}?roleId=${roleId}`}
-                    className="text-sm font-medium text-zinc-100 hover:text-violet-300 transition-colors truncate block"
+                    className="text-sm font-medium text-[var(--color-fg)] hover:text-violet-300 transition-colors truncate block"
                   >
                     {c.firstName} {c.lastName}
                   </Link>
                   {c.email && (
-                    <p className="text-xs text-zinc-500 truncate">{c.email}</p>
+                    <p className="text-xs text-[var(--color-fg-subtle)] truncate">{c.email}</p>
                   )}
                 </div>
                 <SimilarityBadge similarity={c.similarity} />
@@ -131,7 +131,7 @@ export function SuggestCandidatesPanel({ roleId, roleText }: Props) {
                     href={`/api/candidates/${c.id}/cv`}
                     download
                     title="Download original CV"
-                    className="rounded p-1.5 text-zinc-600 hover:text-blue-400 hover:bg-blue-950/40
+                    className="rounded p-1.5 text-[var(--color-fg-subtle)] hover:text-blue-400 hover:bg-blue-950/40
                                border border-transparent hover:border-blue-800 transition-colors"
                   >
                     <Download className="h-4 w-4" />
@@ -143,8 +143,8 @@ export function SuggestCandidatesPanel({ roleId, roleText }: Props) {
                   <button
                     onClick={() => handleScore(c.id)}
                     disabled={scoringId === c.id}
-                    className="flex items-center gap-1.5 rounded-md bg-zinc-700 text-zinc-200 text-xs
-                               font-medium px-3 py-1.5 hover:bg-zinc-600 transition-colors
+                    className="flex items-center gap-1.5 rounded-md bg-[var(--color-border)] text-[var(--color-fg)] text-xs
+                               font-medium px-3 py-1.5 hover:bg-[var(--color-bg-input)] transition-colors
                                disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     {scoringId === c.id ? (


### PR DESCRIPTION
Third of 5 phased PRs for [Epic #103](https://github.com/olafkfreund/SkillAi/issues/103). ~210 conversions across 21 files via 2 parallel agents. Light-mode-side `bg-zinc-100 text-zinc-700` values inside `dark:` pill patterns retained (correct). Saturated solid buttons left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)