### PR TITLE
fix(ai): unify all helpers to use resolveAnthropicKey(tenantId) (closes #40)

### DIFF
--- a/src/actions/enrichment.ts
+++ b/src/actions/enrichment.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from 'next/cache'
 import Anthropic from '@anthropic-ai/sdk'
+import { resolveAnthropicKey } from '@/lib/ai/keys'
 import { eq, and } from 'drizzle-orm'
 import { withTenant } from '@/db'
 import { candidates, candidateEnrichments, cvProfiles } from '@/db/schema'
@@ -264,12 +265,6 @@ async function fetchStackOverflowProfile(url: string): Promise<StackOverflowProf
 
 const PERSONAL_SITE_INPUT_CHAR_CAP = 3000
 
-const personalSiteAnthropic = new Anthropic({
-  apiKey: process.env.ANTHROPIC_API_KEY,
-  maxRetries: 2,
-  timeout: 30_000,
-})
-
 async function fetchPersonalSiteSummary(
   url: string,
   candidateName: string,
@@ -309,6 +304,16 @@ async function fetchPersonalSiteSummary(
 
   let aiSummary = ''
   try {
+    let personalSiteApiKey: string
+    if (tenantId) {
+      personalSiteApiKey = await resolveAnthropicKey(tenantId)
+    } else {
+      console.warn('[enrichment] no tenantId — falling back to env API key')
+      const envKey = process.env.ANTHROPIC_API_KEY
+      if (!envKey) throw new Error('No Anthropic API key configured')
+      personalSiteApiKey = envKey
+    }
+    const personalSiteAnthropic = new Anthropic({ apiKey: personalSiteApiKey, maxRetries: 2, timeout: 30_000 })
     const startedAt = Date.now()
     const response = await personalSiteAnthropic.messages.create({
       model: 'claude-haiku-4-5-20251001',

--- a/src/lib/ai/claude.ts
+++ b/src/lib/ai/claude.ts
@@ -7,15 +7,10 @@
  */
 
 import Anthropic from '@anthropic-ai/sdk'
+import { resolveAnthropicKey } from './keys'
 import { CandidateScoreSchema, type CandidateScore } from './schema'
 import { formatManagerPriorities } from './priorities'
 import { logAiUsage, anthropicUsageToInput } from './usage-logger'
-
-const anthropic = new Anthropic({
-  apiKey: process.env.ANTHROPIC_API_KEY,
-  timeout: 120_000,
-  maxRetries: 3,
-})
 
 const SCORING_TOOL: Anthropic.Tool = {
   name: 'submit_candidate_score',
@@ -89,6 +84,8 @@ type ScoringInput = {
 }
 
 export async function scoreCandidateWithClaude(input: ScoringInput): Promise<CandidateScore> {
+  const apiKey = await resolveAnthropicKey(input.tenantId)
+  const anthropic = new Anthropic({ apiKey, timeout: 120_000, maxRetries: 3 })
   const startedAt = Date.now()
   const response = await anthropic.messages.create({
     model: 'claude-sonnet-4-6',

--- a/src/lib/ai/cv-reformat.ts
+++ b/src/lib/ai/cv-reformat.ts
@@ -13,13 +13,8 @@ import Anthropic from '@anthropic-ai/sdk'
 import { eq } from 'drizzle-orm'
 import { withTenant } from '@/db'
 import { candidates } from '@/db/schema'
+import { resolveAnthropicKey } from './keys'
 import { logAiUsage, anthropicUsageToInput } from './usage-logger'
-
-const anthropic = new Anthropic({
-  apiKey: process.env.ANTHROPIC_API_KEY,
-  maxRetries: 3,
-  timeout: 120_000,
-})
 
 const REFORMAT_TOOL: Anthropic.Tool = {
   name: 'submit_formatted_cv',
@@ -53,6 +48,8 @@ export async function reformatCvText(
   const truncated = cvText.length > MAX_INPUT_CHARS
   const input = truncated ? cvText.slice(0, MAX_INPUT_CHARS) : cvText
 
+  const apiKey = await resolveAnthropicKey(tenantId)
+  const anthropic = new Anthropic({ apiKey, maxRetries: 3, timeout: 120_000 })
   const startedAt = Date.now()
   const response = await anthropic.messages.create({
     model: 'claude-haiku-4-5-20251001',

--- a/src/lib/ai/interview.ts
+++ b/src/lib/ai/interview.ts
@@ -16,15 +16,10 @@ import {
 import { inferExperienceLevel, inferLanguage } from './interview-helpers'
 import { formatManagerPriorities } from './priorities'
 import { formatLanguageDirective, TOOL_LANGUAGE_REINFORCEMENT, type SupportedLanguage } from './language'
+import { resolveAnthropicKey } from './keys'
 import { logAiUsage, anthropicUsageToInput } from './usage-logger'
 
 export { inferExperienceLevel, inferLanguage }
-
-const anthropic = new Anthropic({
-  apiKey: process.env.ANTHROPIC_API_KEY,
-  timeout: 240_000,
-  maxRetries: 3,
-})
 
 // -- Stage 1: CV Profile Extraction --
 
@@ -77,6 +72,8 @@ export async function extractCvProfile(
   tenantId: string,
   candidateId?: string
 ): Promise<CvProfile> {
+  const apiKey = await resolveAnthropicKey(tenantId)
+  const anthropic = new Anthropic({ apiKey, timeout: 240_000, maxRetries: 3 })
   const startedAt = Date.now()
   const response = await anthropic.messages.create({
     model: 'claude-haiku-4-5-20251001',
@@ -184,6 +181,8 @@ export async function generateQuestions(
     },
   }
 
+  const apiKey = await resolveAnthropicKey(tenantId ?? '')
+  const anthropic = new Anthropic({ apiKey, timeout: 240_000, maxRetries: 3 })
   const startedAt = Date.now()
   const response = await anthropic.messages.create({
     model: 'claude-sonnet-4-6',

--- a/src/lib/ai/profile-matcher.ts
+++ b/src/lib/ai/profile-matcher.ts
@@ -14,12 +14,7 @@
 import Anthropic from '@anthropic-ai/sdk'
 import { z } from 'zod'
 import { logAiUsage, anthropicUsageToInput } from './usage-logger'
-
-const anthropic = new Anthropic({
-  apiKey: process.env.ANTHROPIC_API_KEY,
-  maxRetries: 3,
-  timeout: 60_000,
-})
+import { resolveAnthropicKey } from './keys'
 
 const MODEL = 'claude-haiku-4-5-20251001'
 const MAX_OUTPUT_TOKENS = 2048
@@ -97,6 +92,17 @@ export async function verifyProfilesAgainstCv(
   candidateId?: string,
 ): Promise<MatchVerdict[]> {
   if (candidates.length === 0) return []
+
+  let apiKey: string
+  if (tenantId) {
+    apiKey = await resolveAnthropicKey(tenantId)
+  } else {
+    console.warn('[profile-matcher] no tenantId — falling back to env API key')
+    const envKey = process.env.ANTHROPIC_API_KEY
+    if (!envKey) throw new Error('No Anthropic API key configured')
+    apiKey = envKey
+  }
+  const anthropic = new Anthropic({ apiKey, maxRetries: 3, timeout: 60_000 })
 
   const cvBlock = [
     `Name: ${cvSignals.fullName}`,

--- a/src/lib/ai/role-tags.ts
+++ b/src/lib/ai/role-tags.ts
@@ -5,10 +5,7 @@
 
 import Anthropic from '@anthropic-ai/sdk'
 import { logAiUsage, anthropicUsageToInput } from './usage-logger'
-
-const anthropic = new Anthropic({
-  apiKey: process.env.ANTHROPIC_API_KEY,
-})
+import { resolveAnthropicKey } from './keys'
 
 const TAG_TOOL: Anthropic.Tool = {
   name: 'submit_role_tags',
@@ -45,6 +42,8 @@ export async function extractRoleTags(
   tenantId: string,
   roleId?: string
 ): Promise<RoleTags> {
+  const apiKey = await resolveAnthropicKey(tenantId)
+  const anthropic = new Anthropic({ apiKey })
   const startedAt = Date.now()
   const response = await anthropic.messages.create({
     model: 'claude-sonnet-4-6',

--- a/src/lib/ai/synechron-extract.ts
+++ b/src/lib/ai/synechron-extract.ts
@@ -16,16 +16,11 @@ import { withTenant } from '@/db'
 import { candidates } from '@/db/schema/candidates'
 import { writeAuditLog } from '@/lib/audit'
 import { logAiUsage, anthropicUsageToInput } from './usage-logger'
+import { resolveAnthropicKey } from './keys'
 import {
   SynechronCvDataSchema,
   type SynechronCvData,
 } from './synechron-schema'
-
-const anthropic = new Anthropic({
-  apiKey: process.env.ANTHROPIC_API_KEY,
-  maxRetries: 3,
-  timeout: 60_000,
-})
 
 const MODEL = 'claude-haiku-4-5-20251001'
 const INPUT_CHAR_CAP = 10_000
@@ -232,10 +227,12 @@ export async function extractSynechronCvData(
   candidateId: string,
   tenantId: string
 ): Promise<SynechronCvData> {
+  const apiKey = await resolveAnthropicKey(tenantId)
+  const anthropic = new Anthropic({ apiKey, maxRetries: 3, timeout: 60_000 })
   const cvText = await loadCandidateCvText(candidateId, tenantId)
   const input = capInputForClaude(cvText, candidateId)
   const startedAt = Date.now()
-  const response = await callClaudeWithSynechronTool(input)
+  const response = await callClaudeWithSynechronTool(anthropic, input)
   logAiUsage({
     tenantId,
     userId: null,
@@ -283,6 +280,7 @@ function capInputForClaude(cvText: string, candidateId: string): string {
 
 // 3. Call Claude with tool_use structured output
 async function callClaudeWithSynechronTool(
+  anthropic: Anthropic,
   input: string
 ): Promise<Anthropic.Message> {
   return anthropic.messages.create({

--- a/src/lib/ai/transcript-analysis.ts
+++ b/src/lib/ai/transcript-analysis.ts
@@ -25,17 +25,7 @@ import {
   type SupportedLanguage,
 } from './language'
 import { logAiUsage, anthropicUsageToInput } from './usage-logger'
-
-const anthropic = new Anthropic({
-  apiKey: process.env.ANTHROPIC_API_KEY,
-  // Match the resilience config used by other AI calls in the codebase —
-  // built-in exponential backoff handles transient network blips and
-  // 429/529/500 responses that would otherwise surface as "Connection error".
-  // Long transcripts (60+ minute meetings ≈ 100K+ tokens) need a longer
-  // timeout — Claude can take 60-180s to process large inputs.
-  maxRetries: 3,
-  timeout: 300_000,
-})
+import { resolveAnthropicKey } from './keys'
 
 // Soft cap on transcript size sent to Claude. claude-sonnet-4-6 supports
 // 200K tokens (~800K chars) but very large requests are unreliable and
@@ -71,8 +61,11 @@ export type AnalyzeTranscriptResult = {
  * directive injection differs.
  */
 async function detectTranscriptLanguage(
-  transcriptText: string
+  transcriptText: string,
+  tenantId: string
 ): Promise<SupportedLanguage> {
+  const apiKey = await resolveAnthropicKey(tenantId)
+  const anthropic = new Anthropic({ apiKey, maxRetries: 3, timeout: 300_000 })
   const sample = transcriptText.slice(0, 500)
   try {
     const response = await anthropic.messages.create({
@@ -102,6 +95,22 @@ async function detectTranscriptLanguage(
 export async function analyzeTranscriptWithClaude(
   input: AnalysisInput
 ): Promise<AnalyzeTranscriptResult> {
+  let apiKey: string
+  if (input.tenantId) {
+    apiKey = await resolveAnthropicKey(input.tenantId)
+  } else {
+    console.warn('[profile-matcher] no tenantId — falling back to env API key')
+    const envKey = process.env.ANTHROPIC_API_KEY
+    if (!envKey) throw new Error('No Anthropic API key configured')
+    apiKey = envKey
+  }
+  // Match the resilience config used by other AI calls in the codebase —
+  // built-in exponential backoff handles transient network blips and
+  // 429/529/500 responses that would otherwise surface as "Connection error".
+  // Long transcripts (60+ minute meetings ≈ 100K+ tokens) need a longer
+  // timeout — Claude can take 60-180s to process large inputs.
+  const anthropic = new Anthropic({ apiKey, maxRetries: 3, timeout: 300_000 })
+
   const questionsBlock =
     input.packQuestions && input.packQuestions.length > 0
       ? `\n\nINTERVIEW QUESTIONS (score responses against these):\n${input.packQuestions
@@ -136,7 +145,7 @@ Numeric scores are language-agnostic. Reasoning text and the summary must be in 
   // language directive into the uncached per-transcript block. Putting
   // it in the cached system block would fragment the prompt cache per
   // language. Falls back to 'en' on any failure (analysis still works).
-  const detectedLanguage = await detectTranscriptLanguage(input.transcriptText)
+  const detectedLanguage = await detectTranscriptLanguage(input.transcriptText, input.tenantId ?? '')
   console.log(
     `[transcript-analysis] detected language=${detectedLanguage} for transcript=${input.transcriptId ?? '<unknown>'}`
   )

--- a/src/lib/ai/welcome-letter.ts
+++ b/src/lib/ai/welcome-letter.ts
@@ -17,13 +17,8 @@ import {
   type InterviewType,
 } from './welcome-letter-schemas'
 import { formatLanguageDirective, TOOL_LANGUAGE_REINFORCEMENT, type SupportedLanguage } from './language'
+import { resolveAnthropicKey } from './keys'
 import { logAiUsage, anthropicUsageToInput } from './usage-logger'
-
-const anthropic = new Anthropic({
-  apiKey: process.env.ANTHROPIC_API_KEY,
-  timeout: 60_000,
-  maxRetries: 3,
-})
 
 const KARAT_LINK = 'https://karat.com/candidate-experience/'
 
@@ -251,6 +246,8 @@ TEAM NAME (use in signoff): ${tenantName}
 
 Write the welcome letter now. Submit via the submit_welcome_letter tool.${formatLanguageDirective(language)}`
 
+  const apiKey = await resolveAnthropicKey(tenantId)
+  const anthropic = new Anthropic({ apiKey, timeout: 60_000, maxRetries: 3 })
   const startedAt = Date.now()
   const response = await anthropic.messages.create({
     model: 'claude-haiku-4-5-20251001',


### PR DESCRIPTION
Audit found 9 files needed conversion (issue body listed 4 — stale).

## What changed

All AI helpers now resolve the Anthropic API key via `resolveAnthropicKey(tenantId)` instead of module-level `process.env.ANTHROPIC_API_KEY`. Tenants with custom keys see them honoured everywhere.

| Agent | Files |
|---|---|
| **A** | `claude.ts` (scoring) · `cv-reformat.ts` · `interview.ts` (2 functions) · `welcome-letter.ts` |
| **B** | `synechron-extract.ts` · `role-tags.ts` · `transcript-analysis.ts` (2 functions) · `profile-matcher.ts` · `actions/enrichment.ts` |

## Notable details

- `detectTranscriptLanguage` was missing `tenantId` entirely — added required param + updated its single internal caller
- `profile-matcher` and `analyzeTranscriptWithClaude` keep optional `tenantId` for background paths; fall back to env var + `console.warn` for observability
- All original timeout/maxRetries options preserved per file

## Test plan

- [x] Typecheck zero errors
- [x] Lint clean (one pre-existing warning at `enrichment.ts:136`, unrelated)
- [ ] Trigger a CV rescore → AI usage logs the call OK
- [ ] Trigger an interview pack generation
- [ ] Trigger a CV reformat
- [ ] Trigger a welcome letter generation
- [ ] Per-tenant isolation: tenant with custom `anthropic_api_key` in tenant_settings → all operations resolve to that key

🤖 Generated with [Claude Code](https://claude.com/claude-code)