### PR TITLE
feat(notifications): Slack + Teams webhook notifications on key events (closes #77)

### DIFF
--- a/src/actions/approvals.ts
+++ b/src/actions/approvals.ts
@@ -30,6 +30,7 @@ import {
 import { requireRole } from '@/lib/auth/require-role'
 import { writeAuditLog } from '@/lib/audit'
 import { getActionContext } from '@/lib/auth/action-context'
+import { dispatchManagerDecisionNotification } from '@/lib/notifications/dispatcher'
 
 type ActionResult = { success: true } | { success: false; error: string }
 
@@ -231,6 +232,18 @@ async function recordDecision(
     entityId: candidateId,
     metadata: { roleId, candidateId, comment: commentValue },
   })
+
+  // Fire-and-forget: notify configured Slack / Teams webhooks of the decision.
+  // Dispatch starts before revalidatePath so it isn't blocked; .catch() ensures
+  // it never propagates to the caller.
+  dispatchManagerDecisionNotification({
+    tenantId,
+    decision,
+    candidateId,
+    roleId,
+    managerName: null, // ActionContext does not carry a display name; dispatcher renders it gracefully
+    comment: commentValue,
+  }).catch(() => {})
 
   revalidatePath(`/dashboard/roles/${roleId}`)
   return { success: true }

--- a/src/actions/settings.ts
+++ b/src/actions/settings.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
-import { eq, and, notInArray } from 'drizzle-orm'
+import { eq, and, inArray, notInArray } from 'drizzle-orm'
 import { z } from 'zod'
 import { withTenant, db } from '@/db'
 import { tenantSettings, users } from '@/db/schema'
@@ -11,6 +11,8 @@ import { getActionContext } from '@/lib/auth/action-context'
 import { writeAuditLog } from '@/lib/audit'
 import { isSupportedLanguage } from '@/lib/ai/language'
 import { getSenderForTenant } from '@/lib/email/sender'
+import { testWebhookDelivery, type NotificationTestResult } from '@/lib/notifications/dispatcher'
+export type { NotificationTestResult }
 
 const ALLOWED_KEYS = [
   'anthropic_api_key',
@@ -537,4 +539,179 @@ export async function sendSmtpTestEmail(): Promise<SmtpSettingsState> {
   }
 
   return { success: true }
+}
+
+// ---------------------------------------------------------------------------
+// Notification settings (Slack / Teams webhooks + per-event toggles)
+// ---------------------------------------------------------------------------
+
+const NOTIFICATION_KEYS = [
+  'slack_webhook_url',
+  'teams_webhook_url',
+  'notify_high_score_enabled',
+  'notify_manager_decision_enabled',
+  'notify_score_threshold',
+] as const
+type NotificationKey = (typeof NOTIFICATION_KEYS)[number]
+
+// Keys that are encrypted before storage (webhook URLs contain bearer secrets)
+const ENCRYPTED_NOTIFICATION_KEYS = new Set<string>(['slack_webhook_url', 'teams_webhook_url'])
+
+export type NotificationSettingsState =
+  | { success: true }
+  | { success: false; error: string }
+
+/**
+ * Saves a single notification setting for the current tenant.
+ *
+ * Webhook URL keys (slack_webhook_url, teams_webhook_url) are encrypted with
+ * the same AES-256-GCM scheme used for SMTP passwords and API keys.
+ * Toggle and threshold keys are stored as plain text.
+ */
+export async function saveNotificationSetting(
+  key: string,
+  value: string
+): Promise<NotificationSettingsState> {
+  const ctx = await getActionContext()
+  if (!ctx) return { success: false, error: 'Unauthorized' }
+  const { tenantId, userId, userRole } = ctx
+
+  try { requireRole(userRole ?? undefined, 'admin') } catch {
+    return { success: false, error: 'Only admins can manage notification settings' }
+  }
+
+  if (!NOTIFICATION_KEYS.includes(key as NotificationKey)) {
+    return { success: false, error: 'Invalid notification setting key' }
+  }
+
+  if (!value || value.trim().length === 0) {
+    return { success: false, error: 'Value cannot be empty' }
+  }
+
+  const storedValue = ENCRYPTED_NOTIFICATION_KEYS.has(key) ? encrypt(value.trim()) : value.trim()
+
+  await withTenant(tenantId, async (tx) => {
+    await tx
+      .insert(tenantSettings)
+      .values({ tenantId, key, value: storedValue, updatedBy: userId })
+      .onConflictDoUpdate({
+        target: [tenantSettings.tenantId, tenantSettings.key],
+        set: { value: storedValue, updatedBy: userId, updatedAt: new Date() },
+      })
+  })
+
+  writeAuditLog(tenantId, {
+    action: 'settings.notification_updated',
+    entityType: 'settings',
+    metadata: { key },
+  }).catch(() => {})
+
+  revalidatePath('/dashboard/settings')
+  return { success: true }
+}
+
+/**
+ * Removes a single notification setting for the current tenant.
+ */
+export async function removeNotificationSetting(
+  key: string
+): Promise<NotificationSettingsState> {
+  const ctx = await getActionContext()
+  if (!ctx) return { success: false, error: 'Unauthorized' }
+  const { tenantId, userRole } = ctx
+
+  try { requireRole(userRole ?? undefined, 'admin') } catch {
+    return { success: false, error: 'Only admins can manage notification settings' }
+  }
+
+  if (!NOTIFICATION_KEYS.includes(key as NotificationKey)) {
+    return { success: false, error: 'Invalid notification setting key' }
+  }
+
+  await withTenant(tenantId, async (tx) => {
+    await tx
+      .delete(tenantSettings)
+      .where(and(eq(tenantSettings.tenantId, tenantId), eq(tenantSettings.key, key)))
+  })
+
+  writeAuditLog(tenantId, {
+    action: 'settings.notification_updated',
+    entityType: 'settings',
+    metadata: { key, removed: true },
+  }).catch(() => {})
+
+  revalidatePath('/dashboard/settings')
+  return { success: true }
+}
+
+/**
+ * Sends a test message to all configured Slack / Teams webhooks and returns
+ * the per-channel result. Intended for the settings UI "Send test message"
+ * button — Agent B's component calls this action directly.
+ */
+export async function testNotificationDelivery(): Promise<NotificationTestResult> {
+  const ctx = await getActionContext()
+  if (!ctx) {
+    return {
+      slack: { configured: false, ok: false, error: 'Unauthorized' },
+      teams: { configured: false, ok: false, error: 'Unauthorized' },
+    }
+  }
+
+  const { tenantId, userRole } = ctx
+
+  try { requireRole(userRole ?? undefined, 'admin') } catch {
+    return {
+      slack: { configured: false, ok: false, error: 'Forbidden' },
+      teams: { configured: false, ok: false, error: 'Forbidden' },
+    }
+  }
+
+  return testWebhookDelivery(tenantId)
+}
+
+/**
+ * Reads the current notification settings for the tenant. Returns boolean flags
+ * for whether webhook URLs are configured (NEVER returns the decrypted URLs to
+ * the client), plus the toggle + threshold values. Used by the settings page
+ * to seed the NotificationsPanel props.
+ */
+export type NotificationSettingsRecord = {
+  slack_webhook_configured: boolean
+  teams_webhook_configured: boolean
+  notify_high_score_enabled: boolean
+  notify_manager_decision_enabled: boolean
+  notify_score_threshold: number
+}
+
+export async function getNotificationSettings(): Promise<NotificationSettingsRecord> {
+  const fallback: NotificationSettingsRecord = {
+    slack_webhook_configured: false,
+    teams_webhook_configured: false,
+    notify_high_score_enabled: true,
+    notify_manager_decision_enabled: true,
+    notify_score_threshold: 85,
+  }
+
+  const ctx = await getActionContext()
+  if (!ctx) return fallback
+  const { tenantId, userRole } = ctx
+  try { requireRole(userRole ?? undefined, 'admin') } catch { return fallback }
+
+  const rows = await withTenant(tenantId, async (tx) =>
+    tx
+      .select({ key: tenantSettings.key, value: tenantSettings.value })
+      .from(tenantSettings)
+      .where(and(eq(tenantSettings.tenantId, tenantId), inArray(tenantSettings.key, NOTIFICATION_KEYS as unknown as string[])))
+  )
+
+  const m = new Map(rows.map((r) => [r.key, r.value]))
+
+  return {
+    slack_webhook_configured: m.has('slack_webhook_url'),
+    teams_webhook_configured: m.has('teams_webhook_url'),
+    notify_high_score_enabled: (m.get('notify_high_score_enabled') ?? 'true') === 'true',
+    notify_manager_decision_enabled: (m.get('notify_manager_decision_enabled') ?? 'true') === 'true',
+    notify_score_threshold: parseInt(m.get('notify_score_threshold') ?? '85', 10) || 85,
+  }
 }

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -10,6 +10,7 @@ import {
   getTrustedHosts,
   getDefaultPackLanguage,
   getSmtpSettings,
+  getNotificationSettings,
 } from '@/actions/settings'
 import { listTenantUsers } from '@/actions/users'
 import { listApiTokens } from '@/actions/api-tokens'
@@ -26,6 +27,7 @@ import { DefaultLanguageForm } from '@/components/settings/default-language-form
 import { AiUsagePanel } from '@/components/settings/ai-usage-panel'
 import { ApiTokensPanel } from '@/components/settings/api-tokens-panel'
 import { SmtpSettingsPanel } from '@/components/settings/smtp-settings-panel'
+import { NotificationsPanel } from '@/components/settings/notifications-panel'
 import { EmailTemplatesPanel } from '@/components/settings/email-templates-panel'
 import { OAuthCredentialsForm } from '@/components/settings/oauth-credentials-form'
 import { BackupsPanel } from '@/components/settings/backups-panel'
@@ -43,6 +45,7 @@ export default async function SettingsPage() {
   const trustedHosts = isAdmin ? await getTrustedHosts(tenantId) : []
   const defaultPackLanguage = isAdmin ? await getDefaultPackLanguage(tenantId) : 'en'
   const smtpSettings = isAdmin ? await getSmtpSettings(tenantId) : null
+  const notificationSettings = isAdmin ? await getNotificationSettings() : null
   const emailTemplates = isAdmin ? await listEmailTemplates() : []
 
   // Last manual tenant export timestamp — admin only
@@ -240,6 +243,19 @@ export default async function SettingsPage() {
           {smtpSettings && (
             <div>
               <SmtpSettingsPanel initial={smtpSettings} />
+            </div>
+          )}
+
+          {/* Slack & Teams notifications */}
+          {notificationSettings && (
+            <div>
+              <NotificationsPanel
+                initialSlackWebhook={notificationSettings.slack_webhook_configured ? '••' : ''}
+                initialTeamsWebhook={notificationSettings.teams_webhook_configured ? '••' : ''}
+                initialHighScoreEnabled={notificationSettings.notify_high_score_enabled}
+                initialManagerDecisionEnabled={notificationSettings.notify_manager_decision_enabled}
+                initialScoreThreshold={notificationSettings.notify_score_threshold}
+              />
             </div>
           )}
 

--- a/src/components/settings/notifications-panel.tsx
+++ b/src/components/settings/notifications-panel.tsx
@@ -1,0 +1,475 @@
+'use client'
+
+/**
+ * NotificationsPanel — admin-only panel for configuring Slack/Teams webhook
+ * notifications.
+ *
+ * Mirrors the SmtpSettingsPanel pattern: each field/group has its own save
+ * button; webhook URLs use a masked password input with show/hide toggle;
+ * boolean toggles auto-save on change; a "Send test message" button fires
+ * Agent A's testNotificationDelivery action and reports per-channel results
+ * inline.
+ *
+ * Usage (in settings/page.tsx):
+ *   const notifSettings = isAdmin ? await getNotificationSettings(tenantId) : null
+ *   {notifSettings && <NotificationsPanel {...notifSettings} />}
+ */
+
+import { useState, useTransition } from 'react'
+import {
+  BellIcon,
+  EyeIcon,
+  EyeOffIcon,
+  CheckCircleIcon,
+  Loader2Icon,
+  SendIcon,
+} from 'lucide-react'
+import { saveNotificationSetting, testNotificationDelivery } from '@/actions/settings'
+import type { NotificationTestResult } from '@/actions/settings'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type NotificationsPanelProps = {
+  initialSlackWebhook: string
+  initialTeamsWebhook: string
+  initialHighScoreEnabled: boolean
+  initialManagerDecisionEnabled: boolean
+  initialScoreThreshold: number
+}
+
+type FieldState = 'idle' | 'saving' | 'saved' | 'error'
+
+// ---------------------------------------------------------------------------
+// Shared style constants (mirrors smtp-settings-panel.tsx)
+// ---------------------------------------------------------------------------
+
+const INPUT_BASE =
+  'w-full text-sm rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] ' +
+  'text-[var(--color-fg)] px-3 py-2 placeholder:text-[var(--color-fg-subtle)] ' +
+  'focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-60'
+
+// ---------------------------------------------------------------------------
+// Webhook URL row (masked input with show/hide)
+// ---------------------------------------------------------------------------
+
+function WebhookRow({
+  settingKey,
+  label,
+  description,
+  isConfigured,
+}: {
+  settingKey: 'slack_webhook_url' | 'teams_webhook_url'
+  label: string
+  description: string
+  isConfigured: boolean
+}) {
+  const [value, setValue] = useState('')
+  const [show, setShow] = useState(false)
+  const [state, setState] = useState<FieldState>('idle')
+  const [errorMsg, setErrorMsg] = useState('')
+  const [pending, startTransition] = useTransition()
+
+  const handleSave = () => {
+    if (!value) return
+    setState('saving')
+    setErrorMsg('')
+    startTransition(async () => {
+      const result = await saveNotificationSetting(settingKey, value)
+      if (result.success) {
+        setValue('')
+        setState('saved')
+        setTimeout(() => setState('idle'), 2500)
+      } else {
+        setState('error')
+        setErrorMsg(result.error)
+      }
+    })
+  }
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-1.5">
+        <label
+          htmlFor={`notif-${settingKey}`}
+          className="block text-xs font-medium text-[var(--color-fg-muted)]"
+        >
+          {label}
+        </label>
+        {isConfigured && (
+          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-emerald-950 text-emerald-400 border border-emerald-700">
+            <CheckCircleIcon className="h-3 w-3" />
+            Configured
+          </span>
+        )}
+      </div>
+      <p className="text-[11px] text-[var(--color-fg-subtle)] mb-1.5">{description}</p>
+      <div className="flex gap-2">
+        <div className="relative flex-1">
+          <input
+            id={`notif-${settingKey}`}
+            type={show ? 'text' : 'password'}
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder={
+              isConfigured
+                ? '••••••••••••••••'
+                : settingKey === 'slack_webhook_url'
+                  ? 'https://hooks.slack.com/services/…'
+                  : 'https://outlook.office.com/webhook/…'
+            }
+            disabled={pending}
+            className={INPUT_BASE + ' pr-10'}
+            autoComplete="off"
+            aria-label={label}
+          />
+          <button
+            type="button"
+            onClick={() => setShow((s) => !s)}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)]"
+            tabIndex={-1}
+            aria-label={show ? 'Hide webhook URL' : 'Show webhook URL'}
+          >
+            {show ? <EyeOffIcon className="h-4 w-4" /> : <EyeIcon className="h-4 w-4" />}
+          </button>
+        </div>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={pending || !value}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-blue-600 text-white text-xs
+                     font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors whitespace-nowrap"
+        >
+          {pending && <Loader2Icon className="h-3 w-3 animate-spin" />}
+          {isConfigured ? 'Update' : 'Save'}
+        </button>
+      </div>
+      {state === 'saved' && (
+        <p className="mt-1 text-xs text-emerald-400">Saved.</p>
+      )}
+      {state === 'error' && (
+        <p className="mt-1 text-xs text-red-400">{errorMsg}</p>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Triggers section (checkboxes + threshold)
+// ---------------------------------------------------------------------------
+
+function TriggersSection({
+  initialHighScoreEnabled,
+  initialManagerDecisionEnabled,
+  initialScoreThreshold,
+}: {
+  initialHighScoreEnabled: boolean
+  initialManagerDecisionEnabled: boolean
+  initialScoreThreshold: number
+}) {
+  const [highScoreEnabled, setHighScoreEnabled] = useState(initialHighScoreEnabled)
+  const [managerEnabled, setManagerEnabled] = useState(initialManagerDecisionEnabled)
+  const [threshold, setThreshold] = useState(String(initialScoreThreshold))
+  const [thresholdState, setThresholdState] = useState<FieldState>('idle')
+  const [thresholdError, setThresholdError] = useState('')
+
+  const [togglePending, startToggleTransition] = useTransition()
+  const [thresholdPending, startThresholdTransition] = useTransition()
+
+  const handleHighScoreToggle = (checked: boolean) => {
+    setHighScoreEnabled(checked)
+    startToggleTransition(async () => {
+      const result = await saveNotificationSetting(
+        'notify_high_score_enabled',
+        checked ? 'true' : 'false',
+      )
+      if (!result.success) {
+        // Revert on failure
+        setHighScoreEnabled(!checked)
+      }
+    })
+  }
+
+  const handleManagerToggle = (checked: boolean) => {
+    setManagerEnabled(checked)
+    startToggleTransition(async () => {
+      const result = await saveNotificationSetting(
+        'notify_manager_decision_enabled',
+        checked ? 'true' : 'false',
+      )
+      if (!result.success) {
+        setManagerEnabled(!checked)
+      }
+    })
+  }
+
+  const handleThresholdSave = () => {
+    const parsed = parseInt(threshold, 10)
+    if (isNaN(parsed) || parsed < 0 || parsed > 100) {
+      setThresholdState('error')
+      setThresholdError('Enter a value between 0 and 100.')
+      return
+    }
+    setThresholdState('saving')
+    setThresholdError('')
+    startThresholdTransition(async () => {
+      const result = await saveNotificationSetting('notify_score_threshold', String(parsed))
+      if (result.success) {
+        setThresholdState('saved')
+        setTimeout(() => setThresholdState('idle'), 2500)
+      } else {
+        setThresholdState('error')
+        setThresholdError(result.error)
+      }
+    })
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* High-score toggle + threshold */}
+      <div>
+        <label className="flex items-start gap-3 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={highScoreEnabled}
+            onChange={(e) => handleHighScoreToggle(e.target.checked)}
+            disabled={togglePending}
+            className="mt-0.5 h-4 w-4 accent-blue-600 cursor-pointer"
+            aria-describedby="high-score-desc"
+          />
+          <div>
+            <span className="text-sm font-medium text-[var(--color-fg)]">
+              Send notifications for high-score candidates
+            </span>
+            <p id="high-score-desc" className="text-[11px] text-[var(--color-fg-subtle)] mt-0.5">
+              Fires when a candidate&apos;s overall AI score meets or exceeds the threshold below.
+            </p>
+          </div>
+        </label>
+
+        {/* Threshold — always shown; disabled when toggle is off */}
+        <div className="mt-3 ml-7">
+          <label
+            htmlFor="notif-score-threshold"
+            className="block text-xs font-medium text-[var(--color-fg-muted)] mb-1.5"
+          >
+            Score threshold
+          </label>
+          <div className="flex items-center gap-2">
+            <input
+              id="notif-score-threshold"
+              type="number"
+              min={0}
+              max={100}
+              value={threshold}
+              onChange={(e) => setThreshold(e.target.value)}
+              disabled={thresholdPending || !highScoreEnabled}
+              className="w-24 text-sm rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)]
+                         text-[var(--color-fg)] px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500
+                         disabled:opacity-60"
+              aria-label="Score threshold (0–100)"
+            />
+            <span className="text-xs text-[var(--color-fg-muted)]">/ 100</span>
+            <button
+              type="button"
+              onClick={handleThresholdSave}
+              disabled={thresholdPending || !highScoreEnabled}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-blue-600 text-white text-xs
+                         font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            >
+              {thresholdPending && <Loader2Icon className="h-3 w-3 animate-spin" />}
+              Save
+            </button>
+          </div>
+          {thresholdState === 'saved' && (
+            <p className="mt-1 text-xs text-emerald-400">Threshold saved.</p>
+          )}
+          {thresholdState === 'error' && (
+            <p className="mt-1 text-xs text-red-400">{thresholdError}</p>
+          )}
+        </div>
+      </div>
+
+      {/* Manager decision toggle */}
+      <div>
+        <label className="flex items-start gap-3 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={managerEnabled}
+            onChange={(e) => handleManagerToggle(e.target.checked)}
+            disabled={togglePending}
+            className="mt-0.5 h-4 w-4 accent-blue-600 cursor-pointer"
+            aria-describedby="manager-decision-desc"
+          />
+          <div>
+            <span className="text-sm font-medium text-[var(--color-fg)]">
+              Send notifications for manager approve/reject decisions
+            </span>
+            <p
+              id="manager-decision-desc"
+              className="text-[11px] text-[var(--color-fg-subtle)] mt-0.5"
+            >
+              Fires when a hiring manager approves or rejects a shortlisted candidate.
+            </p>
+          </div>
+        </label>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Test delivery button + per-channel result display
+// ---------------------------------------------------------------------------
+
+function TestDeliveryButton() {
+  const [result, setResult] = useState<NotificationTestResult | null>(null)
+  const [pending, startTransition] = useTransition()
+
+  const handleTest = () => {
+    setResult(null)
+    startTransition(async () => {
+      const res = await testNotificationDelivery()
+      setResult(res)
+    })
+  }
+
+  return (
+    <div className="pt-4 border-t border-[var(--color-border)]">
+      <div className="flex items-center gap-3 flex-wrap">
+        <button
+          type="button"
+          onClick={handleTest}
+          disabled={pending}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-[var(--color-border)]
+                     text-xs font-medium text-[var(--color-fg-muted)] hover:text-[var(--color-fg)]
+                     hover:bg-[var(--color-bg-input)] disabled:opacity-50 transition-colors"
+          aria-label="Send test notification to all configured webhooks"
+        >
+          {pending ? (
+            <Loader2Icon className="h-3 w-3 animate-spin" />
+          ) : (
+            <SendIcon className="h-3 w-3" />
+          )}
+          Send test message
+        </button>
+
+        {result && (
+          <ul
+            className="flex flex-col gap-1 text-xs"
+            role="status"
+            aria-live="polite"
+            aria-label="Test delivery results"
+          >
+            <TestChannelResult channel="Slack" outcome={result.slack} />
+            <TestChannelResult channel="Teams" outcome={result.teams} />
+          </ul>
+        )}
+      </div>
+      <p className="mt-1.5 text-[11px] text-[var(--color-fg-subtle)]">
+        Sends a test message to all configured webhooks immediately, regardless of toggle state.
+      </p>
+    </div>
+  )
+}
+
+function TestChannelResult({
+  channel,
+  outcome,
+}: {
+  channel: string
+  outcome: { configured: boolean; ok: boolean; error?: string }
+}) {
+  if (!outcome.configured) {
+    return (
+      <li className="text-[var(--color-fg-subtle)]">
+        {channel}: not configured
+      </li>
+    )
+  }
+  if (outcome.ok) {
+    return (
+      <li className="text-emerald-400">
+        {channel}: delivered
+      </li>
+    )
+  }
+  return (
+    <li className="text-red-400">
+      {channel}: {outcome.error ?? 'failed'}
+    </li>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main panel
+// ---------------------------------------------------------------------------
+
+export function NotificationsPanel({
+  initialSlackWebhook,
+  initialTeamsWebhook,
+  initialHighScoreEnabled,
+  initialManagerDecisionEnabled,
+  initialScoreThreshold,
+}: NotificationsPanelProps) {
+  const slackConfigured = initialSlackWebhook.length > 0
+  const teamsConfigured = initialTeamsWebhook.length > 0
+
+  return (
+    <section
+      className="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-elevated)] p-6"
+      aria-labelledby="notifications-settings-heading"
+    >
+      <div className="flex items-center gap-2 mb-2">
+        <BellIcon className="h-4 w-4 text-[var(--color-fg-muted)]" aria-hidden="true" />
+        <h2
+          id="notifications-settings-heading"
+          className="text-lg font-semibold text-[var(--color-fg)]"
+        >
+          Slack &amp; Teams notifications
+        </h2>
+      </div>
+      <p className="text-xs text-[var(--color-fg-subtle)] mb-5">
+        Post real-time alerts to a Slack or Teams channel when high-score candidates are ranked or
+        hiring managers make decisions. Webhook URLs are encrypted at rest.
+      </p>
+
+      <div className="space-y-6">
+        {/* Webhook URLs */}
+        <div className="space-y-4">
+          <WebhookRow
+            settingKey="slack_webhook_url"
+            label="Slack Incoming Webhook URL"
+            description="Create one at api.slack.com/apps — add the Incoming Webhooks feature to your app."
+            isConfigured={slackConfigured}
+          />
+          <WebhookRow
+            settingKey="teams_webhook_url"
+            label="Microsoft Teams Webhook URL"
+            description="Add an Incoming Webhook connector to your Teams channel via Channel Settings → Connectors."
+            isConfigured={teamsConfigured}
+          />
+        </div>
+
+        {/* Divider */}
+        <div className="border-t border-[var(--color-border)]" />
+
+        {/* Triggers */}
+        <div>
+          <h3 className="text-xs font-semibold text-[var(--color-fg-muted)] uppercase tracking-wide mb-3">
+            Triggers
+          </h3>
+          <TriggersSection
+            initialHighScoreEnabled={initialHighScoreEnabled}
+            initialManagerDecisionEnabled={initialManagerDecisionEnabled}
+            initialScoreThreshold={initialScoreThreshold}
+          />
+        </div>
+
+        {/* Test button */}
+        <TestDeliveryButton />
+      </div>
+    </section>
+  )
+}

--- a/src/lib/ai/scoring.ts
+++ b/src/lib/ai/scoring.ts
@@ -18,6 +18,7 @@ import { candidates, roles, scores, customerFrameworks, tenantSettings } from '@
 import { scoreCandidateWithClaude } from './claude'
 import { scoreCandidateWithGemini } from './gemini'
 import { writeAuditLog } from '@/lib/audit'
+import { dispatchHighScoreNotification } from '@/lib/notifications/dispatcher'
 
 export async function triggerScoring(
   candidateId: string,
@@ -127,6 +128,16 @@ When scoring experience_level, assess specifically whether the candidate's senio
         })
         .where(and(eq(scores.candidateId, candidateId), eq(scores.roleId, roleId)))
     })
+
+    // Fire-and-forget: notify configured Slack / Teams webhooks if this score
+    // meets the tenant's threshold. The dispatcher applies the threshold gate
+    // internally and loads names from the DB — no additional args needed here.
+    dispatchHighScoreNotification({
+      tenantId,
+      candidateId,
+      roleId,
+      overallScore: result.overall_score,
+    }).catch(() => {})
 
     writeAuditLog(tenantId, {
       action: 'score.completed',

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -54,6 +54,10 @@ export type AuditAction =
   | 'tenant.exported'
   | 'tenant.csv_exported'
   | 'candidate.welcome_letter_generated'
+  | 'notification.high_score_sent'
+  | 'notification.approval_sent'
+  | 'notification.webhook_failed'
+  | 'settings.notification_updated'
 
 type AuditEntry = {
   action: AuditAction

--- a/src/lib/notifications/dispatcher.ts
+++ b/src/lib/notifications/dispatcher.ts
@@ -1,0 +1,408 @@
+/**
+ * Notification dispatcher — routes high-score and manager-decision events to
+ * configured Slack / Teams webhooks.
+ *
+ * Design principles (mirrors src/lib/email/notify-recruiter-of-customer-update.ts):
+ *  - Never throws. All failure paths are swallowed and logged via console.warn.
+ *  - All dispatches are fire-and-forget — callers use .catch(() => {}).
+ *  - Audit log writes are themselves fire-and-forget (.catch(() => {})).
+ *  - Names are loaded internally from the DB so call sites stay minimal.
+ */
+
+import { eq, and, inArray } from 'drizzle-orm'
+import { withTenant } from '@/db'
+import { candidates, roles, tenantSettings } from '@/db/schema'
+import { decrypt } from '@/lib/crypto'
+import { writeAuditLog } from '@/lib/audit'
+import { sendSlack } from './slack'
+import { sendTeams } from './teams'
+
+// ---------------------------------------------------------------------------
+// Internal constants
+// ---------------------------------------------------------------------------
+
+const SETTING_KEYS = {
+  slackWebhook: 'slack_webhook_url',
+  teamsWebhook: 'teams_webhook_url',
+  highScoreEnabled: 'notify_high_score_enabled',
+  managerDecisionEnabled: 'notify_manager_decision_enabled',
+  scoreThreshold: 'notify_score_threshold',
+} as const
+
+// ---------------------------------------------------------------------------
+// Public argument types
+// ---------------------------------------------------------------------------
+
+export type HighScoreArgs = {
+  tenantId: string
+  candidateId: string
+  roleId: string
+  overallScore: number
+}
+
+export type ManagerDecisionArgs = {
+  tenantId: string
+  decision: 'approved' | 'rejected'
+  candidateId: string
+  roleId: string
+  managerName: string | null
+  comment: string | null
+}
+
+export type NotificationTestResult = {
+  slack: { configured: boolean; ok: boolean; error?: string }
+  teams: { configured: boolean; ok: boolean; error?: string }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads all 5 notification-related keys from tenant_settings in a single
+ * query and returns a map of key → value.
+ */
+async function loadNotificationSettings(tenantId: string): Promise<Map<string, string>> {
+  const keys = Object.values(SETTING_KEYS) as string[]
+  const rows = await withTenant(tenantId, async (tx) =>
+    tx
+      .select({ key: tenantSettings.key, value: tenantSettings.value })
+      .from(tenantSettings)
+      .where(
+        and(
+          eq(tenantSettings.tenantId, tenantId),
+          inArray(tenantSettings.key, keys)
+        )
+      )
+  )
+  const map = new Map<string, string>()
+  for (const row of rows) {
+    map.set(row.key, row.value)
+  }
+  return map
+}
+
+/**
+ * Safely decrypts an encrypted webhook URL.
+ * Returns null on any decryption failure (missing key, malformed value, etc.).
+ */
+function safeDecrypt(encrypted: string | undefined): string | null {
+  if (!encrypted) return null
+  try {
+    return decrypt(encrypted)
+  } catch {
+    return null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// dispatchHighScoreNotification
+// ---------------------------------------------------------------------------
+
+/**
+ * Fires Slack + Teams notifications when a candidate scores above the
+ * configured threshold on a role.
+ *
+ * Loads candidate name and role title internally — call sites pass only IDs
+ * and the numeric score.
+ *
+ * Safe to call fire-and-forget: dispatchHighScoreNotification(...).catch(() => {})
+ */
+export async function dispatchHighScoreNotification(args: HighScoreArgs): Promise<void> {
+  try {
+    const settings = await loadNotificationSettings(args.tenantId)
+
+    // Respect the per-tenant enable toggle (defaults to enabled when not set)
+    const enabled = settings.get(SETTING_KEYS.highScoreEnabled)
+    if (enabled === 'false') return
+
+    // Threshold gate
+    const threshold = parseInt(settings.get(SETTING_KEYS.scoreThreshold) ?? '85', 10)
+    if (args.overallScore < threshold) return
+
+    // Decrypt webhook URLs
+    const slackUrl = safeDecrypt(settings.get(SETTING_KEYS.slackWebhook))
+    const teamsUrl = safeDecrypt(settings.get(SETTING_KEYS.teamsWebhook))
+
+    if (!slackUrl && !teamsUrl) return // nothing configured
+
+    // Load candidate name + role title in a single joined query
+    const [row] = await withTenant(args.tenantId, async (tx) =>
+      tx
+        .select({
+          candidateFirstName: candidates.firstName,
+          candidateLastName: candidates.lastName,
+          roleTitle: roles.title,
+        })
+        .from(candidates)
+        .innerJoin(roles, eq(roles.tenantId, candidates.tenantId))
+        .where(
+          and(
+            eq(candidates.id, args.candidateId),
+            eq(roles.id, args.roleId)
+          )
+        )
+        .limit(1)
+    )
+
+    if (!row) return // candidate or role no longer exists
+
+    const candidateName = `${row.candidateFirstName} ${row.candidateLastName}`.trim()
+    const roleTitle = row.roleTitle
+
+    // Compose messages
+    const slackText = `⭐ ${candidateName} scored ${args.overallScore} for ${roleTitle}`
+    const teamsTitle = `High score: ${candidateName}`
+    const teamsText = `Scored ${args.overallScore} for ${roleTitle}`
+    const teamsColor = '2EB67D' // green
+
+    // Fire both in parallel — failures are independent
+    const results = await Promise.allSettled([
+      slackUrl ? sendSlack(slackUrl, slackText) : Promise.resolve(null),
+      teamsUrl ? sendTeams(teamsUrl, { title: teamsTitle, text: teamsText, themeColor: teamsColor }) : Promise.resolve(null),
+    ])
+
+    // Audit each result
+    const channels = ['slack', 'teams'] as const
+    for (let i = 0; i < channels.length; i++) {
+      const channel = channels[i]
+      const configured = channel === 'slack' ? Boolean(slackUrl) : Boolean(teamsUrl)
+      if (!configured) continue
+
+      const settled = results[i]
+      if (settled.status === 'rejected') {
+        console.warn(`[notifications] ${channel} high-score dispatch threw:`, settled.reason)
+        writeAuditLog(args.tenantId, {
+          action: 'notification.webhook_failed',
+          entityType: 'candidate',
+          entityId: args.candidateId,
+          metadata: {
+            channel,
+            error: settled.reason instanceof Error ? settled.reason.message : String(settled.reason),
+            candidateId: args.candidateId,
+            roleId: args.roleId,
+          },
+        }).catch(() => {})
+        continue
+      }
+
+      const result = settled.value
+      if (result === null) continue // channel not configured
+
+      if (!result.ok) {
+        console.warn(`[notifications] ${channel} high-score delivery failed:`, result.error)
+        writeAuditLog(args.tenantId, {
+          action: 'notification.webhook_failed',
+          entityType: 'candidate',
+          entityId: args.candidateId,
+          metadata: {
+            channel,
+            error: result.error,
+            candidateId: args.candidateId,
+            roleId: args.roleId,
+          },
+        }).catch(() => {})
+      } else {
+        writeAuditLog(args.tenantId, {
+          action: 'notification.high_score_sent',
+          entityType: 'candidate',
+          entityId: args.candidateId,
+          entityLabel: `${candidateName} → ${roleTitle}`,
+          metadata: {
+            channel,
+            overallScore: args.overallScore,
+            roleId: args.roleId,
+          },
+        }).catch(() => {})
+      }
+    }
+  } catch (err) {
+    console.warn('[notifications] dispatchHighScoreNotification failed:', err)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// dispatchManagerDecisionNotification
+// ---------------------------------------------------------------------------
+
+/**
+ * Fires Slack + Teams notifications when a hiring manager approves or rejects
+ * a candidate.
+ *
+ * Loads candidate name and role title internally — call sites pass only IDs,
+ * the decision, manager name, and optional comment.
+ *
+ * Safe to call fire-and-forget: dispatchManagerDecisionNotification(...).catch(() => {})
+ */
+export async function dispatchManagerDecisionNotification(args: ManagerDecisionArgs): Promise<void> {
+  try {
+    const settings = await loadNotificationSettings(args.tenantId)
+
+    // Respect the per-tenant enable toggle (defaults to enabled when not set)
+    const enabled = settings.get(SETTING_KEYS.managerDecisionEnabled)
+    if (enabled === 'false') return
+
+    // Decrypt webhook URLs
+    const slackUrl = safeDecrypt(settings.get(SETTING_KEYS.slackWebhook))
+    const teamsUrl = safeDecrypt(settings.get(SETTING_KEYS.teamsWebhook))
+
+    if (!slackUrl && !teamsUrl) return // nothing configured
+
+    // Load candidate name + role title in a single joined query
+    const [row] = await withTenant(args.tenantId, async (tx) =>
+      tx
+        .select({
+          candidateFirstName: candidates.firstName,
+          candidateLastName: candidates.lastName,
+          roleTitle: roles.title,
+        })
+        .from(candidates)
+        .innerJoin(roles, eq(roles.tenantId, candidates.tenantId))
+        .where(
+          and(
+            eq(candidates.id, args.candidateId),
+            eq(roles.id, args.roleId)
+          )
+        )
+        .limit(1)
+    )
+
+    if (!row) return // candidate or role no longer exists
+
+    const candidateName = `${row.candidateFirstName} ${row.candidateLastName}`.trim()
+    const roleTitle = row.roleTitle
+
+    // Compose messages
+    const emoji = args.decision === 'approved' ? '✅' : '❌'
+    const commentSuffix = args.comment ? ` — "${args.comment}"` : ''
+    const slackText = `${emoji} Hiring manager ${args.decision} ${candidateName} for ${roleTitle}${commentSuffix}`
+    const teamsTitle = `${emoji} Manager ${args.decision}: ${candidateName}`
+    const teamsText = `${candidateName} ${args.decision} for ${roleTitle}${commentSuffix}`
+    const teamsColor = args.decision === 'approved' ? '2EB67D' : 'E01E5A'
+
+    // Fire both in parallel
+    const results = await Promise.allSettled([
+      slackUrl ? sendSlack(slackUrl, slackText) : Promise.resolve(null),
+      teamsUrl ? sendTeams(teamsUrl, { title: teamsTitle, text: teamsText, themeColor: teamsColor }) : Promise.resolve(null),
+    ])
+
+    // Audit each result
+    const channels = ['slack', 'teams'] as const
+    for (let i = 0; i < channels.length; i++) {
+      const channel = channels[i]
+      const configured = channel === 'slack' ? Boolean(slackUrl) : Boolean(teamsUrl)
+      if (!configured) continue
+
+      const settled = results[i]
+      if (settled.status === 'rejected') {
+        console.warn(`[notifications] ${channel} manager-decision dispatch threw:`, settled.reason)
+        writeAuditLog(args.tenantId, {
+          action: 'notification.webhook_failed',
+          entityType: 'candidate',
+          entityId: args.candidateId,
+          metadata: {
+            channel,
+            error: settled.reason instanceof Error ? settled.reason.message : String(settled.reason),
+            candidateId: args.candidateId,
+            roleId: args.roleId,
+          },
+        }).catch(() => {})
+        continue
+      }
+
+      const result = settled.value
+      if (result === null) continue // channel not configured
+
+      if (!result.ok) {
+        console.warn(`[notifications] ${channel} manager-decision delivery failed:`, result.error)
+        writeAuditLog(args.tenantId, {
+          action: 'notification.webhook_failed',
+          entityType: 'candidate',
+          entityId: args.candidateId,
+          metadata: {
+            channel,
+            error: result.error,
+            candidateId: args.candidateId,
+            roleId: args.roleId,
+          },
+        }).catch(() => {})
+      } else {
+        writeAuditLog(args.tenantId, {
+          action: 'notification.approval_sent',
+          entityType: 'candidate',
+          entityId: args.candidateId,
+          entityLabel: `${candidateName} → ${roleTitle}`,
+          metadata: {
+            channel,
+            decision: args.decision,
+            roleId: args.roleId,
+            managerName: args.managerName,
+          },
+        }).catch(() => {})
+      }
+    }
+  } catch (err) {
+    console.warn('[notifications] dispatchManagerDecisionNotification failed:', err)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// testWebhookDelivery
+// ---------------------------------------------------------------------------
+
+/**
+ * Posts a test message to both configured webhooks and returns the per-channel
+ * result. Used by the settings UI "Send test message" button.
+ *
+ * Successful test deliveries are NOT audited (would be noisy). Only failures
+ * are audited via notification.webhook_failed.
+ */
+export async function testWebhookDelivery(tenantId: string): Promise<NotificationTestResult> {
+  const settings = await loadNotificationSettings(tenantId)
+
+  const slackUrl = safeDecrypt(settings.get(SETTING_KEYS.slackWebhook))
+  const teamsUrl = safeDecrypt(settings.get(SETTING_KEYS.teamsWebhook))
+
+  const testMessage = '✓ SkillAI test message — your webhook is wired up'
+
+  const [slackResult, teamsResult] = await Promise.allSettled([
+    slackUrl ? sendSlack(slackUrl, testMessage) : Promise.resolve(null),
+    teamsUrl ? sendTeams(teamsUrl, { title: 'SkillAI test', text: testMessage }) : Promise.resolve(null),
+  ])
+
+  const slack = resolveTestResult(slackUrl, slackResult)
+  const teams = resolveTestResult(teamsUrl, teamsResult)
+
+  // Audit failures only
+  if (slackUrl && !slack.ok) {
+    writeAuditLog(tenantId, {
+      action: 'notification.webhook_failed',
+      entityType: 'settings',
+      metadata: { channel: 'slack', error: slack.error, test: true },
+    }).catch(() => {})
+  }
+  if (teamsUrl && !teams.ok) {
+    writeAuditLog(tenantId, {
+      action: 'notification.webhook_failed',
+      entityType: 'settings',
+      metadata: { channel: 'teams', error: teams.error, test: true },
+    }).catch(() => {})
+  }
+
+  return { slack, teams }
+}
+
+function resolveTestResult(
+  url: string | null,
+  settled: PromiseSettledResult<{ ok: true } | { ok: false; error: string } | null>
+): { configured: boolean; ok: boolean; error?: string } {
+  if (!url) return { configured: false, ok: false }
+  if (settled.status === 'rejected') {
+    const error = settled.reason instanceof Error ? settled.reason.message : String(settled.reason)
+    return { configured: true, ok: false, error }
+  }
+  const result = settled.value
+  if (result === null) return { configured: false, ok: false }
+  if (!result.ok) return { configured: true, ok: false, error: result.error }
+  return { configured: true, ok: true }
+}

--- a/src/lib/notifications/slack.ts
+++ b/src/lib/notifications/slack.ts
@@ -1,0 +1,21 @@
+export type WebhookResult = { ok: true } | { ok: false; error: string }
+
+/**
+ * Posts a plain-text message to a Slack incoming webhook URL.
+ *
+ * Designed to be called fire-and-forget from the dispatcher — never throws;
+ * all failure modes are captured in the returned WebhookResult.
+ */
+export async function sendSlack(webhookUrl: string, text: string): Promise<WebhookResult> {
+  try {
+    const res = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text }),
+    })
+    if (!res.ok) return { ok: false, error: `Slack webhook returned HTTP ${res.status}` }
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}

--- a/src/lib/notifications/teams.ts
+++ b/src/lib/notifications/teams.ts
@@ -1,0 +1,30 @@
+export type WebhookResult = { ok: true } | { ok: false; error: string }
+
+type Args = { title: string; text: string; themeColor?: string }
+
+/**
+ * Posts a MessageCard to a Microsoft Teams Connector webhook URL.
+ *
+ * Designed to be called fire-and-forget from the dispatcher — never throws;
+ * all failure modes are captured in the returned WebhookResult.
+ */
+export async function sendTeams(webhookUrl: string, args: Args): Promise<WebhookResult> {
+  const body = {
+    '@type': 'MessageCard',
+    '@context': 'https://schema.org/extensions',
+    themeColor: args.themeColor ?? '0078D7',
+    title: args.title,
+    text: args.text,
+  }
+  try {
+    const res = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    if (!res.ok) return { ok: false, error: `Teams webhook returned HTTP ${res.status}` }
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}


### PR DESCRIPTION
v1 ships 2 event-driven triggers (no cron needed): **high-score scored** (`overall_score >= threshold`, default 85) and **manager approve/reject decision**. Tenant-level Slack/Teams webhook URLs (encrypted, mirrors SMTP pattern) + per-trigger toggles + configurable threshold + test-message button.

## Files

**Backend:** `slack.ts`, `teams.ts`, `dispatcher.ts` (new) + hooks in `scoring.ts` and `approvals.ts` + `saveNotificationSetting`/`removeNotificationSetting`/`testNotificationDelivery`/`getNotificationSettings` server actions + 4 new audit actions.

**Frontend:** `notifications-panel.tsx` (new) + settings page edit.

## Deferred to v2

- Interview reminders (time-based; needs cron)
- Daily digest (time-based + per-user state)
- Stale priorities (depends on Epic #42)
- Per-user notification prefs (channel broadcasts don't support per-user mute; OAuth/DM v2 prerequisite)

## Test plan

- [x] Typecheck + lint clean
- [x] Dev server compiled cleanly
- [ ] Configure Slack webhook → score a candidate to 90+ → message arrives
- [ ] Configure Teams webhook → same
- [ ] Approve a candidate as hiring manager → both channels notify
- [ ] Toggle off high-score → next 90+ doesn't trigger
- [ ] Set threshold to 95 → 92 doesn't trigger; 96 does
- [ ] Audit log: `notification.high_score_sent` / `approval_sent` / `webhook_failed` rows on respective paths
- [ ] Failure isolation: invalid webhook URL → audit logs failure; main action still succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)