### PR TITLE
fix(notifications): drop NotificationTestResult type re-export from settings.ts

### DIFF
--- a/src/actions/settings.ts
+++ b/src/actions/settings.ts
@@ -12,7 +12,9 @@ import { writeAuditLog } from '@/lib/audit'
 import { isSupportedLanguage } from '@/lib/ai/language'
 import { getSenderForTenant } from '@/lib/email/sender'
 import { testWebhookDelivery, type NotificationTestResult } from '@/lib/notifications/dispatcher'
-export type { NotificationTestResult }
+// NOTE: NotificationTestResult is intentionally NOT re-exported here. This file
+// has 'use server' which restricts exports to async functions. Consumers must
+// import the type directly from '@/lib/notifications/dispatcher'.
 
 const ALLOWED_KEYS = [
   'anthropic_api_key',

--- a/src/components/settings/notifications-panel.tsx
+++ b/src/components/settings/notifications-panel.tsx
@@ -25,7 +25,7 @@ import {
   SendIcon,
 } from 'lucide-react'
 import { saveNotificationSetting, testNotificationDelivery } from '@/actions/settings'
-import type { NotificationTestResult } from '@/actions/settings'
+import type { NotificationTestResult } from '@/lib/notifications/dispatcher'
 
 // ---------------------------------------------------------------------------
 // Types


### PR DESCRIPTION
PR #168 broke the build by re-exporting a type from a `'use server'` file. Next 16 statically rejects non-async exports from server-action files.

Fix: drop the re-export; consumers import the type directly from `@/lib/notifications/dispatcher` (the original location). The settings.ts file gets an explanatory comment so future hands don't reintroduce the pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)