### PR TITLE
docs(help): catch up help articles with all features shipped since 2026-04-28

### DIFF
--- a/src/content/help/candidate-emails.md
+++ b/src/content/help/candidate-emails.md
@@ -3,8 +3,8 @@ title: "Sending emails to candidates"
 category: "Roles & Candidates"
 audience: ["recruiter", "admin"]
 order: 60
-lastUpdated: "2026-04-28"
-tags: ["emails", "smtp", "templates", "communications"]
+lastUpdated: "2026-05-01"
+tags: ["emails", "smtp", "templates", "communications", "welcome-letter"]
 ---
 
 # Sending emails to candidates
@@ -85,8 +85,15 @@ The Email History panel is hidden for hiring managers — they see the candidate
 
 **Send failed (red status badge in Email History)** — Hover the red badge to see the error message. Common causes: incorrect SMTP credentials, the recipient address rejected the email, or a network issue between SkillAI and your mail server. Check Settings → Email & SMTP and confirm the credentials are correct.
 
+## Want to attach a personalised welcome letter?
+
+If you're inviting a candidate to a screening or interview, the AI-generated **welcome letter PDF** pairs naturally with the screening-invite email. Generate the letter on the candidate detail page, download it, and attach it to your screening-invite send.
+
+The letter is one page, multilingual, and explains in the candidate's preferred language exactly why they were shortlisted (STAR-format strengths, tied to the role's competencies). It gives candidates a reason to be excited before they walk in. See [Welcome letter PDF for candidates](/dashboard/help/candidates-welcome-letter).
+
 ## See also
 
 - [Settings: API keys and SMTP](/dashboard/help/settings-api-keys)
+- [Welcome letter PDF for candidates](/dashboard/help/candidates-welcome-letter)
 - [Candidate statuses and the bench](/dashboard/help/candidates-statuses-and-bench)
 - [Uploading CVs](/dashboard/help/candidates-uploading-cvs)

--- a/src/content/help/candidates-welcome-letter.md
+++ b/src/content/help/candidates-welcome-letter.md
@@ -1,0 +1,59 @@
+---
+title: "Welcome letter PDF for candidates"
+category: "Roles & Candidates"
+audience: ["recruiter", "admin"]
+order: 36
+lastUpdated: "2026-05-01"
+tags: ["candidate", "pdf", "welcome-letter", "ai", "multilingual"]
+---
+
+# Welcome letter PDF for candidates
+
+The welcome letter is a one-page AI-generated PDF you can hand a candidate after they've been shortlisted for a role. It explains, in their preferred language, why they're a strong match — using their CV evidence formatted into STAR-style rows (Situation / Task / Action / Result).
+
+It is **not** a generic email template. Each letter is regenerated against the specific candidate × role pairing and reflects the actual scoring run, including the AI's reasoning.
+
+## When to use it
+
+- You've shortlisted a candidate and want to set the right tone before the interview.
+- You're sending the candidate to a customer (via the customer share-link flow) and want them to walk in primed about why they were chosen.
+- The candidate's first language isn't the role's primary language and you want to write in theirs without manually translating.
+
+## What's in the letter
+
+- A short personal greeting using the candidate's first name.
+- 3–4 STAR rows pulled from their CV, each tied to a competency the role explicitly asks for. The rows are stacked vertically (one per page-section) for easy scanning.
+- A "Karat section" — a structured paragraph framing the candidate's overall fit story for this specific role.
+- The agency / customer logos and your tenant branding in the header. Same logos as the candidate / role / shortlist PDFs use.
+
+The letter never includes day rates, internal notes, margin, or anything from the recruiter-private side of the candidate record. It's safe to hand directly to the candidate.
+
+## Generating one
+
+1. Open the candidate detail page for the candidate.
+2. The candidate must already have a score against at least one role — the letter is anchored to a specific scoring run.
+3. Click **"Generate welcome letter"** and pick the target role (if the candidate is on multiple).
+4. Pick the language (see below).
+5. Wait ~10–20 seconds for the AI to compose and the PDF to render. Click-to-download when ready.
+
+## Languages
+
+Languages are picked per-letter, not per-candidate. The current supported set covers the core European languages your tenant is configured for in **Settings → Default Pack Language** plus the candidate's CV language if SkillAi can detect one.
+
+If your candidate's CV is in Polish but the role is being interviewed in English, the AI can still write the letter in Polish — pick whichever language puts the candidate at ease. Score quality is unaffected by letter language; the letter is downstream of scoring.
+
+## What does NOT get regenerated automatically
+
+- **Editing the role's description** does not regenerate existing letters. If you change priority keywords or the role's `description` field after generating a letter, regenerate manually if you want the letter to reflect the new framing.
+- **Re-scoring the candidate** does not regenerate the letter either. The letter caches the snapshot of reasoning that existed when it was generated.
+
+This is intentional — recruiters often tweak the role description or re-run scoring multiple times, and silently rewriting downstream candidate-facing content would be unsafe.
+
+## Cost note
+
+Each letter is a Claude call against the candidate's full CV + the role's full description, plus a render pass. Cost shows up in the AI spend dashboard under the `welcome-letter` operation tag. Order-of-magnitude similar to a single scoring run.
+
+## Related
+
+- Sending a candidate to a customer: see "Sending candidates to a customer".
+- Customer-facing PDF (separate doc): the candidate PDF available from the role detail's `Sent to customer` panel is a different artefact — it's the candidate's full sanitised profile, not the letter.

--- a/src/content/help/dashboard-ai-spend.md
+++ b/src/content/help/dashboard-ai-spend.md
@@ -1,0 +1,60 @@
+---
+title: "AI spend dashboard"
+category: "Settings & Admin"
+audience: ["admin"]
+order: 65
+lastUpdated: "2026-05-01"
+tags: ["ai", "spend", "cost", "tokens", "reports"]
+---
+
+# AI spend dashboard
+
+Found at `/dashboard/reports/ai-spend` (or via the Reports landing page → "AI spend"). Admin-only.
+
+## What it shows
+
+Three layers, all scoped to the current tenant:
+
+1. **Headline cards** — total tokens, total estimated cost (USD), and number of AI calls in the selected window.
+2. **Operation breakdown** — same numbers split by what the call was for: scoring runs, interview pack generation, transcript analysis, welcome letter generation, CV reformatting, semantic search embeddings, and a catch-all `other` bucket for one-off calls.
+3. **Time-series chart** — daily cost, stacked by operation type, so you can see what's burning budget on which day.
+
+## Date-range presets
+
+The same `?range=7d|30d|90d|12mo` URL search-param model used by the Reports dashboard. Default: 30 days.
+
+## Where the numbers come from
+
+Every Claude / Gemini call routes through a single client wrapper that captures `{ tenantId, operation, model, promptTokens, completionTokens, costUsd }` and writes a row to `audit_logs` with `action = 'ai.api_call'`. The dashboard aggregates those rows in real time — there is no snapshot / cron / cached number to go stale.
+
+This means:
+- A call that just happened is visible within seconds.
+- If you re-run scoring for a candidate, that re-run shows up as a new row, not a replacement.
+- The `costUsd` is **estimated** using the per-token pricing table for each model. If Anthropic / Google change pricing, your historical numbers don't retroactively update — the at-the-time estimate sticks.
+
+## What the dashboard is NOT
+
+- **Not a billing source of truth.** Claude and Gemini bill you on their side; this dashboard is for operational sanity-checking. If your Anthropic invoice doesn't match this number to the dollar, that's expected.
+- **Not a per-user breakdown.** v1 aggregates by operation, not by recruiter. If you need to know who's burning the most tokens, look at audit_logs directly.
+- **Not a budget enforcement tool.** Spend is observed, not capped. Per-tenant rate limiting (set in `tenant_settings`) is the only enforcement layer today; it caps requests-per-window, not dollars.
+
+## Per-tenant API keys interaction
+
+If your tenant uses **per-tenant Anthropic / Gemini keys** (set in Settings → API keys), the calls hit your billing account directly and the spend you see here is what you actually pay. If your tenant falls back to platform keys (no per-tenant key configured), the spend is still tracked but billing flows to the platform operator — talk to them about reconciling.
+
+## Common patterns
+
+- **Sudden jump on a Tuesday morning:** usually a bulk CV upload + bulk score-run on a new role. Check the time-series chart and cross-reference the role's `audit_logs`.
+- **Welcome letter slice growing:** healthy signal that recruiters are actively shortlisting and personalising candidate communication. Each letter is one call, similar cost to a single scoring run.
+- **Transcript analysis dominating:** transcripts are long; analysis calls are the most token-heavy single op type. If this is eating budget, consider summarising transcripts before analysis or limiting transcript analysis to final-round candidates.
+- **Embeddings near-zero:** expected. Embeddings are tiny per call.
+
+## Exporting
+
+Each chart has an "Export CSV" button (same pattern as the Reports dashboard). The CSV format is RFC 4180.
+
+## Related
+
+- Per-tenant rate limiting: see "API tokens" article.
+- Per-tenant API keys: see "API keys: Anthropic, Gemini, Brave, GitHub".
+- General reporting dashboard: see "Reports dashboard".

--- a/src/content/help/keyboard-shortcuts.md
+++ b/src/content/help/keyboard-shortcuts.md
@@ -1,44 +1,75 @@
 ---
-title: "Keyboard shortcuts"
+title: "Keyboard shortcuts and the Cmd-K command palette"
 category: "Getting Started"
 audience: ["all"]
 order: 3
-lastUpdated: "2026-04-28"
-tags: ["shortcuts", "keyboard", "power-user", "roadmap"]
+lastUpdated: "2026-05-01"
+tags: ["shortcuts", "keyboard", "power-user", "command-palette", "cmd-k", "search"]
 ---
 
-# Keyboard shortcuts
+# Keyboard shortcuts and the Cmd-K command palette
 
-> **Status: coming soon.** Keyboard shortcuts are on the roadmap (Phase 4 — power-user navigation) but not yet shipped. This page exists so you know what to expect, not to document something that already works.
+The single most useful shortcut in SkillAi is **Cmd-K** (macOS) or **Ctrl-K** (Windows / Linux). It opens the global command palette — a search bar over every candidate, role, customer, and agency in your tenant. From anywhere in the app.
 
-## Why we haven't shipped this yet
+## The Cmd-K command palette
 
-SkillAI's UI is dense — ranked lists, status badges, score modals, comparison trays. Shortcuts genuinely help once the layout is stable, but adding them too early means rebinding everything later as the screens change. Phases 1–4 prioritised getting the workflow right; shortcuts come once the workflow stops moving.
+### What it does
 
-## What we plan to add
+Press **Cmd-K** (or **Ctrl-K**) anywhere in the dashboard. A search overlay drops down. Type a name, role title, customer name, or agency name. Results appear instantly, grouped by entity type. Press **Enter** on the highlighted row, or click — you're navigated straight to that page.
 
-When the feature lands you should expect, roughly:
+### What's searchable
 
-- **Global navigation** — jump between Dashboard, Roles, Candidates, Customers, Agencies and Settings without the mouse.
-- **List navigation** — move between candidates in a ranked role view, open the current row, change status, mark for comparison.
-- **Search** — focus the top-bar search from anywhere.
-- **Modals and dialogs** — close with `Esc`, confirm with `Enter`, never lose your scroll position when one opens.
-- **Help** — open this help portal from any screen.
+- **Candidates** — by first name, last name, email.
+- **Roles** — by title, customer-specific role ID, internal role ID.
+- **Customers** — by name.
+- **Agencies** — by name (including the per-tenant "Internal" agency).
 
-The exact bindings will be discoverable in-app via a `?` overlay that lists every shortcut for the current screen. We'd rather ship one good overlay later than a half-documented set of bindings now.
+The search is fuzzy — `kim su` will find "Kimberly Sutton". Type at least 2 characters; below that the palette shows the empty state.
 
-## What works today
+Results are RLS-scoped to your tenant. You'll never see another tenant's data, and managers see only candidates / roles they're assigned to via `role_managers`.
 
-The browser's native shortcuts work everywhere:
+### Keyboard nav inside the palette
+
+| Key | Action |
+|---|---|
+| `↑` / `↓` | Move between results |
+| `Enter` | Open the highlighted result |
+| `Esc` | Close the palette |
+| Click on backdrop | Close the palette |
+
+### Why Cmd-K matters
+
+The browser's back/forward and the sidebar navigation both work, but they're slower than typing. If you're triaging 20 candidates across 5 roles, typing the name and hitting Enter is consistently 2–4× faster than clicking through. The palette becomes muscle memory after a day.
+
+### Speed notes
+
+- The palette query is debounced 200 ms — so a fast typist isn't sending a request per keystroke.
+- Results cap at 5 per category to keep the list scannable.
+- If you don't see what you expected, type more characters — there's no "load more". The palette is for fast jumps, not exhaustive listing.
+
+## Other keyboard behaviour
+
+The browser's native keyboard works everywhere:
 
 - `Tab` / `Shift+Tab` to move between interactive elements.
 - `Enter` / `Space` to activate the focused element.
 - `Esc` to close most dialogs.
-- `Ctrl+F` (or `Cmd+F` on macOS) to search within the current page — handy on long candidate lists.
+- `Cmd+F` / `Ctrl+F` to search within the current page (e.g. a long candidate list).
 
-If you have strong opinions about which shortcuts matter most, tell your admin so they can flag it on the roadmap. Real recruiter input is what will drive the bindings we eventually choose.
+Forms honour the standard pattern: `Enter` submits, `Esc` cancels.
+
+## What's NOT a keyboard shortcut yet
+
+We deliberately haven't added per-page shortcuts (e.g. `J/K` to move between candidates in the ranked list, `S` to change status). The screens are still shifting as the workflow matures, and rebinding everything later is more painful than not having them now.
+
+If you want a specific shortcut, tell your admin. The bar for adding more is "this saves 5+ seconds × 50+ times a day" — point shortcuts at workflows you actually do constantly, not edge cases.
+
+## Mobile
+
+Cmd-K isn't reachable from a phone keyboard. The mobile top app bar has a search icon that opens the same command palette as a tap target. See "Using SkillAi on your phone" for the full mobile rundown.
 
 ## See also
 
-- [Welcome to SkillAI](/dashboard/help/welcome)
+- [Welcome to SkillAi](/dashboard/help/welcome)
 - [Your first role](/dashboard/help/your-first-role)
+- [Using SkillAi on your phone](/dashboard/help/mobile-and-pwa)

--- a/src/content/help/manager-getting-started.md
+++ b/src/content/help/manager-getting-started.md
@@ -3,8 +3,8 @@ title: "Hiring manager: what you'll see when you log in"
 category: "Hiring Manager Workflow"
 audience: ["hiring_manager", "admin"]
 order: 10
-lastUpdated: "2026-04-28"
-tags: ["hiring-manager", "onboarding", "approvals"]
+lastUpdated: "2026-05-01"
+tags: ["hiring-manager", "onboarding", "approvals", "shareable-notes"]
 ---
 
 # Hiring manager: what you'll see when you log in
@@ -33,6 +33,12 @@ When you open a shortlisted candidate, you get the parts of the profile that mat
 - **Interview transcript analysis** (if uploaded) — how the candidate scored against the role in their actual interview.
 
 You will **not** see day rates, margin, or internal recruiter notes. Those are scrubbed from the manager view by design — your job is to judge fit, not to negotiate the commercial terms.
+
+### Shareable notes
+
+You will see notes the recruiter has explicitly marked **shareable**. The default for any new note is **private** (recruiter-only) — recruiters opt-in per note when they want managers to see it. This is a deliberate safety: notes often contain recruiter shorthand or commercially sensitive comments that aren't meant for the hiring panel.
+
+If you expect a note to be visible and it isn't, the recruiter hasn't toggled the shareable flag yet. Ask them; they can flip it in seconds without rewriting the note.
 
 ## What you do here
 

--- a/src/content/help/mobile-and-pwa.md
+++ b/src/content/help/mobile-and-pwa.md
@@ -1,0 +1,74 @@
+---
+title: "Using SkillAi on your phone (mobile + PWA)"
+category: "Getting Started"
+audience: ["all"]
+order: 27
+lastUpdated: "2026-05-01"
+tags: ["mobile", "pwa", "responsive", "ios", "android"]
+---
+
+# Using SkillAi on your phone (mobile + PWA)
+
+Every page in SkillAi works on small screens. The portal is fully responsive from a 320 px-wide viewport upwards, and you can install it as a PWA (Progressive Web App) for a phone-like experience without going through the App Store / Play Store.
+
+## What's responsive
+
+- **Sidebar → drawer.** On phones the sidebar is hidden behind a hamburger menu in the top app bar. Tap to slide it in; tap the backdrop to dismiss.
+- **Top app bar.** A compact bar at the top of every dashboard page on mobile shows the page title and your avatar. The Cmd-K search button is also there.
+- **Candidate list as cards.** Below the `xs:400` breakpoint the candidate list collapses from table rows to stacked cards — easier to scan with a thumb. Bulk-select still works via the checkbox on each card.
+- **Candidate detail reflow.** The two-column layout collapses to one column on phones. The score breakdown and notes stack below the candidate header rather than sitting beside it.
+- **Manager mobile Approve / Reject.** Hiring managers reviewing on their phone get a sticky bottom bar with Approve / Reject / Comment so the action stays in reach.
+- **Comparison tray repositioning.** When comparing candidates on a phone, the tray docks to the bottom of the screen rather than floating right.
+- **Forms + modals.** All form fields and modal dialogs honour the 44 px minimum tap-target size required for iOS / Android accessibility.
+
+## Installing as a PWA
+
+### iOS (Safari)
+1. Open SkillAi in Safari (not Chrome on iOS — iOS PWA install is Safari-only).
+2. Tap the share icon (the box with an up arrow) at the bottom of the screen.
+3. Scroll down → **Add to Home Screen**.
+4. Confirm the name and tap Add.
+5. SkillAi appears as an app icon. Tapping it opens the portal in a fullscreen window with no Safari chrome.
+
+### Android (Chrome)
+1. Open SkillAi in Chrome.
+2. Tap the three-dot menu (top right) → **Install app** (or **Add to Home screen**).
+3. Confirm the name and tap Install.
+4. SkillAi appears in your app drawer + home screen.
+
+### Desktop (Chrome / Edge)
+1. Open SkillAi.
+2. Look for the install icon in the URL bar (a small monitor with a down arrow).
+3. Click → Install.
+4. SkillAi opens as a standalone desktop app window.
+
+## What the PWA gives you
+
+- **Home-screen icon** with the SkillAi logo.
+- **Standalone window** — no browser address bar, no tab clutter.
+- **Offline shell** — if you lose connectivity mid-session, the app shell stays loaded and you'll see a graceful offline indicator instead of a "no internet" browser page.
+- **Faster load** — the static shell (CSS, fonts, JS) is cached. First navigation after launch is near-instant.
+
+## What the PWA does NOT give you
+
+- **Offline editing.** SkillAi is data-heavy and tenant-isolated; we do not cache candidate data or scoring runs offline. If you're offline, you can open the app but most pages will say "couldn't load."
+- **Push notifications.** Not implemented in v1. Use email notifications (Slack / Teams webhooks for tenant-wide events).
+- **Native camera / file system access** beyond what the browser provides. CV upload still goes through the standard file-picker.
+
+## Things to know on a phone
+
+- **The Cmd-K command palette** is reachable from the top app bar's search icon on mobile (no keyboard shortcut).
+- **Light / dark theme** follows your system preference by default. Override in the sidebar drawer (sun / moon button above sign-out).
+- **Long forms** (creating a role, editing a candidate) are still long. The mobile layout stacks fields cleanly but the form itself is the same — there's no "mobile-only minimal create" flow. If you're doing a lot of creation, prefer desktop.
+- **Bulk operations** are designed mobile-friendly. Selecting 5 candidates and bulk-changing status works well on a phone; selecting 50 does not.
+
+## Troubleshooting
+
+- **Install option missing.** PWA install requires HTTPS. If you're hitting SkillAi over plain HTTP (dev environment), iOS Safari and Android Chrome both hide the install option.
+- **Logged-out unexpectedly after install.** PWAs share cookies with the source browser. If you cleared Safari cookies after installing, re-open and sign in again.
+- **Sidebar drawer doesn't dismiss.** Tap the dark backdrop area outside the drawer, not just the menu button.
+
+## Related
+
+- Light/dark theme: see "Light and dark theme".
+- Cmd-K command palette: see "Keyboard shortcuts".

--- a/src/content/help/notifications-slack-teams.md
+++ b/src/content/help/notifications-slack-teams.md
@@ -1,0 +1,90 @@
+---
+title: "Slack and Teams webhook notifications"
+category: "Settings & Admin"
+audience: ["admin"]
+order: 67
+lastUpdated: "2026-05-01"
+tags: ["notifications", "slack", "teams", "webhook", "integrations"]
+---
+
+# Slack and Teams webhook notifications
+
+SkillAi can push key tenant events to a Slack channel or Microsoft Teams channel via an incoming webhook. No OAuth dance, no app to install — just paste the webhook URL into Settings and pick the events you care about.
+
+Admin-only setup. Once configured, the notifications are tenant-wide — every recruiter and admin's actions trigger them; messages aren't per-user.
+
+## Supported platforms
+
+- **Slack** — incoming webhook (the kind you create in a Slack app's "Incoming Webhooks" feature).
+- **Microsoft Teams** — channel webhook (Teams' MessageCard format).
+
+You can configure one of each, both, or neither. They're independent.
+
+## Which events trigger notifications
+
+Pick which events fire from the Settings → Notifications panel. Available triggers:
+
+- **New candidate submission** — a recruiter sent candidates to a customer for a role.
+- **Customer feedback** — a customer changed a submission status (accepted / rejected / interview_requested) or left a comment.
+- **Manager approval decision** — a hiring manager approved or rejected a candidate via the manager workflow.
+- **Role expired** — a role's `cutoffDate` passed and it's still active.
+- **AI scoring failure** — a CV failed to score after retries (so you can intervene before the candidate sits stuck).
+- **Test event** — manual button that fires a single test message; use this to verify the webhook works.
+
+Every event type is opt-in. None fire unless you explicitly enable it.
+
+## Setting up Slack
+
+1. In Slack: **Apps → Manage → Custom Integrations → Incoming WebHooks** (or via a custom app's Incoming Webhooks page).
+2. Pick the target channel.
+3. Slack gives you a webhook URL like `https://hooks.slack.com/services/T0XXX/B0XXX/XXXXXXXX`.
+4. Copy it.
+5. In SkillAi: **Settings → Notifications → Slack webhook URL** → paste → Save.
+6. Click **Send test** and confirm a message appears in the Slack channel.
+7. Tick the events you want to fire.
+
+## Setting up Microsoft Teams
+
+1. In Teams: open the target channel → **More options** (...) → **Manage channel** → **Connectors** → **Incoming Webhook**.
+2. Name it (e.g. "SkillAi Notifications") and click Create.
+3. Teams gives you a webhook URL.
+4. Copy it.
+5. In SkillAi: **Settings → Notifications → Teams webhook URL** → paste → Save.
+6. Click **Send test** and confirm a message appears in the Teams channel.
+7. Tick the events you want to fire.
+
+## What the messages look like
+
+**Slack** — plain text JSON payload with a single line per event. Mentions the actor, the entity (role / candidate), and a direct link back into SkillAi.
+
+**Teams** — MessageCard format with a title, a short body, and an "Open in SkillAi" action link. Renders as a card in the channel.
+
+Both formats include enough context to act on without opening SkillAi (who, what, which role) but link back for the detailed view.
+
+## What's NOT included in the payload
+
+- **No CV text or candidate PII** beyond the candidate's first name + last name.
+- **No day rates, margin, or commercial data.**
+- **No AI reasoning or scoring detail.**
+
+This keeps it safe to point the webhook at a wide channel without accidentally leaking interview content. If you want detailed messages, click through the link.
+
+## Security notes
+
+- **Webhook URLs are secrets.** Anyone holding the Slack / Teams URL can post messages into the channel. SkillAi stores the URL encrypted (AES-256-GCM) in `tenant_settings`. The UI masks it after save and only shows a "Replace" affordance.
+- **Rotate when in doubt.** If a webhook URL leaks (e.g. accidentally pasted into a public chat), regenerate from Slack / Teams and update the value in SkillAi. Old URL stops working immediately.
+- **Tenant isolation.** Tenant A's webhook URL is invisible to tenant B; the encryption key is per-platform but the row is filtered by `tenant_id` like every other tenant_settings row.
+
+## Failure handling
+
+- If the webhook returns a 4xx / 5xx, SkillAi logs the failure to `audit_logs` (action `notification.send_failed`) but does not block the underlying SkillAi operation. You'll see a stale message stream rather than failed core actions.
+- If your Slack / Teams workspace deletes the webhook, the next event fires, fails, and audit-logs. Re-create the webhook and update the URL in Settings.
+
+## When NOT to use webhook notifications
+
+If you want **per-user** notifications (e.g. "ping me when MY submission gets feedback"), use the email notification on submissions instead — it's already wired to fire to the recruiter who sent the submission. Webhooks are tenant-wide and broadcast.
+
+## Related
+
+- Per-tenant API keys (different concept — these are AI provider keys, not webhook URLs): see "API keys: Anthropic, Gemini, Brave, GitHub".
+- Audit logging: see "Troubleshooting: when things don't work" for how to inspect `audit_logs` directly.

--- a/src/content/help/roles-creating-and-editing.md
+++ b/src/content/help/roles-creating-and-editing.md
@@ -3,8 +3,8 @@ title: "Creating and editing roles"
 category: "Roles & Candidates"
 audience: ["recruiter", "admin"]
 order: 10
-lastUpdated: "2026-04-28"
-tags: ["roles", "create", "edit", "deadlines", "budget"]
+lastUpdated: "2026-05-01"
+tags: ["roles", "create", "edit", "deadlines", "budget", "customer-role-id"]
 ---
 
 # Creating and editing roles
@@ -19,6 +19,7 @@ From **Roles → New role**, fill in:
 
 - **Title** — visible to candidates on interview packs and on customer-facing PDFs. Use the real job title, not an internal code.
 - **Customer** — pick the client this role is for, or skip if it's an internal hire. New customers can be added without leaving the form. See [Customers and frameworks](/dashboard/help/customers-and-frameworks).
+- **Customer-specific role ID** (optional) — the reference the customer uses for this role on their side, e.g. `ACME-2026-042` or whatever code they put in their requisition system. Independent of SkillAi's internal role ID. Shows up next to the role title on the role detail page, on the customer share-link view, and on the customer-facing PDF — so when the customer emails you "any update on ACME-2026-042?" you can find it instantly. The internal SkillAi role ID is unchanged and remains the canonical key everywhere else.
 - **Framework level** — if the customer has a hiring framework configured (Junior / Mid / Senior / Principal etc.), pick the level here. The AI uses this when judging experience level.
 
 ### Description

--- a/src/content/help/roles-customer-submissions.md
+++ b/src/content/help/roles-customer-submissions.md
@@ -1,0 +1,92 @@
+---
+title: "Sending candidates to a customer (submissions + share-link feedback)"
+category: "Roles & Candidates"
+audience: ["recruiter", "admin"]
+order: 22
+lastUpdated: "2026-05-01"
+tags: ["roles", "customer", "submissions", "share-link", "shortlist"]
+---
+
+# Sending candidates to a customer (submissions + share-link feedback)
+
+Once you've ranked candidates against a role and the customer is ready to look, you can formally **submit** a subset to the customer. SkillAi tracks each submission, gives you a customer-facing share-link they can review through, and surfaces their feedback in your dashboard so you can act on it without chasing email replies.
+
+This replaces the previous flow of "email a PDF, hope they reply, manually track in a spreadsheet."
+
+## The flow at a glance
+
+1. On the role detail page, select the candidates you want to submit (checkbox column).
+2. Click **Send to customer** — choose to share the customer's pre-existing portal base URL or generate a per-role share-link.
+3. SkillAi bundles the customer-safe candidate PDFs (no rates / margin / agency / internal notes) and creates a `submission` record per candidate.
+4. Each candidate gets a status pill: `pending` → `under_review` → `accepted` / `rejected` / `interview_requested`.
+5. The customer reviews the link, submits per-candidate feedback inline, and SkillAi emails you the moment any status changes.
+6. The dashboard's "Awaiting customer feedback" widget shows everything still outstanding so nothing is lost.
+
+## On the role detail page
+
+A new **Sent to customer** panel sits below the ranked candidate list. It shows every candidate you've already submitted for this role, with:
+
+- The submission status pill (see below).
+- The date sent.
+- A timestamp of the customer's last response, if any.
+- A direct link to the customer's view of that candidate's PDF.
+
+If a candidate is still on the role but not yet submitted, the **Send to customer** action remains available. You can submit additional candidates to the same role over time — submissions are append-only.
+
+## Submission status pill
+
+Each submitted candidate carries one of:
+
+- **`pending`** — submitted, the customer hasn't opened the link yet.
+- **`under_review`** — the customer has opened the candidate's view at least once.
+- **`accepted`** — the customer marked them a yes (typically meaning "let's interview").
+- **`rejected`** — the customer marked them a no, with optional comment.
+- **`interview_requested`** — the customer wants you to schedule an interview. Useful when "accepted" alone doesn't capture the next step.
+
+The pill colour scheme follows the standard status pill pattern (token-based for light/dark mode parity).
+
+## The customer share-link
+
+The link is **per-role** — it scopes the customer to the candidates you submitted on that specific role. They cannot see other roles, candidates not on this submission, or any internal SkillAi data.
+
+What the customer sees:
+- Each submitted candidate's customer-facing PDF (same artefact as the existing candidate PDF customer variant).
+- A simple status dropdown per candidate.
+- A free-text comment box per candidate.
+
+What the customer does NOT see:
+- Day rates, margin, or budget.
+- Agency identity / internal notes.
+- Other candidates on the role they weren't sent.
+- Other roles or any tenant data.
+
+The link is bearer-token style — anyone holding the URL can submit feedback. Treat it like a Google Doc share-link: send it through the customer's expected channel, and rotate or revoke if it leaks (the URL is single-use-style and can be invalidated from the role detail panel).
+
+## Email notifications back to you
+
+When a customer changes a candidate's submission status or leaves a comment, SkillAi emails the recruiter who originally sent the submission. The email includes:
+- Which candidate.
+- Which role.
+- The new status + comment if any.
+- A direct link to the candidate detail page.
+
+This means you don't need to refresh the role detail page — your inbox is the trigger.
+
+## Awaiting customer feedback dashboard widget
+
+A new widget on `/dashboard` shows every submission that's `pending` or `under_review` across all your roles, ordered by oldest-first. If a customer is sitting on a candidate for too long, you'll see it here without hunting.
+
+## Submissions index page
+
+Visit `/dashboard/roles/submissions` for the cross-role view: every submission you've ever sent, grouped by customer, filterable by status. Useful for monthly reporting ("how many candidates did I submit this month and what was the accept rate per customer").
+
+## Tips
+
+- Submit in small batches (3–5) rather than a 20-candidate dump. Customers respond faster to a curated shortlist.
+- Re-submitting a candidate that was previously rejected creates a new submission row — the old `rejected` status stays in the history. Use the comment field to explain "round 2 — different team".
+- The customer's view is read-only on candidate content. They cannot edit the PDF or see your scoring; only respond with status + comment.
+
+## Related
+
+- Customer-facing PDF format: see "Customers, hiring frameworks, and customer portal links".
+- Audience-based view sanitisation (what customers see vs recruiters): see the architecture pattern in CLAUDE.md.

--- a/src/content/help/theme-light-dark.md
+++ b/src/content/help/theme-light-dark.md
@@ -1,0 +1,63 @@
+---
+title: "Light and dark theme"
+category: "Getting Started"
+audience: ["all"]
+order: 28
+lastUpdated: "2026-05-01"
+tags: ["theme", "light-mode", "dark-mode", "ui"]
+---
+
+# Light and dark theme
+
+SkillAi has full light and dark mode coverage across every page, panel, modal, and PDF preview. The default is **system** — SkillAi follows whatever your OS / browser is set to (light during the day, dark at night, if you have macOS / Windows / Android set to auto).
+
+## How to change theme
+
+Look at the sidebar (or sidebar drawer on mobile). Just above the sign-out button you'll see three options:
+
+- **System** (default) — follow OS preference. Switches automatically when your OS does.
+- **Light** — force light mode regardless of OS.
+- **Dark** — force dark mode regardless of OS.
+
+The choice is per-browser (stored in `localStorage`), not per-tenant or per-user. If you sign in on a different device, that device's setting applies.
+
+## What changes
+
+- All page surfaces (sidebar, dashboard cards, role / candidate detail panels, forms, modals).
+- Status pills (e.g. `pending` / `accepted` / `rejected`) — both modes get readable contrast.
+- Borders and dividers.
+- Form inputs.
+- The login page.
+
+## What stays constant across modes
+
+- **Saturated accent colours** (the blue Submit buttons, the red Delete buttons, etc.) are theme-invariant. They're solid action colours and need to read the same in both modes.
+- **AI-generated PDFs** (candidate, role, shortlist, interview pack, welcome letter) are always rendered in light mode. PDFs are designed to be printed and shared; dark-mode PDFs would be a usability disaster.
+- **Charts and reports** use a single neutral palette that works in both modes.
+
+## Accessibility
+
+Both modes are tested against WCAG AA contrast standards. If you find a panel that's hard to read, that's a bug — open an issue with a screenshot and what mode you're in.
+
+## When to use which
+
+- **System** is the right answer for almost everyone. Your OS is already calibrated to your environment.
+- **Light** is good for screen-shares (especially in well-lit rooms / projector environments) where dark mode tends to "burn" through.
+- **Dark** is easier on the eyes for long reading sessions (reviewing a stack of CVs late at night).
+
+## Why "system" is the default
+
+Browsers honour the OS-level preference automatically (`prefers-color-scheme`), so SkillAi just follows along. This means:
+- New users immediately get the right theme without configuring anything.
+- A user with auto-switching OS gets auto-switching SkillAi.
+- A user who's set their OS once and forgotten gets the theme they've already decided is right.
+
+## Troubleshooting
+
+- **Theme flicker on page load.** Should be near-zero — SkillAi sets the theme before the first paint to avoid the "white flash on dark mode" anti-pattern. If you see flicker, hard-reload (Cmd-Shift-R / Ctrl-Shift-R) to clear cached HTML.
+- **Switched to Light but page header is still dark.** Some browser extensions inject their own dark-mode CSS. Disable the extension on the SkillAi domain.
+- **Theme persisted across sign-out / sign-in:** intentional. The setting is browser-local, not tied to your account.
+
+## Related
+
+- Mobile + PWA install: see "Using SkillAi on your phone".

--- a/src/content/help/welcome.md
+++ b/src/content/help/welcome.md
@@ -3,8 +3,8 @@ title: "Welcome to SkillAI"
 category: "Getting Started"
 audience: ["all"]
 order: 1
-lastUpdated: "2026-04-28"
-tags: ["overview", "intro", "orientation"]
+lastUpdated: "2026-05-01"
+tags: ["overview", "intro", "orientation", "what's-new"]
 ---
 
 # Welcome to SkillAI
@@ -20,6 +20,21 @@ SkillAI is your team's internal recruiting portal. It does one job well: rank ca
 - Generate interview packs (questions + optional code challenges) tailored to each candidate-role pair.
 - Upload interview transcripts and get an AI second opinion on how the conversation went.
 - Export candidate profiles, role briefs and shortlists as PDFs — internal-detailed or customer-sanitised.
+- Send candidates to a customer with a per-role share-link the customer responds through — feedback flows back to your dashboard, no email chasing. See [Sending candidates to a customer](/dashboard/help/roles-customer-submissions).
+- Generate AI-personalised, multilingual welcome letters for shortlisted candidates. See [Welcome letter PDF for candidates](/dashboard/help/candidates-welcome-letter).
+
+## What's new
+
+The portal has shipped a lot recently. The headlines:
+
+- **Light + dark theme** across every page — toggle from the sidebar above sign-out, or follow your OS preference. See [Light and dark theme](/dashboard/help/theme-light-dark).
+- **Mobile + PWA support** — every page is responsive and you can install SkillAi as a phone / desktop PWA. See [Using SkillAi on your phone](/dashboard/help/mobile-and-pwa).
+- **Cmd-K command palette** — press Cmd-K (Ctrl-K on Windows / Linux) anywhere to jump to a candidate, role, customer, or agency. See [Keyboard shortcuts and the Cmd-K command palette](/dashboard/help/keyboard-shortcuts).
+- **Customer share-links + submissions tracking** — track what you've sent to which customer, get email-back on customer feedback. See [Sending candidates to a customer](/dashboard/help/roles-customer-submissions).
+- **Welcome letter PDF** — AI-personalised multilingual one-pager for shortlisted candidates.
+- **Slack + Teams notifications** — pipe key tenant events into your team chat. See [Slack and Teams webhook notifications](/dashboard/help/notifications-slack-teams).
+- **AI spend dashboard** — admin-only token-and-cost breakdown by operation type and over time. See [AI spend dashboard](/dashboard/help/dashboard-ai-spend).
+- **Customer-specific role IDs** — the reference the customer uses for the role on their side, displayed alongside SkillAi's internal ID.
 
 ## How the pieces fit together
 


### PR DESCRIPTION
## Summary

Brings the in-app help portal current with every feature shipped since the last help-content sweep (2026-04-28). Six new articles + five updated.

**New articles**
- \`candidates-welcome-letter.md\` — multilingual welcome letter PDF (PRs #144, #145, #148)
- \`roles-customer-submissions.md\` — sent-to-customer flow, share-link feedback, dashboard widget, submissions index (PRs #147, #150, #160)
- \`dashboard-ai-spend.md\` — admin-only token / cost breakdown (PR #152)
- \`mobile-and-pwa.md\` — responsive layout + PWA install for iOS / Android / desktop (PRs #155–#159)
- \`theme-light-dark.md\` — sidebar toggle + system-preference behaviour (PRs #161–#165)
- \`notifications-slack-teams.md\` — webhook setup + event triggers (PR #168)

**Updated**
- \`welcome.md\` — adds a \"What's new\" section and cross-links to all six new articles
- \`keyboard-shortcuts.md\` — replaced the \"coming soon\" placeholder with full Cmd-K command palette docs (PR #170)
- \`roles-creating-and-editing.md\` — added customer-specific role ID field (PR #141)
- \`candidate-emails.md\` — cross-link to welcome letter PDF for screening-invite pairing
- \`manager-getting-started.md\` — clarified shareable-notes default (PR #166): notes default to private; recruiters opt-in per note

Every touched article gets \`lastUpdated: 2026-05-01\`. All 35 articles parse cleanly against the Zod front-matter schema.

## Test plan

- [x] All 35 markdown files parse cleanly (validated via gray-matter inside the running container)
- [x] Front-matter required fields (\`title\`, \`category\`, \`audience\`, \`order\`, \`lastUpdated\`) present everywhere; \`lastUpdated\` matches \`YYYY-MM-DD\` regex
- [x] No \`summary\` field leakage (Zod schema doesn't include it; stripped from all new files for consistency)
- [ ] Reviewer spot-checks at least one new article in the running app via \`/dashboard/help\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)