### PR TITLE
ci: add test/typecheck/build gate for core-mvp-foundation PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,140 @@
+# ci.yml
+#
+# Continuous integration gate for pull requests targeting core-mvp-foundation.
+#
+# Runs three jobs in parallel where possible:
+#   1. test      — vitest unit + integration tests (excludes DB integration tests
+#                  that require RUN_DB_INTEGRATION_TESTS=true and a live Postgres)
+#   2. typecheck — tsc --noEmit across the whole project (src + tests)
+#   3. build     — next build with stub env vars to catch compile-time errors
+#                  (depends on test + typecheck so we don't waste build minutes
+#                  on a branch that's already red)
+#
+# Why stub env vars for build:
+#   next.config.ts uses `output: 'standalone'` and all routes carry
+#   `export const dynamic = 'force-dynamic'` so no static prerendering runs.
+#   The postgres pool is created at module scope but connections are lazy —
+#   no TCP connection is attempted until a query executes. AUTH_SECRET and
+#   ENCRYPTION_KEY are only validated at request time, not build time.
+#   Therefore a syntactically-valid placeholder is sufficient for `next build`.
+#
+# Why not lint:
+#   ESLint is currently not enforced in the project's CI (no eslint config
+#   produces zero warnings on the codebase today). Lint is deferred to a
+#   follow-up PR that establishes a clean baseline before gating it.
+#
+# Why not e2e:
+#   Playwright e2e tests (test:e2e) require a running Postgres + Next.js server
+#   and are therefore not suitable for this PR-gate workflow. They will be
+#   addressed in a dedicated e2e-in-CI spec.
+
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - core-mvp-foundation
+  push:
+    branches:
+      - core-mvp-foundation
+
+# Cancel in-progress runs for the same PR or branch so stale runs
+# don't consume runners after a force-push.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # 1. test — vitest run (NODE_ENV=test is set in the npm script)
+  # ---------------------------------------------------------------------------
+  test:
+    name: Tests (vitest)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Setup Node 22
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        # NODE_ENV must NOT be 'production' here — that causes npm ci to omit
+        # devDependencies (including vitest). Unset it explicitly.
+        env:
+          NODE_ENV: test
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+  # ---------------------------------------------------------------------------
+  # 2. typecheck — tsc --noEmit across src/ + tests/
+  # ---------------------------------------------------------------------------
+  typecheck:
+    name: Typecheck (tsc)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Setup Node 22
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        env:
+          NODE_ENV: test
+        run: npm ci
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+  # ---------------------------------------------------------------------------
+  # 3. build — next build with stub env vars
+  # ---------------------------------------------------------------------------
+  build:
+    name: Build (next build)
+    runs-on: ubuntu-latest
+    needs:
+      - test
+      - typecheck
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Setup Node 22
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        # Build only needs prod + peer deps, but NODE_ENV=test ensures a
+        # consistent install regardless of the host environment variable.
+        env:
+          NODE_ENV: test
+        run: npm ci
+
+      - name: Build
+        # DATABASE_URL: stub connection string — pool is created lazily; no
+        #   TCP connection is made during build because all routes are force-dynamic.
+        # AUTH_SECRET: Auth.js v5 requires a value at runtime; during build
+        #   no request handlers execute, so any non-empty string is sufficient.
+        # ENCRYPTION_KEY: used only in request-time crypto helpers; not
+        #   evaluated during static analysis.
+        # NEXT_TELEMETRY_DISABLED: suppress telemetry pings from CI runners.
+        env:
+          DATABASE_URL: 'postgresql://ci:ci@localhost:5432/ci_stub'
+          AUTH_SECRET: 'ci-stub-secret-must-be-at-least-32-chars-x'
+          ENCRYPTION_KEY: 'ci-stub-encryption-key-placeholder'
+          NEXT_TELEMETRY_DISABLED: '1'
+        run: npm run build

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -9,7 +9,7 @@ if (typeof (Promise as unknown as { try?: unknown }).try !== 'function') {
   ;(Promise as unknown as { try: typeof Promise.try }).try = function tryPolyfill<T, A extends unknown[]>(
     fn: (...args: A) => T | PromiseLike<T>,
     ...args: A
-  ): Promise<T> {
-    return new Promise<T>((resolve) => resolve(fn(...args)))
+  ): Promise<Awaited<T>> {
+    return new Promise<Awaited<T>>((resolve) => resolve(fn(...args) as Awaited<T>))
   }
 }

--- a/tests/unit/lib/calendar/sync-loop.test.ts
+++ b/tests/unit/lib/calendar/sync-loop.test.ts
@@ -263,8 +263,9 @@ describe('runCalendarSync', () => {
   })
 
   it('3. reschedule detected — event start changed → slot updated + audit fired', async () => {
-    const newStart = new Date('2026-05-02T14:00:00Z')
-    const newEnd = new Date('2026-05-02T15:30:00Z')
+    // Use a date 7 days in the future so the past-event skip (event.start < now-1d) never fires
+    const newStart = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+    const newEnd = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000 + 90 * 60 * 1000)
     // Event snapshot has a different start than the slot
     mockListGoogleEvents.mockResolvedValue({
       events: [makeSnapshot({

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,9 @@ import { resolve } from 'path'
 // NODE_ENV=production for the running app, which would otherwise propagate to
 // vitest workers and cause React 19 to load `cjs/react.production.js` — which
 // does not export `React.act`, breaking @testing-library/react.
-process.env.NODE_ENV = 'test'
+// The cast bypasses the strict-mode read-only typing on NodeJS.ProcessEnv while
+// keeping the assignment at runtime where it is valid.
+;(process.env as Record<string, string>)['NODE_ENV'] = 'test'
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` with three jobs: **test**, **typecheck**, and **build**
- Triggers on `pull_request` targeting `core-mvp-foundation` and `push` to `core-mvp-foundation`
- Concurrency group cancels stale in-progress runs on force-push

## What each job runs

| Job | Command | Notes |
|-----|---------|-------|
| `test` | `npm ci` + `npm test` | vitest run; 464 pass, 4 DB-integration tests skipped |
| `typecheck` | `npm ci` + `npx tsc --noEmit` | covers `src/` + `tests/` |
| `build` | `npm ci` + `npm run build` | stub env vars; see below |

**Build job stub env vars:** `DATABASE_URL`, `AUTH_SECRET`, `ENCRYPTION_KEY` are set to syntactically-valid placeholders. All routes carry `export const dynamic = 'force-dynamic'` so no static prerendering fires and the postgres pool never makes a TCP connection. `next build` exits 0 with 47 `ƒ (Dynamic)` routes.

**Build depends on test + typecheck** to avoid spending runner minutes on a branch that is already red.

## Prerequisites bundled in this PR

Three commits cherry-picked from `docs/mcp-claude-code-integration` are included because `core-mvp-foundation` HEAD has 23 failing tests without them:

1. `docs(mcp)` — MCP documentation and tool catalogue (no code changes)
2. `test: bring vitest suite to green` — vitest.config.ts + package.json scripts + test file fixes only; **no production code changed**
3. `fix(test): sync-loop test 3 stale date` — hardcoded `2026-05-02` event date had passed the 24-hour past-event skip threshold; replaced with `Date.now() + 7d`

Also fixes two TypeScript strict-mode errors in the test infrastructure introduced by the cherry-picked test commit.

## Deliberately not gated (follow-up PRs)

- **ESLint** — no clean zero-warning baseline exists today; establishing one is a separate PR
- **Playwright e2e** (`npm run test:e2e`) — requires a running Postgres + Next.js server; dedicated e2e-in-CI spec needed
- **Docker build** — multi-stage Docker build is not gated here; addressed in a follow-up

## Test plan

- [ ] Merge this PR — the three CI jobs should show green on the PR check list
- [ ] Open a test PR against `core-mvp-foundation` with a trivial change; all three jobs should run and pass
- [ ] Introduce a deliberate type error in a test file; `typecheck` job should fail while `test` continues
- [ ] Confirm `test` job fails loudly if a unit test is broken (not silently skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)