### PR TITLE
refactor(audit): introduce emitAudit helper, migrate 37 of 79 audit call sites

### DIFF
--- a/src/actions/gdpr.ts
+++ b/src/actions/gdpr.ts
@@ -31,7 +31,7 @@ import {
 } from '@/db/schema'
 import { getActionContext } from '@/lib/auth/action-context'
 import { requireRole } from '@/lib/auth/require-role'
-import { writeAuditLog } from '@/lib/audit'
+import { emitAudit } from '@/lib/audit-middleware'
 import { deleteCvFile } from '@/lib/cv/store'
 
 // ---------------------------------------------------------------------------
@@ -264,7 +264,7 @@ export async function deleteCandidateForGdpr(
   // now deleted), so no additional file deletion is needed.
 
   // 9. Write tombstone audit entry
-  writeAuditLog(tenantId, {
+  emitAudit(tenantId, {
     action: 'candidate.deleted_gdpr',
     entityType: 'candidate',
     entityId: candidateId,
@@ -273,7 +273,7 @@ export async function deleteCandidateForGdpr(
       deletedAt: new Date().toISOString(),
       deletedBy: ctx.userId,
     },
-  }).catch(() => {})
+  })
 
   // 10. Invalidate candidate list cache
   revalidatePath('/dashboard/candidates')

--- a/src/actions/settings.ts
+++ b/src/actions/settings.ts
@@ -8,7 +8,7 @@ import { tenantSettings, users } from '@/db/schema'
 import { requireRole } from '@/lib/auth/require-role'
 import { encrypt } from '@/lib/crypto'
 import { getActionContext } from '@/lib/auth/action-context'
-import { writeAuditLog } from '@/lib/audit'
+import { emitAudit } from '@/lib/audit-middleware'
 import { isSupportedLanguage } from '@/lib/ai/language'
 import { getSenderForTenant } from '@/lib/email/sender'
 import { testWebhookDelivery, type NotificationTestResult } from '@/lib/notifications/dispatcher'
@@ -85,11 +85,11 @@ export async function saveApiKey(
   // Emit targeted audit event for OAuth credential writes
   const oauthMeta = OAUTH_KEY_META[key]
   if (oauthMeta) {
-    writeAuditLog(tenantId, {
+    emitAudit(tenantId, {
       action: 'settings.oauth_credentials_updated',
       entityType: 'settings',
       metadata: { provider: oauthMeta.provider, field: oauthMeta.field },
-    }).catch(() => {})
+    })
   }
 
   revalidatePath('/dashboard/settings')
@@ -122,11 +122,11 @@ export async function removeApiKey(
   // Emit targeted audit event for OAuth credential removals
   const oauthMeta = OAUTH_KEY_META[key]
   if (oauthMeta) {
-    writeAuditLog(tenantId, {
+    emitAudit(tenantId, {
       action: 'settings.oauth_credentials_removed',
       entityType: 'settings',
       metadata: { provider: oauthMeta.provider, field: oauthMeta.field },
-    }).catch(() => {})
+    })
   }
 
   revalidatePath('/dashboard/settings')
@@ -288,11 +288,11 @@ export async function saveTrustedHosts(
   })
 
   if (added.length > 0 || removed.length > 0) {
-    writeAuditLog(tenantId, {
+    emitAudit(tenantId, {
       action: 'settings.trusted_hosts_updated',
       entityType: 'settings',
       metadata: { added, removed },
-    }).catch(() => {})
+    })
   }
 
   revalidatePath('/dashboard/settings')
@@ -360,11 +360,11 @@ export async function saveDefaultPackLanguage(
   })
 
   if (previous !== language) {
-    writeAuditLog(tenantId, {
+    emitAudit(tenantId, {
       action: 'settings.default_pack_language_updated',
       entityType: 'settings',
       metadata: { setting: DEFAULT_PACK_LANGUAGE_KEY, previous, current: language },
-    }).catch(() => {})
+    })
   }
 
   revalidatePath('/dashboard/settings')
@@ -443,11 +443,11 @@ export async function saveSmtpSetting(
       })
   })
 
-  writeAuditLog(tenantId, {
+  emitAudit(tenantId, {
     action: 'settings.smtp_updated',
     entityType: 'settings',
     metadata: { key },
-  }).catch(() => {})
+  })
 
   revalidatePath('/dashboard/settings')
   return { success: true }
@@ -602,11 +602,11 @@ export async function saveNotificationSetting(
       })
   })
 
-  writeAuditLog(tenantId, {
+  emitAudit(tenantId, {
     action: 'settings.notification_updated',
     entityType: 'settings',
     metadata: { key },
-  }).catch(() => {})
+  })
 
   revalidatePath('/dashboard/settings')
   return { success: true }
@@ -636,11 +636,11 @@ export async function removeNotificationSetting(
       .where(and(eq(tenantSettings.tenantId, tenantId), eq(tenantSettings.key, key)))
   })
 
-  writeAuditLog(tenantId, {
+  emitAudit(tenantId, {
     action: 'settings.notification_updated',
     entityType: 'settings',
     metadata: { key, removed: true },
-  }).catch(() => {})
+  })
 
   revalidatePath('/dashboard/settings')
   return { success: true }

--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -9,7 +9,7 @@ import { users } from '@/db/schema'
 import { auth } from '@/lib/auth'
 import { requireRole } from '@/lib/auth/require-role'
 import { getActionContext } from '@/lib/auth/action-context'
-import { writeAuditLog } from '@/lib/audit'
+import { emitAudit } from '@/lib/audit-middleware'
 import type { UserRole } from '@/lib/auth/types'
 import type { User } from '@/db/schema/users'
 
@@ -149,11 +149,11 @@ export async function changePassword(
       )
   })
 
-  writeAuditLog(session.user.tenantId, {
+  emitAudit(session.user.tenantId, {
     action: 'user.password_changed',
     entityType: 'user',
     entityId: session.user.id,
-  }).catch(() => {})
+  })
 
   return { success: true }
 }
@@ -318,13 +318,13 @@ export async function createUserDirect(
     return { ok: false, error: 'Failed to create user' }
   }
 
-  writeAuditLog(ctx.tenantId, {
+  emitAudit(ctx.tenantId, {
     action: 'user.created',
     entityType: 'user',
     entityId: created.id,
     entityLabel: parsed.data.email,
     metadata: { createdVia: 'manual', role: parsed.data.role },
-  }).catch(() => {})
+  })
 
   revalidatePath('/settings')
 

--- a/src/app/api/export/dsar/[candidateId]/route.ts
+++ b/src/app/api/export/dsar/[candidateId]/route.ts
@@ -11,7 +11,7 @@
 import { NextResponse } from 'next/server'
 import { auth } from '@/lib/auth'
 import { buildDsarZip } from '@/lib/gdpr/dsar-builder'
-import { writeAuditLog } from '@/lib/audit'
+import { emitAudit } from '@/lib/audit-middleware'
 
 export async function GET(
   _req: Request,
@@ -39,7 +39,7 @@ export async function GET(
     const archive = await buildDsarZip(candidateId, tenantId)
 
     // 4. Non-fatal audit log (fire-and-forget)
-    writeAuditLog(tenantId, {
+    emitAudit(tenantId, {
       action: 'candidate.dsar_exported',
       entityType: 'candidate',
       entityId: candidateId,
@@ -48,7 +48,7 @@ export async function GET(
         exportedAt: new Date().toISOString(),
         exportedBy: session.user.id,
       },
-    }).catch(() => {})
+    })
 
     // 5. Wrap archiver in a ReadableStream for the Response body
     const date = new Date().toISOString().slice(0, 10)

--- a/src/app/api/export/synechron-cv/[candidateId]/route.ts
+++ b/src/app/api/export/synechron-cv/[candidateId]/route.ts
@@ -5,7 +5,7 @@ import { renderToBuffer } from '@react-pdf/renderer'
 import { auth } from '@/lib/auth'
 import { withTenant } from '@/db'
 import { candidates } from '@/db/schema'
-import { writeAuditLog } from '@/lib/audit'
+import { emitAudit } from '@/lib/audit-middleware'
 import { extractSynechronCvData } from '@/lib/ai/synechron-extract'
 import { SynechronCvPDF } from '@/lib/pdf'
 import type { SynechronCvData } from '@/lib/ai/synechron-schema'
@@ -181,14 +181,12 @@ export async function GET(
     return failResponse('PDF generation', err)
   }
 
-  writeAuditLog(tenantId, {
+  emitAudit(tenantId, {
     action: 'candidate.synechron_cv_downloaded',
     entityType: 'candidate',
     entityId: candidateId,
     entityLabel: `${candidate.firstName} ${candidate.lastName}`.trim() || candidateId,
     metadata: { wasFreshlyExtracted },
-  }).catch(() => {
-    /* audit failures must not break the download */
   })
 
   const filename = buildFilename(candidate)

--- a/src/app/api/export/tenant/csv/[entity]/route.ts
+++ b/src/app/api/export/tenant/csv/[entity]/route.ts
@@ -11,7 +11,7 @@
  */
 
 import { auth } from '@/lib/auth'
-import { writeAuditLog } from '@/lib/audit'
+import { emitAudit } from '@/lib/audit-middleware'
 import {
   buildCandidatesCsv,
   buildRolesCsv,
@@ -86,7 +86,7 @@ export async function GET(
   const { csv, rowCount } = await builders[entity](tenantId)
 
   // 5. Fire-and-forget audit log
-  void writeAuditLog(tenantId, {
+  emitAudit(tenantId, {
     action: 'tenant.csv_exported',
     entityType: 'tenant',
     entityId: tenantId,

--- a/src/app/api/export/tenant/route.ts
+++ b/src/app/api/export/tenant/route.ts
@@ -16,7 +16,7 @@ import { auth } from '@/lib/auth'
 import { withTenant } from '@/db'
 import { auditLogs } from '@/db/schema'
 import { buildTenantExportZip } from '@/lib/export/tenant-export-builder'
-import { writeAuditLog } from '@/lib/audit'
+import { emitAudit } from '@/lib/audit-middleware'
 
 const RATE_LIMIT_SECONDS = 60
 
@@ -107,7 +107,7 @@ export async function GET(req: Request): Promise<Response> {
         })
         archive.on('end', () => {
           // Fire-and-forget audit after stream completes
-          writeAuditLog(tenantId, {
+          emitAudit(tenantId, {
             action: 'tenant.exported',
             entityType: 'tenant',
             entityId: tenantId,
@@ -117,7 +117,7 @@ export async function GET(req: Request): Promise<Response> {
               exportedBy: session.user.id,
               includedFiles: includeFiles,
             },
-          }).catch(() => {})
+          })
           controller.close()
         })
         archive.on('error', (err: Error) => {

--- a/src/app/api/export/welcome-letter/[candidateId]/route.ts
+++ b/src/app/api/export/welcome-letter/[candidateId]/route.ts
@@ -13,7 +13,7 @@ import { INTERVIEW_TYPES } from '@/lib/ai/welcome-letter-schemas'
 import { generateWelcomeLetter } from '@/lib/ai/welcome-letter'
 import { WelcomeLetterPDF } from '@/lib/pdf/welcome-letter-pdf'
 import { getOrExtractCvProfile } from '@/lib/ai/cv-profile'
-import { writeAuditLog } from '@/lib/audit'
+import { emitAudit } from '@/lib/audit-middleware'
 
 // AI + PDF generation can take up to 60s on first call (cache miss + extraction)
 export const maxDuration = 60
@@ -159,13 +159,13 @@ export async function GET(
     )
 
     // Fire-and-forget audit log — never blocks the response
-    writeAuditLog(tenantId, {
+    emitAudit(tenantId, {
       action: 'candidate.welcome_letter_generated',
       entityType: 'candidate',
       entityId: candidateId,
       entityLabel: candidateFullName,
       metadata: { language: lang, interviewType, roleId: roleId ?? null },
-    }).catch(() => { /* audit failures must not break the download */ })
+    })
 
     const slug = slugify(candidate.firstName)
     const filename = `welcome-letter-${slug}-${lang}.pdf`

--- a/src/app/api/interview-packs/generate/route.ts
+++ b/src/app/api/interview-packs/generate/route.ts
@@ -16,7 +16,7 @@ import { generateQuestions } from '@/lib/ai/interview'
 import { getOrExtractCvProfile } from '@/lib/ai/cv-profile'
 import { inferLanguage } from '@/lib/ai/interview-helpers'
 import { SUPPORTED_LANGUAGES, isSupportedLanguage, type SupportedLanguage } from '@/lib/ai/language'
-import { writeAuditLog } from '@/lib/audit'
+import { emitAudit } from '@/lib/audit-middleware'
 
 export const maxDuration = 300
 
@@ -180,7 +180,7 @@ export async function POST(request: Request) {
       }).where(eq(interviewPacks.id, packId))
     })
 
-    writeAuditLog(tenantId, {
+    emitAudit(tenantId, {
       action: 'interview_pack.completed',
       entityType: 'interview_pack',
       entityId: packId,
@@ -189,19 +189,19 @@ export async function POST(request: Request) {
         experienceLevel: result.experience_level,
         includesCodeChallenge: !!result.code_challenge,
       },
-    }).catch(() => {})
+    })
 
     return NextResponse.json({ success: true })
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error'
     await failPack(tenantId, packId, message)
 
-    writeAuditLog(tenantId, {
+    emitAudit(tenantId, {
       action: 'interview_pack.failed',
       entityType: 'interview_pack',
       entityId: packId,
       metadata: { error: message },
-    }).catch(() => {})
+    })
 
     console.error(`Interview pack generation failed for ${packId}:`, message)
     // Return generic error to client — full details logged server-side

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -22,7 +22,7 @@ import { db } from '@/db'
 import { users } from '@/db/schema'
 import { validateApiToken } from '@/lib/api-tokens/validate'
 import { checkRateLimit } from '@/lib/api/rate-limit'
-import { writeAuditLog } from '@/lib/audit'
+import { emitAudit } from '@/lib/audit-middleware'
 import { buildMcpServer } from '@/lib/mcp/server'
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
 import type { ApiTokenScope } from '@/db/schema/api-tokens'
@@ -114,7 +114,7 @@ async function handle(req: Request): Promise<Response> {
   const isWrite = isLikelyWrite(parsedBody)
   const rateLimit = await checkRateLimit(tenantId, tokenId, isWrite)
   if (!rateLimit.ok) {
-    void writeAuditLog(tenantId, {
+    emitAudit(tenantId, {
       action: 'api.rate_limit_exceeded',
       entityType: 'api_token',
       entityId: tokenId,

--- a/src/lib/ai/scoring.ts
+++ b/src/lib/ai/scoring.ts
@@ -17,7 +17,7 @@ import { db, withTenant } from '@/db'
 import { candidates, roles, scores, customerFrameworks, tenantSettings } from '@/db/schema'
 import { scoreCandidateWithClaude } from './claude'
 import { scoreCandidateWithGemini } from './gemini'
-import { writeAuditLog } from '@/lib/audit'
+import { emitAudit } from '@/lib/audit-middleware'
 import { dispatchHighScoreNotification } from '@/lib/notifications/dispatcher'
 
 export async function triggerScoring(
@@ -139,7 +139,7 @@ When scoring experience_level, assess specifically whether the candidate's senio
       overallScore: result.overall_score,
     }).catch(() => {})
 
-    writeAuditLog(tenantId, {
+    emitAudit(tenantId, {
       action: 'score.completed',
       entityType: 'score',
       entityId: candidateId,
@@ -148,7 +148,7 @@ When scoring experience_level, assess specifically whether the candidate's senio
         overallScore: result.overall_score,
         model: useGemini ? 'gemini' : 'claude',
       },
-    }).catch(() => {})
+    })
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error'
     await withTenant(tenantId, async (tx) => {
@@ -158,12 +158,12 @@ When scoring experience_level, assess specifically whether the candidate's senio
         .where(and(eq(scores.candidateId, candidateId), eq(scores.roleId, roleId)))
     })
 
-    writeAuditLog(tenantId, {
+    emitAudit(tenantId, {
       action: 'score.failed',
       entityType: 'score',
       entityId: candidateId,
       metadata: { roleId, error: message },
-    }).catch(() => {})
+    })
 
     console.error(`Scoring failed for candidate ${candidateId}:`, message)
   }

--- a/src/lib/api-tokens/validate.ts
+++ b/src/lib/api-tokens/validate.ts
@@ -2,7 +2,7 @@ import { verify } from '@node-rs/argon2'
 import { eq } from 'drizzle-orm'
 import { db, withTenant } from '@/db'
 import { apiTokens } from '@/db/schema'
-import { writeAuditLog } from '@/lib/audit'
+import { emitAudit } from '@/lib/audit-middleware'
 
 export type ValidatedToken = {
   tenantId: string
@@ -65,7 +65,7 @@ export async function validateApiToken(rawToken: string): Promise<ValidatedToken
 
     // Sampled audit log: every 10th call to avoid log flooding
     if (Math.random() < 0.1) {
-      void writeAuditLog(token.tenantId, {
+      emitAudit(token.tenantId, {
         action: 'api_token.used',
         entityType: 'api_token',
         entityId: token.id,

--- a/src/lib/api/auth-middleware.ts
+++ b/src/lib/api/auth-middleware.ts
@@ -1,6 +1,6 @@
 import { validateApiToken } from '@/lib/api-tokens/validate'
 import { checkRateLimit } from '@/lib/api/rate-limit'
-import { writeAuditLog } from '@/lib/audit'
+import { emitAudit } from '@/lib/audit-middleware'
 import type { ApiTokenScope } from '@/db/schema/api-tokens'
 
 // Re-export for convenience
@@ -89,12 +89,12 @@ export function withApiAuth<TParams = Record<string, string>>(
       if (!rateLimitResult.ok) {
         const { retryAfter } = rateLimitResult
         // Audit rate limit exceeded
-        writeAuditLog(tenantId, {
+        emitAudit(tenantId, {
           action: 'api.rate_limit_exceeded',
           entityType: 'api_token',
           entityId: tokenId,
           metadata: { limit: rateLimitResult.limit, retryAfter },
-        }).catch(() => {})
+        })
 
         return new Response(
           JSON.stringify({ error: 'rate_limit_exceeded', code: 'rate_limited' }),

--- a/src/lib/api/rate-limit.ts
+++ b/src/lib/api/rate-limit.ts
@@ -2,7 +2,7 @@ import { db } from '@/db'
 import { sql } from 'drizzle-orm'
 import { getRateLimitConfig } from './rate-limit-config'
 import { cleanupRateLimitWindows } from './janitor'
-import { writeAuditLog } from '@/lib/audit'
+import { emitAudit } from '@/lib/audit-middleware'
 
 // Run janitor every 200 requests (lazy, non-blocking)
 let requestsSinceCleanup = 0
@@ -141,32 +141,32 @@ export async function checkRateLimit(
   ])
 
   if (tokenSliding >= config.tokenPerMin) {
-    writeAuditLog(tenantId, {
+    emitAudit(tenantId, {
       action: 'api.rate_limit_exceeded',
       entityType: 'api_token',
       entityId: tokenId,
       metadata: { limit: 'token', count: tokenSliding, limitValue: config.tokenPerMin },
-    }).catch(() => {})
+    })
     return { ok: false, retryAfter, limit: 'token' }
   }
 
   if (tenantSliding >= config.tenantPerMin) {
-    writeAuditLog(tenantId, {
+    emitAudit(tenantId, {
       action: 'api.rate_limit_exceeded',
       entityType: 'tenant',
       entityId: tenantId,
       metadata: { limit: 'tenant', count: tenantSliding, limitValue: config.tenantPerMin },
-    }).catch(() => {})
+    })
     return { ok: false, retryAfter, limit: 'tenant' }
   }
 
   if (isWrite && writeSliding >= config.writePerMin) {
-    writeAuditLog(tenantId, {
+    emitAudit(tenantId, {
       action: 'api.rate_limit_exceeded',
       entityType: 'tenant',
       entityId: tenantId,
       metadata: { limit: 'write', count: writeSliding, limitValue: config.writePerMin },
-    }).catch(() => {})
+    })
     return { ok: false, retryAfter, limit: 'write' }
   }
 

--- a/src/lib/audit-middleware.ts
+++ b/src/lib/audit-middleware.ts
@@ -1,0 +1,80 @@
+import { writeAuditLog, type AuditAction } from '@/lib/audit'
+
+/**
+ * AuditEntry — payload accepted by both `writeAuditLog` and `emitAudit`.
+ *
+ * Mirrors the (unexported) internal type in `@/lib/audit`. Kept structurally
+ * identical so that callers can interchange the two helpers.
+ */
+export type AuditEntry = {
+  action: AuditAction
+  entityType: string
+  entityId?: string
+  entityLabel?: string
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * emitAudit — fire-and-forget audit emission.
+ *
+ * Semantically equivalent to:
+ *
+ *     void writeAuditLog(tenantId, entry).catch(() => {})
+ *
+ * which is the dominant audit-call shape across the codebase. Wrapping that
+ * pattern in a single helper:
+ *
+ *   1. Communicates intent — "emit this audit row, don't block the caller,
+ *      swallow any audit-side error". Reads better than the bare `.catch(() => {})`
+ *      idiom which can look like a missed promise.
+ *   2. Preserves test compatibility — `emitAudit` delegates to `writeAuditLog`,
+ *      so every `vi.mock('@/lib/audit', () => ({ writeAuditLog: vi.fn() }))`
+ *      spy continues to fire unchanged.
+ *   3. Keeps `writeAuditLog`'s contract intact — errors are still caught and
+ *      console-logged inside `writeAuditLog`. The outer `.catch(() => {})`
+ *      here is a belt-and-braces guard in case `writeAuditLog`'s wrapper ever
+ *      changes to allow throws.
+ *
+ * When to use:
+ *   - You don't need to await the audit insert before returning to the caller
+ *     (most common case — audit is a side-effect for the trail, not a value
+ *     the response depends on).
+ *   - You want any audit-side failure swallowed silently. `writeAuditLog`
+ *     already console.errors on failure, so callers rarely need their own
+ *     catch handler.
+ *
+ * When NOT to use:
+ *   - You want to await the audit insert before responding (e.g., GDPR
+ *     erasure, where the audit row is part of the regulatory completion
+ *     contract). Keep `await writeAuditLog(...)` for those.
+ *   - You want a custom log message on audit failure (e.g.
+ *     `console.error('[cv/GET] Audit log failed:', err)`). Keep the raw
+ *     `try { await writeAuditLog(...) } catch (err) { console.error(...) }`
+ *     pattern.
+ *   - You're emitting multiple audit rows in a loop or `Promise.allSettled`
+ *     and want shared post-loop accounting. Stay on raw `writeAuditLog`.
+ *
+ * Example:
+ *
+ *     // BEFORE:
+ *     writeAuditLog(tenantId, {
+ *       action: 'settings.smtp_updated',
+ *       entityType: 'settings',
+ *       metadata: { key },
+ *     }).catch(() => {})
+ *
+ *     // AFTER:
+ *     emitAudit(tenantId, {
+ *       action: 'settings.smtp_updated',
+ *       entityType: 'settings',
+ *       metadata: { key },
+ *     })
+ */
+export function emitAudit(tenantId: string, entry: AuditEntry): void {
+  // Defensive `.catch` — `writeAuditLog` already swallows its own errors, but
+  // we keep this so a future change to writeAuditLog's contract doesn't bubble
+  // up as an unhandled rejection at every call site.
+  void writeAuditLog(tenantId, entry).catch(() => {
+    /* audit is fire-and-forget; failures are logged inside writeAuditLog */
+  })
+}

--- a/src/lib/mcp/context.ts
+++ b/src/lib/mcp/context.ts
@@ -10,7 +10,7 @@
  */
 
 import { runWithActionContext } from '@/lib/auth/action-context'
-import { writeAuditLog } from '@/lib/audit'
+import { emitAudit } from '@/lib/audit-middleware'
 import type { ApiTokenScope } from '@/db/schema/api-tokens'
 import type { UserRole } from '@/lib/auth/types'
 
@@ -88,7 +88,7 @@ export async function runTool<T>(
   }
 
   // Audit before running so we have a trace even if the handler throws
-  void writeAuditLog(ctx.tenantId, {
+  emitAudit(ctx.tenantId, {
     action: isWrite ? 'mcp.confirmed_action' : 'mcp.tool_called',
     entityType: 'mcp_tool',
     entityLabel: toolName,

--- a/src/lib/mcp/tools/users.ts
+++ b/src/lib/mcp/tools/users.ts
@@ -17,7 +17,7 @@ import { eq, and } from 'drizzle-orm'
 import { db, withTenant } from '@/db'
 import { users, userInvitations } from '@/db/schema'
 import { listTenantUsers } from '@/actions/users'
-import { writeAuditLog } from '@/lib/audit'
+import { emitAudit } from '@/lib/audit-middleware'
 import { runTool } from '../context'
 import type { McpContext } from '../context'
 import { jsonResult } from './candidates'
@@ -78,7 +78,7 @@ export function registerUserTools(server: McpServer, ctx: McpContext): void {
             .set({ role: args.role as UserRole })
             .where(and(eq(users.id, args.userId), eq(users.tenantId, ctx.tenantId)))
         })
-        void writeAuditLog(ctx.tenantId, {
+        emitAudit(ctx.tenantId, {
           action: 'user.role_changed',
           entityType: 'user',
           entityId: args.userId,
@@ -121,7 +121,7 @@ export function registerUserTools(server: McpServer, ctx: McpContext): void {
           .returning({ id: userInvitations.id })
         const baseUrl = process.env.NEXTAUTH_URL ?? 'http://localhost:3001'
         const inviteUrl = `${baseUrl}/invite/${token}`
-        void writeAuditLog(ctx.tenantId, {
+        emitAudit(ctx.tenantId, {
           action: 'user.invited',
           entityType: 'user_invitation',
           entityId: inserted.id,
@@ -152,7 +152,7 @@ export function registerUserTools(server: McpServer, ctx: McpContext): void {
             .set({ isActive: false })
             .where(and(eq(users.id, args.userId), eq(users.tenantId, ctx.tenantId)))
         })
-        void writeAuditLog(ctx.tenantId, {
+        emitAudit(ctx.tenantId, {
           action: 'user.deactivated',
           entityType: 'user',
           entityId: args.userId,

--- a/src/lib/notifications/dispatcher.ts
+++ b/src/lib/notifications/dispatcher.ts
@@ -5,7 +5,7 @@
  * Design principles (mirrors src/lib/email/notify-recruiter-of-customer-update.ts):
  *  - Never throws. All failure paths are swallowed and logged via console.warn.
  *  - All dispatches are fire-and-forget — callers use .catch(() => {}).
- *  - Audit log writes are themselves fire-and-forget (.catch(() => {})).
+ *  - Audit log writes go via `emitAudit` — fire-and-forget by contract.
  *  - Names are loaded internally from the DB so call sites stay minimal.
  */
 
@@ -13,7 +13,7 @@ import { eq, and, inArray } from 'drizzle-orm'
 import { withTenant } from '@/db'
 import { candidates, roles, tenantSettings } from '@/db/schema'
 import { decrypt } from '@/lib/crypto'
-import { writeAuditLog } from '@/lib/audit'
+import { emitAudit } from '@/lib/audit-middleware'
 import { sendSlack } from './slack'
 import { sendTeams } from './teams'
 
@@ -172,7 +172,7 @@ export async function dispatchHighScoreNotification(args: HighScoreArgs): Promis
       const settled = results[i]
       if (settled.status === 'rejected') {
         console.warn(`[notifications] ${channel} high-score dispatch threw:`, settled.reason)
-        writeAuditLog(args.tenantId, {
+        emitAudit(args.tenantId, {
           action: 'notification.webhook_failed',
           entityType: 'candidate',
           entityId: args.candidateId,
@@ -182,7 +182,7 @@ export async function dispatchHighScoreNotification(args: HighScoreArgs): Promis
             candidateId: args.candidateId,
             roleId: args.roleId,
           },
-        }).catch(() => {})
+        })
         continue
       }
 
@@ -191,7 +191,7 @@ export async function dispatchHighScoreNotification(args: HighScoreArgs): Promis
 
       if (!result.ok) {
         console.warn(`[notifications] ${channel} high-score delivery failed:`, result.error)
-        writeAuditLog(args.tenantId, {
+        emitAudit(args.tenantId, {
           action: 'notification.webhook_failed',
           entityType: 'candidate',
           entityId: args.candidateId,
@@ -201,9 +201,9 @@ export async function dispatchHighScoreNotification(args: HighScoreArgs): Promis
             candidateId: args.candidateId,
             roleId: args.roleId,
           },
-        }).catch(() => {})
+        })
       } else {
-        writeAuditLog(args.tenantId, {
+        emitAudit(args.tenantId, {
           action: 'notification.high_score_sent',
           entityType: 'candidate',
           entityId: args.candidateId,
@@ -213,7 +213,7 @@ export async function dispatchHighScoreNotification(args: HighScoreArgs): Promis
             overallScore: args.overallScore,
             roleId: args.roleId,
           },
-        }).catch(() => {})
+        })
       }
     }
   } catch (err) {
@@ -296,7 +296,7 @@ export async function dispatchManagerDecisionNotification(args: ManagerDecisionA
       const settled = results[i]
       if (settled.status === 'rejected') {
         console.warn(`[notifications] ${channel} manager-decision dispatch threw:`, settled.reason)
-        writeAuditLog(args.tenantId, {
+        emitAudit(args.tenantId, {
           action: 'notification.webhook_failed',
           entityType: 'candidate',
           entityId: args.candidateId,
@@ -306,7 +306,7 @@ export async function dispatchManagerDecisionNotification(args: ManagerDecisionA
             candidateId: args.candidateId,
             roleId: args.roleId,
           },
-        }).catch(() => {})
+        })
         continue
       }
 
@@ -315,7 +315,7 @@ export async function dispatchManagerDecisionNotification(args: ManagerDecisionA
 
       if (!result.ok) {
         console.warn(`[notifications] ${channel} manager-decision delivery failed:`, result.error)
-        writeAuditLog(args.tenantId, {
+        emitAudit(args.tenantId, {
           action: 'notification.webhook_failed',
           entityType: 'candidate',
           entityId: args.candidateId,
@@ -325,9 +325,9 @@ export async function dispatchManagerDecisionNotification(args: ManagerDecisionA
             candidateId: args.candidateId,
             roleId: args.roleId,
           },
-        }).catch(() => {})
+        })
       } else {
-        writeAuditLog(args.tenantId, {
+        emitAudit(args.tenantId, {
           action: 'notification.approval_sent',
           entityType: 'candidate',
           entityId: args.candidateId,
@@ -338,7 +338,7 @@ export async function dispatchManagerDecisionNotification(args: ManagerDecisionA
             roleId: args.roleId,
             managerName: args.managerName,
           },
-        }).catch(() => {})
+        })
       }
     }
   } catch (err) {
@@ -375,18 +375,18 @@ export async function testWebhookDelivery(tenantId: string): Promise<Notificatio
 
   // Audit failures only
   if (slackUrl && !slack.ok) {
-    writeAuditLog(tenantId, {
+    emitAudit(tenantId, {
       action: 'notification.webhook_failed',
       entityType: 'settings',
       metadata: { channel: 'slack', error: slack.error, test: true },
-    }).catch(() => {})
+    })
   }
   if (teamsUrl && !teams.ok) {
-    writeAuditLog(tenantId, {
+    emitAudit(tenantId, {
       action: 'notification.webhook_failed',
       entityType: 'settings',
       metadata: { channel: 'teams', error: teams.error, test: true },
-    }).catch(() => {})
+    })
   }
 
   return { slack, teams }

--- a/tests/unit/lib/audit-middleware.test.ts
+++ b/tests/unit/lib/audit-middleware.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock the underlying writeAuditLog. emitAudit MUST delegate to it, otherwise
+// the 13 other test files that mock '@/lib/audit' would stop seeing audit
+// calls from migrated callers.
+//
+// `vi.hoisted` is needed because the factory in `vi.mock` is hoisted to the
+// top of the file by vitest, ahead of any top-level `const`s. Without
+// `vi.hoisted` the factory references a not-yet-initialised variable.
+const { mockWriteAuditLog } = vi.hoisted(() => ({
+  mockWriteAuditLog: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('@/lib/audit', () => ({
+  writeAuditLog: mockWriteAuditLog,
+}))
+
+import { emitAudit } from '@/lib/audit-middleware'
+
+describe('emitAudit', () => {
+  beforeEach(() => {
+    mockWriteAuditLog.mockClear()
+    mockWriteAuditLog.mockResolvedValue(undefined)
+  })
+
+  it('forwards tenantId and entry to writeAuditLog unchanged', () => {
+    const tenantId = 't-1'
+    const entry = {
+      action: 'role.created' as const,
+      entityType: 'role',
+      entityId: 'r-1',
+      entityLabel: 'Senior Engineer',
+      metadata: { source: 'manual' },
+    }
+
+    emitAudit(tenantId, entry)
+
+    expect(mockWriteAuditLog).toHaveBeenCalledTimes(1)
+    expect(mockWriteAuditLog).toHaveBeenCalledWith(tenantId, entry)
+  })
+
+  it('returns synchronously (void) — caller is never asked to await', () => {
+    const result = emitAudit('t-1', {
+      action: 'role.archived',
+      entityType: 'role',
+      entityId: 'r-1',
+    })
+    expect(result).toBeUndefined()
+  })
+
+  it('does not throw when writeAuditLog rejects (fire-and-forget)', async () => {
+    mockWriteAuditLog.mockRejectedValueOnce(new Error('db down'))
+
+    expect(() => {
+      emitAudit('t-1', { action: 'role.created', entityType: 'role' })
+    }).not.toThrow()
+
+    // Yield to the microtask queue so the .catch runs before assertions end.
+    await new Promise((r) => setTimeout(r, 0))
+  })
+
+  it('does not throw when writeAuditLog throws synchronously', () => {
+    mockWriteAuditLog.mockImplementationOnce(() => {
+      throw new Error('sync boom')
+    })
+
+    // Note: the public contract of writeAuditLog is async (returns Promise),
+    // so this case shouldn't happen in practice — but if the implementation
+    // ever regresses to sync-throw, emitAudit should still not crash the caller.
+    expect(() => {
+      emitAudit('t-1', { action: 'role.created', entityType: 'role' })
+    }).toThrow('sync boom') // current behaviour: sync throws bubble.
+    //
+    // This test pins the current behaviour. If we ever decide to also catch
+    // sync throws, change the assertion to .not.toThrow() and update emitAudit.
+  })
+})


### PR DESCRIPTION
## Summary

Introduces `emitAudit` in `src/lib/audit-middleware.ts` as a fire-and-forget wrapper around the existing `writeAuditLog`. The helper communicates intent ("emit this audit row, don't block, swallow any audit-side error") and replaces 37 mechanically-identical fire-and-forget call sites across 17 source files. **The remaining 42 sites stay on raw `writeAuditLog` by design** — they're awaited or appear in loops / `Promise.allSettled`, where wrapping would change semantics or contort the helper.

This is a behavior-preserving refactor. Every audit row written today is still written after this PR with the same `action` / `entityType` / `entityId` / `entityLabel` / `metadata`. The `AuditAction` literal union stays intact. No DB schema changes.

## Categorization of the 79 call sites in src/

I counted **79 actual call sites** (the user's "117" tracks all `writeAuditLog` mentions in `src/` + `tests/` including imports; on this branch's HEAD the same broad-count is 155 → 101 post-refactor).

| Pattern | Count | Action |
|---|---:|---|
| `await writeAuditLog(...)` | 40 | keep raw (awaited; caller wants completion before returning) |
| `await writeAuditLog(...).catch(() => {})` | 1 | keep raw (awaited but swallows; one site: `synechron-extract.ts:355`) |
| `void writeAuditLog(...)` | 7 | **migrated** (mechanically identical to `emitAudit`) |
| `writeAuditLog(...).catch(() => {})` | 30 | **migrated** (drop the `.catch`; helper handles it) |
| `writeAuditLog(...)` inside `Promise.allSettled(map(...))` | 1 | keep raw (loop pattern; one site: `export/cvs/[roleId]/route.ts:214`) |
| **Total** | **79** | **37 migrated / 42 kept on raw** |

## Why Option C (explicit helper) over the alternatives

- **Option A — wrapper `withAudit(spec, fn)`**: handles the simple after-mutation case but awkward for conditional emit, multi-entity loops, and cross-tenant resolution (where `tenantId` comes from `args.tenantId` / `ctx.tenantId` / a resolved-from-userId lookup, not the default).
- **Option B — server-action decorator `auditedAction(spec, action)`**: clean for the 80% case but doesn't help routes, lib code, MCP tools, or notification dispatchers — many of the loudest audit sites.
- **Option C — explicit `emitAudit` helper that delegates to `writeAuditLog`**: minimal surface, preserves the `AuditAction` literal union, and critically **keeps all 13 existing `vi.mock('@/lib/audit', () => ({ writeAuditLog: vi.fn() }))` test spies firing unchanged** because the helper calls `writeAuditLog` internally. Migration is mechanical and reviewable.

The 17 source files that have *only* fire-and-forget audit sites lose their `writeAuditLog` import entirely and pick up `emitAudit` instead. The 16 files with a mix of awaited + fire-and-forget — there are none in this codebase, every file has either all-awaited or all-fire-and-forget calls — so the import migration is clean.

## Migration evidence

5 randomly-sampled migrated sites, byte-identical audit row content (verified by `git diff`):

1. `src/actions/settings.ts:88` — `settings.oauth_credentials_updated` (no payload change)
2. `src/lib/notifications/dispatcher.ts:175` — `notification.webhook_failed` (no payload change)
3. `src/lib/mcp/context.ts:91` — `mcp.tool_called` / `mcp.confirmed_action` (no payload change)
4. `src/lib/api/rate-limit.ts:144` — `api.rate_limit_exceeded` (no payload change)
5. `src/actions/gdpr.ts:267` — `candidate.deleted_gdpr` with `entityLabel: '[deleted-gdpr]'` (no payload change)

2 sites intentionally left on raw `writeAuditLog`:

1. `src/lib/ai/synechron-extract.ts:355` — uses `await writeAuditLog(...).catch(() => {})`. The `await` keeps the caller in the same task tick until the audit insert completes (or its rejection is swallowed). `emitAudit` is fire-and-forget — switching would change semantics even if the practical I/O effect is similar. Kept raw to be safe.
2. `src/app/api/export/cvs/[roleId]/route.ts:214` — `Promise.allSettled(auditIds.map((c) => writeAuditLog(...)))`. The helper returns `void`, breaking the `.map().Promise.allSettled(...)` shape. Could be rewritten as `forEach(emitAudit)` but that's a structural change, not a mechanical replacement — out of scope for a behavior-preserving refactor.

## Verification

- `npx tsc --noEmit` — 3 errors, all pre-existing in test files (`@testing-library/react` missing `screen` / `waitFor` exports). **No errors in `src/`. Identical to baseline.**
- `npm test` — 415 passed / 23 failed / 4 skipped. **`diff baseline-failures.txt post-refactor-failures.txt` returns exit 0 — zero new failures.** Baseline already had 23 failures from stale mocks in `gdpr.test.ts`, `synechron-extract.test.ts`, `sync-loop.test.ts`, `dashboard-tasks.test.ts`, `interview-schemas.test.ts`, etc. — all unrelated to audit. The 4 new passing tests come from `tests/unit/lib/audit-middleware.test.ts`.
- Test compatibility — the 13 existing `vi.mock('@/lib/audit', ...)` spies all still fire correctly because `emitAudit` → `writeAuditLog` and the mock replaces `writeAuditLog`.

## Counts

```
Before:  79 raw call sites in src/  (155 mentions across src/+tests/ counting imports)
After:   42 raw call sites in src/  (101 mentions across src/+tests/)
         37 emitAudit call sites
         17 source files migrated
         2 new files: src/lib/audit-middleware.ts, tests/unit/lib/audit-middleware.test.ts
```

## Test plan

- [x] `npx tsc --noEmit` clean in `src/`
- [x] `npm test` shows no new failures vs baseline
- [x] 5 random migrated sites verified payload-identical to pre-refactor
- [x] 2 untouched sites documented with rationale
- [ ] CI green on `core-mvp-foundation` base

🤖 Generated with [Claude Code](https://claude.com/claude-code)