### PR TITLE
ci: stub AI keys for vitest job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,13 @@ jobs:
         run: npm ci
 
       - name: Run tests
+        # Stub AI keys so resolveAnthropicKey()/resolveGoogleKey() succeed.
+        # The SDK calls themselves are mocked in tests/unit/ai/*.test.ts via
+        # vi.mock('@anthropic-ai/sdk') and equivalents — these stubs only
+        # satisfy the key-resolution layer that runs before the mocked client.
+        env:
+          ANTHROPIC_API_KEY: stub-anthropic-key
+          GEMINI_API_KEY: stub-gemini-key
         run: npm test
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

First run of the new CI gate (#178) went red. 7 tests across `tests/unit/ai/synechron-extract.test.ts` and `tests/unit/ai/transcript-schemas.test.ts` failed with `No Anthropic API key configured`.

## Root cause

Those tests mock the Anthropic SDK (`vi.mock('@anthropic-ai/sdk')`) but not the key-resolution layer that runs before it. `resolveAnthropicKey()` reads from tenant DB first, falls back to `process.env.ANTHROPIC_API_KEY`, then throws. CI has neither set — the host container has it in `.env`, which is why agents reported green locally.

## Fix

Add stub env vars to the `Run tests` step in the test job. The mocked SDK never makes a network call so the value is cosmetic — it just satisfies the resolver's typecheck for a non-empty string.

## Test plan

- [x] Local CI workflow edit only — single file, 7 inserted lines
- [ ] Push triggers CI on this branch → expected: all 3 jobs green
- [ ] Merge → push-CI on core-mvp-foundation should turn green

## Context

CI run that surfaced this: https://github.com/olafkfreund/SkillAi/actions/runs/26126626433
Failing tests:
- synechron-extract.test.ts:123, 137
- transcript-schemas.test.ts:162, 188, 212, 235, 245

🤖 Generated with [Claude Code](https://claude.com/claude-code)