### PR TITLE
ci: bump checkout v4→v6, setup-node v4→v6 (Node 20 deprecation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Node 22
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -88,10 +88,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Node 22
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -116,10 +116,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Node 22
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: '22'
           cache: 'npm'


### PR DESCRIPTION
## Summary

GitHub deprecating Node 20 actions on **2026-06-02** (full removal 2026-09-16). Our CI ran on 2026-05-19 with a deprecation annotation on the v4 pins of \`actions/checkout\` and \`actions/setup-node\`. Bumping to current latest (v6) which use Node 24.

## Changes

| Action | Old | New |
|---|---|---|
| actions/checkout | v4.2.2 (\`11bd719\`) | **v6.0.2** (\`de0fac2\`) |
| actions/setup-node | v4.4.0 (\`49933ea\`) | **v6.4.0** (\`48b55a0\`) |

Three updates each (test / typecheck / build jobs).

## Why SHA pins not tags

Existing convention in this repo. Hardens against supply-chain risk via mutable tags. The comment preserves the human-readable version.

## Test plan

- [x] Diff confirmed: 6 updates total (2 actions × 3 jobs)
- [ ] CI green on this PR (test, typecheck, build)
- [ ] No deprecation annotation in the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)