### PR TITLE
fix(export): ASCII-safe Content-Disposition for PDF downloads

### DIFF
--- a/src/app/api/export/candidate/[candidateId]/route.ts
+++ b/src/app/api/export/candidate/[candidateId]/route.ts
@@ -19,6 +19,7 @@ import {
 import type { WebHit, GitHubProfile } from '@/db/schema/candidate-enrichments'
 import { CandidatePDF } from '@/lib/pdf'
 import { getLogoAbsolutePath } from '@/lib/branding/store'
+import { contentDispositionHeader } from '@/lib/http/content-disposition'
 
 type Audience = 'internal' | 'customer'
 
@@ -263,7 +264,7 @@ export async function GET(
       // `inline` lets the browser display the PDF in a new tab (via the
       // button's target="_blank"). The filename is still honoured when
       // the user hits "Save" in the PDF viewer.
-      'Content-Disposition': `inline; filename="${filename}"`,
+      'Content-Disposition': contentDispositionHeader('inline', filename),
     },
   })
   } catch (err) {

--- a/src/app/api/export/interview-pack/[packId]/route.ts
+++ b/src/app/api/export/interview-pack/[packId]/route.ts
@@ -6,6 +6,7 @@ import { renderToBuffer } from '@react-pdf/renderer'
 import { withTenant } from '@/db'
 import { interviewPacks, interviewQuestions, codeChallenges, candidates, roles } from '@/db/schema'
 import { InterviewPackPDF } from '@/lib/pdf'
+import { contentDispositionHeader } from '@/lib/http/content-disposition'
 
 export async function GET(
   _req: Request,
@@ -64,7 +65,10 @@ export async function GET(
   return new NextResponse(buffer as unknown as BodyInit, {
     headers: {
       'Content-Type': 'application/pdf',
-      'Content-Disposition': `attachment; filename="interview-pack-${candidateName.replace(/\s+/g, '-')}.pdf"`,
+      'Content-Disposition': contentDispositionHeader(
+        'attachment',
+        `interview-pack-${candidateName}.pdf`
+      ),
     },
   })
 }

--- a/src/app/api/export/role/[roleId]/route.ts
+++ b/src/app/api/export/role/[roleId]/route.ts
@@ -6,6 +6,7 @@ import { renderToBuffer } from '@react-pdf/renderer'
 import { withTenant } from '@/db'
 import { roles, customers } from '@/db/schema'
 import { RolePDF } from '@/lib/pdf'
+import { contentDispositionHeader } from '@/lib/http/content-disposition'
 
 export async function GET(
   _req: Request,
@@ -55,7 +56,7 @@ export async function GET(
   return new NextResponse(buffer as unknown as BodyInit, {
     headers: {
       'Content-Type': 'application/pdf',
-      'Content-Disposition': `inline; filename="role-${role.title.replace(/\s+/g, '-')}.pdf"`,
+      'Content-Disposition': contentDispositionHeader('inline', `role-${role.title}.pdf`),
     },
   })
 }

--- a/src/app/api/export/shortlist/[roleId]/route.ts
+++ b/src/app/api/export/shortlist/[roleId]/route.ts
@@ -6,6 +6,7 @@ import { renderToBuffer } from '@react-pdf/renderer'
 import { withTenant } from '@/db'
 import { candidates, scores, roles, agencies, customers } from '@/db/schema'
 import { ShortlistPDF } from '@/lib/pdf'
+import { contentDispositionHeader } from '@/lib/http/content-disposition'
 
 export async function GET(
   _req: Request,
@@ -97,7 +98,7 @@ export async function GET(
   return new NextResponse(buffer as unknown as BodyInit, {
     headers: {
       'Content-Type': 'application/pdf',
-      'Content-Disposition': `inline; filename="shortlist-${role.title.replace(/\s+/g, '-')}.pdf"`,
+      'Content-Disposition': contentDispositionHeader('inline', `shortlist-${role.title}.pdf`),
     },
   })
 }

--- a/src/lib/http/content-disposition.ts
+++ b/src/lib/http/content-disposition.ts
@@ -1,0 +1,55 @@
+/**
+ * Build a Content-Disposition header value that's safe for HTTP transport
+ * AND preserves the original Unicode filename for browsers that understand
+ * RFC 5987's extended `filename*=UTF-8''…` syntax.
+ *
+ * Why this exists: HTTP header values are ByteStrings (each char ≤ 255).
+ * Interpolating a candidate name like "Łukasz Wójcik" directly into
+ * `filename="${name}.pdf"` crashes with a TypeError before the response
+ * ever leaves the server (saw `value 380 > 255` from Polish `ż`).
+ *
+ * The fix is RFC 6266 / RFC 5987:
+ *   - `filename="ascii-fallback.pdf"` for legacy clients
+ *   - `filename*=UTF-8''<percent-encoded>` for the real Unicode value
+ * Modern browsers prefer the extended form; the fallback is sanitised to
+ * the printable-ASCII subset so it never trips the ByteString limit.
+ */
+export function contentDispositionHeader(
+  disposition: 'attachment' | 'inline',
+  filename: string
+): string {
+  const sanitised = asciiFallback(filename)
+  // Treat empty or just-an-extension (e.g. '.pdf' from all-CJK input) as
+  // "no usable fallback" — modern browsers honour filename* anyway.
+  const fallback = sanitised && !/^\.[A-Za-z0-9]+$/.test(sanitised) ? sanitised : 'download'
+  const encoded = encodeRFC5987(filename) || encodeRFC5987(fallback)
+  return `${disposition}; filename="${fallback}"; filename*=UTF-8''${encoded}`
+}
+
+/**
+ * Strip a string down to characters that survive an HTTP ByteString header.
+ * Keeps printable ASCII letters, digits, space, dot, underscore, hyphen.
+ * Collapses whitespace + runs of hyphens; trims leading/trailing hyphens.
+ */
+export function asciiFallback(value: string): string {
+  return value
+    .normalize('NFKD') // decompose accents so we can drop the combining marks
+    .replace(/[^\x20-\x7E]/g, '') // strip non-printable-ASCII
+    .replace(/[^A-Za-z0-9 ._-]/g, '') // strip ASCII punctuation we don't want in filenames
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+}
+
+/**
+ * Percent-encode a string per RFC 5987 §3.2.1 (UTF-8 + attr-char allowlist).
+ * attr-char = ALPHA / DIGIT / "!" / "#" / "$" / "&" / "+" / "-" / "." /
+ *             "^" / "_" / "`" / "|" / "~"
+ * Everything else (including space, paren, slash) gets %HH-encoded.
+ */
+function encodeRFC5987(value: string): string {
+  return encodeURIComponent(value)
+    .replace(/['()*]/g, (c) => '%' + c.charCodeAt(0).toString(16).toUpperCase())
+    .replace(/%(7C|60|5E)/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
+}

--- a/tests/unit/lib/http/content-disposition.test.ts
+++ b/tests/unit/lib/http/content-disposition.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { asciiFallback, contentDispositionHeader } from '@/lib/http/content-disposition'
+
+describe('contentDispositionHeader', () => {
+  it('produces a ByteString-safe value for plain ASCII names', () => {
+    const header = contentDispositionHeader('attachment', 'interview-pack-Alice-Smith.pdf')
+    expect(() => new Headers({ 'Content-Disposition': header })).not.toThrow()
+    expect(header).toContain('filename="interview-pack-Alice-Smith.pdf"')
+    expect(header).toContain("filename*=UTF-8''interview-pack-Alice-Smith.pdf")
+  })
+
+  it('survives the bug that hit production: Polish name with ż', () => {
+    // The original crash: `Content-Disposition: filename="${candidateName}.pdf"`
+    // with candidateName containing 'ż' (U+017C, decimal 380) throws
+    // TypeError before the response ever leaves the server.
+    const header = contentDispositionHeader('attachment', 'interview-pack-Małgorzata-Żurawski.pdf')
+    expect(() => new Headers({ 'Content-Disposition': header })).not.toThrow()
+    // ASCII fallback strips characters NFKD can't decompose to ASCII (ł has
+    // no precomposed ASCII equivalent, so it's dropped). The accented Ż
+    // decomposes to Z + combining dot, leaving Z. Readable, not pretty.
+    expect(header).toMatch(/filename="interview-pack-Magorzata-Zurawski\.pdf"/)
+    // RFC 5987 extended form preserves the original Unicode via percent-encoding
+    expect(header).toMatch(/filename\*=UTF-8''interview-pack-Ma%C5%82gorzata-%C5%BBurawski\.pdf/)
+  })
+
+  it('falls back to "download" when sanitisation strips everything', () => {
+    const header = contentDispositionHeader('attachment', '中文文件名.pdf')
+    expect(() => new Headers({ 'Content-Disposition': header })).not.toThrow()
+    expect(header).toContain('filename="download"')
+    expect(header).toMatch(/filename\*=UTF-8''/)
+  })
+
+  it('uses inline disposition for inline previews', () => {
+    const header = contentDispositionHeader('inline', 'role-Senior-Engineer.pdf')
+    expect(header.startsWith('inline;')).toBe(true)
+  })
+})
+
+describe('asciiFallback', () => {
+  it('passes through clean ASCII', () => {
+    expect(asciiFallback('hello-world.pdf')).toBe('hello-world.pdf')
+  })
+
+  it('strips diacritics via NFKD decomposition', () => {
+    expect(asciiFallback('Małgorzata')).toBe('Magorzata') // ł has no ASCII letter after NFKD
+    expect(asciiFallback('Żurawski')).toBe('Zurawski') // Ż decomposes to Z + combining dot
+    expect(asciiFallback('Wójcik')).toBe('Wojcik') // ó decomposes to o + acute
+  })
+
+  it('collapses whitespace and hyphens', () => {
+    expect(asciiFallback('  alice   smith  ')).toBe('alice-smith')
+    expect(asciiFallback('a---b')).toBe('a-b')
+  })
+
+  it('returns empty for input with only non-ASCII chars', () => {
+    expect(asciiFallback('中文')).toBe('')
+    expect(asciiFallback('🎉🎊')).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary

PDF downloads were 500-ing with
\`\`\`
TypeError: Cannot convert argument to a ByteString because the character at index 50 has a value of 380 which is greater than 255.
\`\`\`
whenever a candidate name or role title contained any non-Latin-1 character (e.g. Polish \`ż\` = U+017C = 380 decimal). HTTP header values must be ByteStrings — interpolating raw Unicode into \`Content-Disposition\` throws before the response leaves the server.

## Affected routes (all fixed)

| Route | Bug source |
|---|---|
| \`/api/export/interview-pack/[packId]\` | \`\${candidateName}\` (the reported URL) |
| \`/api/export/role/[roleId]\` | \`\${role.title}\` |
| \`/api/export/shortlist/[roleId]\` | \`\${role.title}\` |
| \`/api/export/candidate/[candidateId]\` | \`\${candidate.firstName}-\${candidate.lastName}\` |

3 other export routes (welcome-letter, synechron-cv, cvs) already have their own inline slugifiers — left alone, deliberately.

## Fix

New shared helper \`src/lib/http/content-disposition.ts\` that returns a full RFC 6266 header value:
\`\`\`
attachment; filename="ascii-fallback.pdf"; filename*=UTF-8''<percent-encoded>
\`\`\`
- \`filename=\` uses ASCII-safe sanitisation (NFKD decomposition + strip non-printable-ASCII)
- \`filename*=\` per RFC 5987 carries the original Unicode for modern browsers
- Detects "just-an-extension" edge case (e.g. all-CJK input → \`.pdf\`) and substitutes \`download\`

## Test plan

- [x] 8 unit tests in \`tests/unit/lib/http/content-disposition.test.ts\` covering ASCII passthrough, Polish characters (the actual crash), all-CJK, emoji-only, and inline disposition
- [x] \`npm test\` green (177/177 across helper + action tests)
- [x] \`tsc --noEmit\` clean
- [ ] CI green
- [ ] Manual: retry the original URL after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)