### PR TITLE
test(actions): add coverage for search, matching, frameworks, role-submissions

### DIFF
--- a/tests/unit/actions/frameworks.test.ts
+++ b/tests/unit/actions/frameworks.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Unit tests for src/actions/frameworks.ts
+ *
+ * Covers:
+ *   saveCustomerFramework — unauthenticated, viewer/hiring_manager role gate,
+ *     invalid JSON levels, schema validation (name missing, empty levels),
+ *     happy path (insert/upsert called with correct values).
+ *
+ *   deleteCustomerFramework — unauthenticated (no-op), non-admin throws,
+ *     happy path (roles cleared + framework deleted + redirect).
+ *
+ *   getCustomerFramework — returns framework when found, null when not found.
+ *
+ * Mocks:
+ *   @/db                     — withTenant
+ *   @/db/schema              — customerFrameworks, roles stubs
+ *   drizzle-orm              — eq / and pass-throughs
+ *   @/lib/auth/action-context — getActionContext
+ *   next/cache               — revalidatePath silenced
+ *   next/navigation          — redirect silenced
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const TENANT_ID   = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const USER_ID     = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const CUSTOMER_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const VALID_LEVELS = JSON.stringify([
+  { id: 'L1', code: 'junior', title: 'Junior', description: 'Entry level', order: 1 },
+  { id: 'L2', code: 'senior', title: 'Senior', description: 'Experienced', order: 2 },
+])
+
+const FRAMEWORK_ROW = {
+  id: 'ffffffff-ffff-4fff-8fff-ffffffffffff',
+  tenantId: TENANT_ID,
+  customerId: CUSTOMER_ID,
+  name: 'Engineering Levels',
+  description: 'Standard levels',
+  levels: JSON.parse(VALID_LEVELS),
+  createdAt: new Date('2026-01-01'),
+  updatedAt: new Date('2026-01-01'),
+}
+
+// ── Mock builders ─────────────────────────────────────────────────────────────
+
+function makeSelectChain(rows: unknown[]) {
+  const c: Record<string, unknown> = {}
+  const resolved = Promise.resolve(rows)
+  c.then      = resolved.then.bind(resolved)
+  c.catch     = resolved.catch.bind(resolved)
+  c.from      = vi.fn(() => c)
+  c.where     = vi.fn(() => c)
+  c.limit     = vi.fn(() => Promise.resolve(rows))
+  return c
+}
+
+// ── Per-test captured calls ───────────────────────────────────────────────────
+
+const mockInsertValues         = vi.fn()
+const mockOnConflictDoUpdate   = vi.fn()
+const mockUpdateSet            = vi.fn()
+const mockUpdateWhere          = vi.fn()
+const mockDeleteWhere          = vi.fn()
+
+// Controls select() return value per withTenant call index
+let withTenantSelectRows: unknown[] = []
+
+vi.mock('@/db', () => ({
+  db: {},
+  withTenant: vi.fn().mockImplementation(
+    async (_tenantId: string, fn: (tx: unknown) => unknown) => {
+      const tx = {
+        select: vi.fn(() => makeSelectChain(withTenantSelectRows)),
+
+        insert: vi.fn(() => ({
+          values: (...args: unknown[]) => {
+            mockInsertValues(...args)
+            return {
+              onConflictDoUpdate: (...ocdArgs: unknown[]) => {
+                mockOnConflictDoUpdate(...ocdArgs)
+                return Promise.resolve()
+              },
+            }
+          },
+        })),
+
+        update: vi.fn(() => ({
+          set: (...args: unknown[]) => {
+            mockUpdateSet(...args)
+            return {
+              where: (...wargs: unknown[]) => {
+                mockUpdateWhere(...wargs)
+                return Promise.resolve()
+              },
+            }
+          },
+        })),
+
+        delete: vi.fn(() => ({
+          where: (...wargs: unknown[]) => {
+            mockDeleteWhere(...wargs)
+            return Promise.resolve()
+          },
+        })),
+      }
+      return fn(tx)
+    }
+  ),
+}))
+
+vi.mock('@/db/schema', () => ({
+  customerFrameworks: {
+    id: 'id', tenantId: 'tenant_id', customerId: 'customer_id',
+    name: 'name', description: 'description', levels: 'levels', updatedAt: 'updated_at',
+  },
+  roles: {
+    id: 'id', tenantId: 'tenant_id', customerId: 'customer_id',
+    frameworkLevelId: 'framework_level_id', frameworkLevelLabel: 'framework_level_label',
+  },
+}))
+
+vi.mock('drizzle-orm', () => ({
+  eq:  vi.fn(() => ({ type: 'eq' })),
+  and: vi.fn((...args: unknown[]) => ({ type: 'and', args })),
+}))
+
+const mockGetActionContext = vi.fn()
+vi.mock('@/lib/auth/action-context', () => ({
+  getActionContext: () => mockGetActionContext(),
+}))
+
+const mockRevalidatePath = vi.fn()
+vi.mock('next/cache', () => ({
+  revalidatePath: mockRevalidatePath,
+}))
+
+// redirect() throws in Next.js (redirects via thrown NEXT_REDIRECT error).
+// We just capture it.
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn(() => { throw new Error('NEXT_REDIRECT') }),
+}))
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function recruiterCtx() {
+  return { tenantId: TENANT_ID, userId: USER_ID, userRole: 'recruiter' as const }
+}
+
+function adminCtx() {
+  return { tenantId: TENANT_ID, userId: USER_ID, userRole: 'admin' as const }
+}
+
+function makeFormData(overrides: Record<string, string | null> = {}): FormData {
+  const fd = new FormData()
+  fd.set('name', 'Engineering Levels')
+  fd.set('description', 'Standard engineering framework')
+  fd.set('levels', VALID_LEVELS)
+  for (const [k, v] of Object.entries(overrides)) {
+    if (v === null) fd.delete(k)
+    else fd.set(k, v)
+  }
+  return fd
+}
+
+// ── saveCustomerFramework ─────────────────────────────────────────────────────
+
+describe('saveCustomerFramework', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    withTenantSelectRows = []
+    mockGetActionContext.mockResolvedValue(recruiterCtx())
+  })
+
+  // ── Auth + role gates ─────────────────────────────────────────────────────
+
+  it('returns error when unauthenticated', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { saveCustomerFramework } = await import('@/actions/frameworks')
+
+    const result = await saveCustomerFramework(CUSTOMER_ID, null, makeFormData())
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/not authenticated/i)
+  })
+
+  it('returns error when role is viewer', async () => {
+    mockGetActionContext.mockResolvedValue({
+      tenantId: TENANT_ID, userId: USER_ID, userRole: 'viewer' as const,
+    })
+    const { saveCustomerFramework } = await import('@/actions/frameworks')
+
+    const result = await saveCustomerFramework(CUSTOMER_ID, null, makeFormData())
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/forbidden/i)
+  })
+
+  it('returns error when role is hiring_manager', async () => {
+    mockGetActionContext.mockResolvedValue({
+      tenantId: TENANT_ID, userId: USER_ID, userRole: 'hiring_manager' as const,
+    })
+    const { saveCustomerFramework } = await import('@/actions/frameworks')
+
+    const result = await saveCustomerFramework(CUSTOMER_ID, null, makeFormData())
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/forbidden/i)
+  })
+
+  // ── Validation errors ─────────────────────────────────────────────────────
+
+  it('returns error when levels JSON is malformed', async () => {
+    const { saveCustomerFramework } = await import('@/actions/frameworks')
+    const fd = makeFormData({ levels: 'not-valid-json{' })
+
+    const result = await saveCustomerFramework(CUSTOMER_ID, null, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/invalid levels data/i)
+    expect(mockInsertValues).not.toHaveBeenCalled()
+  })
+
+  it('returns fieldErrors when name is empty', async () => {
+    const { saveCustomerFramework } = await import('@/actions/frameworks')
+    const fd = makeFormData({ name: '' })
+
+    const result = await saveCustomerFramework(CUSTOMER_ID, null, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.fieldErrors).toBeDefined()
+    expect(mockInsertValues).not.toHaveBeenCalled()
+  })
+
+  it('returns fieldErrors when levels array is empty', async () => {
+    const { saveCustomerFramework } = await import('@/actions/frameworks')
+    const fd = makeFormData({ levels: '[]' })
+
+    const result = await saveCustomerFramework(CUSTOMER_ID, null, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.fieldErrors).toBeDefined()
+    expect(mockInsertValues).not.toHaveBeenCalled()
+  })
+
+  // ── Happy path ────────────────────────────────────────────────────────────
+
+  it('inserts framework with upsert and returns success', async () => {
+    const { saveCustomerFramework } = await import('@/actions/frameworks')
+
+    const result = await saveCustomerFramework(CUSTOMER_ID, null, makeFormData())
+
+    expect(result.success).toBe(true)
+    expect(mockInsertValues).toHaveBeenCalledTimes(1)
+    const insertArg = mockInsertValues.mock.calls[0][0] as Record<string, unknown>
+    expect(insertArg.tenantId).toBe(TENANT_ID)
+    expect(insertArg.customerId).toBe(CUSTOMER_ID)
+    expect(insertArg.name).toBe('Engineering Levels')
+    expect(Array.isArray(insertArg.levels)).toBe(true)
+    expect(mockOnConflictDoUpdate).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls revalidatePath for the customer page on success', async () => {
+    const { saveCustomerFramework } = await import('@/actions/frameworks')
+
+    await saveCustomerFramework(CUSTOMER_ID, null, makeFormData())
+
+    expect(mockRevalidatePath).toHaveBeenCalledWith(`/dashboard/customers/${CUSTOMER_ID}`)
+  })
+
+  it('succeeds for admin role', async () => {
+    mockGetActionContext.mockResolvedValue(adminCtx())
+    const { saveCustomerFramework } = await import('@/actions/frameworks')
+
+    const result = await saveCustomerFramework(CUSTOMER_ID, null, makeFormData())
+
+    expect(result.success).toBe(true)
+  })
+})
+
+// ── deleteCustomerFramework ───────────────────────────────────────────────────
+
+describe('deleteCustomerFramework', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    withTenantSelectRows = []
+    mockGetActionContext.mockResolvedValue(adminCtx())
+  })
+
+  it('does nothing (no throw) when unauthenticated', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { deleteCustomerFramework } = await import('@/actions/frameworks')
+
+    await expect(deleteCustomerFramework(CUSTOMER_ID)).resolves.toBeUndefined()
+    expect(mockDeleteWhere).not.toHaveBeenCalled()
+  })
+
+  it('throws Forbidden when role is recruiter (below admin)', async () => {
+    mockGetActionContext.mockResolvedValue(recruiterCtx())
+    const { deleteCustomerFramework } = await import('@/actions/frameworks')
+
+    await expect(deleteCustomerFramework(CUSTOMER_ID)).rejects.toThrow(/forbidden/i)
+    expect(mockDeleteWhere).not.toHaveBeenCalled()
+  })
+
+  it('throws Forbidden when role is viewer', async () => {
+    mockGetActionContext.mockResolvedValue({
+      tenantId: TENANT_ID, userId: USER_ID, userRole: 'viewer' as const,
+    })
+    const { deleteCustomerFramework } = await import('@/actions/frameworks')
+
+    await expect(deleteCustomerFramework(CUSTOMER_ID)).rejects.toThrow(/forbidden/i)
+  })
+
+  it('clears frameworkLevelId from roles and deletes framework, then redirects', async () => {
+    const { deleteCustomerFramework } = await import('@/actions/frameworks')
+
+    await expect(deleteCustomerFramework(CUSTOMER_ID)).rejects.toThrow('NEXT_REDIRECT')
+
+    // update() should have been called to clear the role framework references
+    expect(mockUpdateSet).toHaveBeenCalledTimes(1)
+    const updateSetArg = mockUpdateSet.mock.calls[0][0] as Record<string, unknown>
+    expect(updateSetArg.frameworkLevelId).toBeNull()
+    expect(updateSetArg.frameworkLevelLabel).toBeNull()
+
+    // delete() should have been called to remove the framework
+    expect(mockDeleteWhere).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls revalidatePath for the customer page', async () => {
+    const { deleteCustomerFramework } = await import('@/actions/frameworks')
+
+    await expect(deleteCustomerFramework(CUSTOMER_ID)).rejects.toThrow('NEXT_REDIRECT')
+
+    expect(mockRevalidatePath).toHaveBeenCalledWith(`/dashboard/customers/${CUSTOMER_ID}`)
+  })
+})
+
+// ── getCustomerFramework ──────────────────────────────────────────────────────
+
+describe('getCustomerFramework', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    withTenantSelectRows = []
+  })
+
+  it('returns the framework row when found', async () => {
+    withTenantSelectRows = [FRAMEWORK_ROW]
+    const { getCustomerFramework } = await import('@/actions/frameworks')
+
+    const result = await getCustomerFramework(CUSTOMER_ID, TENANT_ID)
+
+    expect(result).toMatchObject({
+      id: FRAMEWORK_ROW.id,
+      name: 'Engineering Levels',
+      customerId: CUSTOMER_ID,
+      tenantId: TENANT_ID,
+    })
+  })
+
+  it('returns null when no framework exists for the customer', async () => {
+    withTenantSelectRows = []
+    const { getCustomerFramework } = await import('@/actions/frameworks')
+
+    const result = await getCustomerFramework(CUSTOMER_ID, TENANT_ID)
+
+    expect(result).toBeNull()
+  })
+})

--- a/tests/unit/actions/matching.test.ts
+++ b/tests/unit/actions/matching.test.ts
@@ -1,0 +1,374 @@
+/**
+ * Unit tests for src/actions/matching.ts
+ *
+ * Covers:
+ *   getSuggestedCandidates — unauthenticated returns [], embedding failure returns [],
+ *     no candidates in tenant returns [], happy path with mocked raw SQL results,
+ *     already-scored candidates excluded.
+ *
+ *   getRoleFitSuggestionsForCandidate — unauthenticated returns [],
+ *     candidate not found returns [], candidate has no cvText returns [],
+ *     no unscored roles returns [], happy path with sorted fit results.
+ *
+ * Mocks:
+ *   @/db                       — withTenant (handles both select + execute calls)
+ *   @/db/schema                — candidates, roles, scores stubs
+ *   drizzle-orm                — eq / and / notInArray / sql pass-throughs
+ *   @/lib/auth/action-context  — getActionContext
+ *   @/lib/ai/embeddings        — generateEmbedding
+ *   @/lib/ai/role-fit          — analyseRoleFitForCandidate
+ *
+ * pgvector note: getSuggestedCandidates uses tx.execute(sql`...`) for the vector
+ * search. The mock captures the execute call and returns pre-set rows directly —
+ * no SQL parsing attempted.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const TENANT_ID     = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const USER_ID       = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const CANDIDATE_ID  = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+const ROLE_ID_1     = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
+const ROLE_ID_2     = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee'
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const CANDIDATE_ROW = {
+  id: CANDIDATE_ID,
+  firstName: 'Jane',
+  lastName: 'Doe',
+  cvText: 'Experienced TypeScript engineer with 6 years in fintech.',
+  embedding: '[0.1,0.2,0.3]',
+}
+
+const ROLE_ROWS = [
+  { id: ROLE_ID_1, title: 'Senior Engineer', requirements: 'TypeScript, Node.js', priorityKeywords: ['TypeScript'] },
+  { id: ROLE_ID_2, title: 'Tech Lead', requirements: 'Leadership, architecture', priorityKeywords: null },
+]
+
+const VECTOR_RAW_ROWS = [
+  { id: 'v1', first_name: 'Alice', last_name: 'Walker', email: 'alice@example.com', file_path: '/uploads/a.pdf', similarity: 0.95 },
+  { id: 'v2', first_name: 'Bob', last_name: 'Smith', email: null, file_path: null, similarity: 0.78 },
+]
+
+// ── Mock builders ─────────────────────────────────────────────────────────────
+
+function makeSelectChain(rows: unknown[]) {
+  const c: Record<string, unknown> = {}
+  const resolved = Promise.resolve(rows)
+  c.then      = resolved.then.bind(resolved)
+  c.catch     = resolved.catch.bind(resolved)
+  c.from      = vi.fn(() => c)
+  c.leftJoin  = vi.fn(() => c)
+  c.innerJoin = vi.fn(() => c)
+  c.where     = vi.fn(() => c)
+  c.orderBy   = vi.fn(() => c)
+  c.limit     = vi.fn(() => Promise.resolve(rows))
+  return c
+}
+
+// ── Per-test state ────────────────────────────────────────────────────────────
+
+// Queue of result batches returned in order per withTenant() call.
+// Each withTenant call gets one entry from this queue.
+let withTenantResults: unknown[][] = []
+let withTenantCallCount = 0
+
+// Controls the raw execute() result (used for pgvector search)
+let executeResult: unknown[] = []
+
+vi.mock('@/db', () => ({
+  db: {},
+  withTenant: vi.fn().mockImplementation(
+    async (_tenantId: string, fn: (tx: unknown) => unknown) => {
+      const rows = withTenantResults[withTenantCallCount] ?? []
+      withTenantCallCount++
+
+      const tx = {
+        select: vi.fn(() => makeSelectChain(rows)),
+        execute: vi.fn(() => Promise.resolve(executeResult)),
+      }
+      return fn(tx)
+    }
+  ),
+}))
+
+vi.mock('@/db/schema', () => ({
+  candidates: {
+    id: 'id', tenantId: 'tenant_id', firstName: 'first_name', lastName: 'last_name',
+    email: 'email', cvText: 'cv_text', embedding: 'embedding', filePath: 'file_path',
+    isActive: 'is_active',
+  },
+  roles: {
+    id: 'id', tenantId: 'tenant_id', title: 'title', requirements: 'requirements',
+    priorityKeywords: 'priority_keywords', isActive: 'is_active',
+  },
+  scores: {
+    id: 'id', tenantId: 'tenant_id', candidateId: 'candidate_id', roleId: 'role_id',
+  },
+}))
+
+vi.mock('drizzle-orm', () => ({
+  eq:         vi.fn(() => ({ type: 'eq' })),
+  and:        vi.fn((...args: unknown[]) => ({ type: 'and', args })),
+  notInArray: vi.fn(() => ({ type: 'notInArray' })),
+  sql:        vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
+    type: 'sql',
+    strings,
+    values,
+  })),
+}))
+
+const mockGetActionContext = vi.fn()
+vi.mock('@/lib/auth/action-context', () => ({
+  getActionContext: () => mockGetActionContext(),
+}))
+
+const mockGenerateEmbedding = vi.fn()
+vi.mock('@/lib/ai/embeddings', () => ({
+  generateEmbedding: (...args: unknown[]) => mockGenerateEmbedding(...args),
+}))
+
+const mockAnalyseRoleFit = vi.fn()
+vi.mock('@/lib/ai/role-fit', () => ({
+  analyseRoleFitForCandidate: (...args: unknown[]) => mockAnalyseRoleFit(...args),
+}))
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function recruiterCtx() {
+  return { tenantId: TENANT_ID, userId: USER_ID, userRole: 'recruiter' as const }
+}
+
+// ── getSuggestedCandidates ────────────────────────────────────────────────────
+
+describe('getSuggestedCandidates', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    withTenantResults = []
+    withTenantCallCount = 0
+    executeResult = []
+    mockGetActionContext.mockResolvedValue(recruiterCtx())
+    mockGenerateEmbedding.mockResolvedValue([0.1, 0.2, 0.3])
+  })
+
+  it('returns [] when unauthenticated', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { getSuggestedCandidates } = await import('@/actions/matching')
+
+    const result = await getSuggestedCandidates(ROLE_ID_1, 'TypeScript engineer', 5)
+
+    expect(result).toEqual([])
+  })
+
+  it('returns [] when generateEmbedding returns null', async () => {
+    mockGenerateEmbedding.mockResolvedValue(null)
+    // Still need to mock the alreadyScored call so withTenant doesn't blow up
+    withTenantResults = [[]]
+    const { getSuggestedCandidates } = await import('@/actions/matching')
+
+    const result = await getSuggestedCandidates(ROLE_ID_1, 'TypeScript engineer', 5)
+
+    expect(result).toEqual([])
+  })
+
+  it('returns [] when pgvector execute returns no rows', async () => {
+    withTenantResults = [[]] // alreadyScored = []
+    executeResult = []
+    const { getSuggestedCandidates } = await import('@/actions/matching')
+
+    const result = await getSuggestedCandidates(ROLE_ID_1, 'TypeScript engineer', 5)
+
+    expect(result).toEqual([])
+  })
+
+  it('maps raw SQL rows to camelCase with similarity as percentage', async () => {
+    withTenantResults = [[]] // alreadyScored = []
+    executeResult = VECTOR_RAW_ROWS
+    const { getSuggestedCandidates } = await import('@/actions/matching')
+
+    const result = await getSuggestedCandidates(ROLE_ID_1, 'TypeScript engineer', 5)
+
+    expect(result).toHaveLength(2)
+    expect(result[0]).toMatchObject({
+      id: 'v1',
+      firstName: 'Alice',
+      lastName: 'Walker',
+      email: 'alice@example.com',
+      filePath: '/uploads/a.pdf',
+      similarity: 95, // Math.round(0.95 * 100)
+    })
+    expect(result[1]).toMatchObject({
+      id: 'v2',
+      firstName: 'Bob',
+      lastName: 'Smith',
+      email: null,
+      filePath: null,
+      similarity: 78, // Math.round(0.78 * 100)
+    })
+  })
+
+  it('respects the limit parameter', async () => {
+    withTenantResults = [[]]
+    executeResult = VECTOR_RAW_ROWS
+    const { getSuggestedCandidates } = await import('@/actions/matching')
+
+    // Limit 1 — the SQL itself is mocked, so mock returns 2 rows regardless.
+    // The action does not slice — it relies on the SQL LIMIT. This test
+    // verifies the action passes through without error (limit is SQL-side).
+    const result = await getSuggestedCandidates(ROLE_ID_1, 'TypeScript engineer', 1)
+
+    expect(Array.isArray(result)).toBe(true)
+  })
+
+  it('returns [] and does not throw on unexpected execute error', async () => {
+    withTenantResults = [[]]
+    const { withTenant } = await import('@/db')
+    const wt = withTenant as ReturnType<typeof vi.fn>
+    // Override to throw on the execute call
+    wt.mockImplementationOnce(async (_tid: string, fn: (tx: unknown) => unknown) => {
+      return fn({ execute: vi.fn().mockRejectedValue(new Error('pgvector unavailable')) })
+    })
+    const { getSuggestedCandidates } = await import('@/actions/matching')
+
+    const result = await getSuggestedCandidates(ROLE_ID_1, 'TypeScript engineer', 5)
+
+    expect(result).toEqual([])
+  })
+})
+
+// ── getRoleFitSuggestionsForCandidate ─────────────────────────────────────────
+
+describe('getRoleFitSuggestionsForCandidate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    withTenantResults = []
+    withTenantCallCount = 0
+    executeResult = []
+    mockGetActionContext.mockResolvedValue(recruiterCtx())
+    mockAnalyseRoleFit.mockResolvedValue([])
+  })
+
+  it('returns [] when unauthenticated', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { getRoleFitSuggestionsForCandidate } = await import('@/actions/matching')
+
+    const result = await getRoleFitSuggestionsForCandidate(CANDIDATE_ID)
+
+    expect(result).toEqual([])
+  })
+
+  it('returns [] when candidate row is not found', async () => {
+    // First withTenant call returns empty (candidate lookup)
+    withTenantResults = [[]]
+    const { getRoleFitSuggestionsForCandidate } = await import('@/actions/matching')
+
+    const result = await getRoleFitSuggestionsForCandidate(CANDIDATE_ID)
+
+    expect(result).toEqual([])
+  })
+
+  it('returns [] when candidate has no cvText', async () => {
+    withTenantResults = [
+      [{ ...CANDIDATE_ROW, cvText: null }], // candidate exists but no CV text
+    ]
+    const { getRoleFitSuggestionsForCandidate } = await import('@/actions/matching')
+
+    const result = await getRoleFitSuggestionsForCandidate(CANDIDATE_ID)
+
+    expect(result).toEqual([])
+  })
+
+  it('returns [] when no active unscored roles exist', async () => {
+    withTenantResults = [
+      [CANDIDATE_ROW],   // candidate found
+      [],                // alreadyScoredRows = []
+      [],                // activeRoles = []
+    ]
+    const { getRoleFitSuggestionsForCandidate } = await import('@/actions/matching')
+
+    const result = await getRoleFitSuggestionsForCandidate(CANDIDATE_ID)
+
+    expect(result).toEqual([])
+    expect(mockAnalyseRoleFit).not.toHaveBeenCalled()
+  })
+
+  it('calls analyseRoleFitForCandidate with correct arguments', async () => {
+    withTenantResults = [
+      [CANDIDATE_ROW], // candidate
+      [],              // alreadyScoredRows (none scored yet)
+      ROLE_ROWS,       // activeRoles
+    ]
+    mockAnalyseRoleFit.mockResolvedValue([])
+    const { getRoleFitSuggestionsForCandidate } = await import('@/actions/matching')
+
+    await getRoleFitSuggestionsForCandidate(CANDIDATE_ID)
+
+    expect(mockAnalyseRoleFit).toHaveBeenCalledWith(
+      'Jane Doe',
+      CANDIDATE_ROW.cvText,
+      expect.arrayContaining([
+        expect.objectContaining({ roleId: ROLE_ID_1, roleTitle: 'Senior Engineer' }),
+        expect.objectContaining({ roleId: ROLE_ID_2, roleTitle: 'Tech Lead' }),
+      ]),
+      TENANT_ID
+    )
+  })
+
+  it('returns results sorted by fitScore descending and capped at 8', async () => {
+    withTenantResults = [
+      [CANDIDATE_ROW],
+      [],
+      ROLE_ROWS,
+    ]
+    const fitResults = [
+      { roleId: ROLE_ID_2, fitScore: 90, pros: ['Leadership'], cons: [], headline: 'Strong lead fit' },
+      { roleId: ROLE_ID_1, fitScore: 75, pros: ['TypeScript'], cons: ['Minimal ops'], headline: 'Good tech fit' },
+    ]
+    mockAnalyseRoleFit.mockResolvedValue(fitResults)
+    const { getRoleFitSuggestionsForCandidate } = await import('@/actions/matching')
+
+    const result = await getRoleFitSuggestionsForCandidate(CANDIDATE_ID)
+
+    expect(result).toHaveLength(2)
+    // Higher fitScore first
+    expect(result[0].fit.fitScore).toBe(90)
+    expect(result[0].role.id).toBe(ROLE_ID_2)
+    expect(result[1].fit.fitScore).toBe(75)
+    expect(result[1].role.id).toBe(ROLE_ID_1)
+  })
+
+  it('excludes already-scored roles from the role query', async () => {
+    withTenantResults = [
+      [CANDIDATE_ROW],
+      [{ roleId: ROLE_ID_1 }], // ROLE_ID_1 already scored
+      [ROLE_ROWS[1]],          // only ROLE_ID_2 returned as active+unscored
+    ]
+    const fitResults = [
+      { roleId: ROLE_ID_2, fitScore: 80, pros: ['Architecture'], cons: [], headline: 'Good arch fit' },
+    ]
+    mockAnalyseRoleFit.mockResolvedValue(fitResults)
+    const { getRoleFitSuggestionsForCandidate } = await import('@/actions/matching')
+
+    const result = await getRoleFitSuggestionsForCandidate(CANDIDATE_ID)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].role.id).toBe(ROLE_ID_2)
+  })
+
+  it('returns [] and does not throw on analyseRoleFitForCandidate error', async () => {
+    withTenantResults = [
+      [CANDIDATE_ROW],
+      [],
+      ROLE_ROWS,
+    ]
+    mockAnalyseRoleFit.mockRejectedValue(new Error('Claude API unavailable'))
+    const { getRoleFitSuggestionsForCandidate } = await import('@/actions/matching')
+
+    const result = await getRoleFitSuggestionsForCandidate(CANDIDATE_ID)
+
+    expect(result).toEqual([])
+  })
+})

--- a/tests/unit/actions/role-submissions.test.ts
+++ b/tests/unit/actions/role-submissions.test.ts
@@ -1,0 +1,888 @@
+/**
+ * Unit tests for src/actions/role-submissions/ (via index barrel)
+ *
+ * Covers:
+ *   mutations:
+ *     submitCandidatesToCustomer — schema validation, auth, role gate, happy path,
+ *       idempotent re-submit (onConflictDoNothing), audit per inserted row.
+ *     updateSubmissionStatus — auth, role gate, not-found, happy path with
+ *       status transition audit log.
+ *     removeSubmission — auth, role gate, not-found, happy path with audit.
+ *
+ *   sharing:
+ *     generateShareToken — auth, role gate, not-found, happy path (token generated
+ *       and URL built from APP_URL), re-generation audit flag.
+ *     revokeShareToken — auth, role gate, not-found, happy path (shareToken cleared).
+ *
+ *   public:
+ *     updateSubmissionStatusByToken — invalid token, disallowed status
+ *       (cannot set 'submitted' via public link), rate-limit rejection,
+ *       expired/revoked token (no row), happy path.
+ *     getSubmissionByToken — invalid token, expired token, happy path returns
+ *       CustomerVisibleSubmission with no commercial fields.
+ *
+ * Mocks:
+ *   @/db                                              — db, withTenant
+ *   @/db/schema/role-submissions                      — roleSubmissions, SubmissionStatus
+ *   @/db/schema/candidates                            — candidates
+ *   @/db/schema/roles                                 — roles
+ *   @/db/schema/tenants                               — tenants
+ *   @/db/schema/customers                             — customers
+ *   @/db/schema/audit-logs                            — auditLogs
+ *   drizzle-orm                                       — eq / and / inArray / sql
+ *   @/lib/auth/action-context                         — getActionContext
+ *   @/lib/audit                                       — writeAuditLog
+ *   @/lib/api/share-rate-limit                        — checkShareUpdateRateLimit
+ *   @/lib/email/notify-recruiter-of-customer-update   — notifyRecruiterOfCustomerUpdate
+ *   next/cache                                        — revalidatePath silenced
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const TENANT_ID      = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const USER_ID        = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const ROLE_ID        = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+const CANDIDATE_ID   = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
+const CANDIDATE_ID_2 = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee'
+const SUBMISSION_ID  = 'ffffffff-ffff-4fff-8fff-ffffffffffff'
+const SHARE_TOKEN    = 'a'.repeat(44) // 44 chars base64url — valid length
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const SUBMISSION_ROW = {
+  id: SUBMISSION_ID,
+  tenantId: TENANT_ID,
+  roleId: ROLE_ID,
+  candidateId: CANDIDATE_ID,
+  status: 'submitted',
+  shareToken: SHARE_TOKEN,
+  shareTokenCreatedAt: new Date('2026-01-01'),
+}
+
+const CANDIDATE_ROW = {
+  id: CANDIDATE_ID,
+  firstName: 'Jane',
+  lastName: 'Doe',
+  tenantId: TENANT_ID,
+}
+
+const ROLE_ROW = {
+  id: ROLE_ID,
+  title: 'Senior TypeScript Engineer',
+}
+
+const TENANT_ROW = {
+  id: TENANT_ID,
+  name: 'Acme Recruiting Ltd',
+}
+
+// ── Mock builders ─────────────────────────────────────────────────────────────
+
+function makeSelectChain(rows: unknown[]) {
+  const c: Record<string, unknown> = {}
+  const resolved = Promise.resolve(rows)
+  c.then      = resolved.then.bind(resolved)
+  c.catch     = resolved.catch.bind(resolved)
+  c.from      = vi.fn(() => c)
+  c.leftJoin  = vi.fn(() => c)
+  c.innerJoin = vi.fn(() => c)
+  c.where     = vi.fn(() => c)
+  c.orderBy   = vi.fn(() => c)
+  c.limit     = vi.fn(() => Promise.resolve(rows))
+  return c
+}
+
+// ── Per-test state ────────────────────────────────────────────────────────────
+
+// withTenant() result queue — one entry per invocation
+let withTenantResults: unknown[][] = []
+let withTenantCallCount = 0
+
+// Captured mutation calls
+const mockInsertValues        = vi.fn()
+const mockOnConflictDoNothing = vi.fn()
+const mockReturning           = vi.fn()
+const mockUpdateSet           = vi.fn()
+const mockUpdateWhere         = vi.fn()
+const mockDeleteWhere         = vi.fn()
+const mockInsertAuditValues   = vi.fn()
+
+// db.execute mock — for public module raw SQL token lookup
+let dbExecuteResult: unknown[] = []
+
+// db.select chain for getSubmissionByToken's tenant lookup
+let dbSelectChainRows: unknown[] = []
+
+vi.mock('@/db', () => ({
+  db: {
+    execute: vi.fn(() => Promise.resolve(dbExecuteResult)),
+    select: vi.fn(() => makeSelectChain(dbSelectChainRows)),
+  },
+  withTenant: vi.fn().mockImplementation(
+    async (_tenantId: string, fn: (tx: unknown) => unknown) => {
+      const rows = withTenantResults[withTenantCallCount] ?? []
+      withTenantCallCount++
+
+      const tx = {
+        select: vi.fn(() => makeSelectChain(rows)),
+
+        insert: vi.fn((table: unknown) => {
+          // Distinguish audit log inserts from submission inserts by the table stub
+          const isAuditLog = table === 'audit_logs_stub'
+          return {
+            values: (...args: unknown[]) => {
+              if (isAuditLog) mockInsertAuditValues(...args)
+              else mockInsertValues(...args)
+              return {
+                onConflictDoNothing: (...ocdArgs: unknown[]) => {
+                  mockOnConflictDoNothing(...ocdArgs)
+                  return {
+                    returning: (...rArgs: unknown[]) => {
+                      mockReturning(...rArgs)
+                      // Return the inserted rows (simulate successful insert)
+                      return Promise.resolve([
+                        { id: SUBMISSION_ID, candidateId: CANDIDATE_ID },
+                      ])
+                    },
+                  }
+                },
+                // Plain values() without onConflictDoNothing (used in audit insert)
+                catch: (fn: (e: unknown) => void) => ({ catch: fn }),
+              }
+            },
+          }
+        }),
+
+        update: vi.fn(() => ({
+          set: (...args: unknown[]) => {
+            mockUpdateSet(...args)
+            return {
+              where: (...wargs: unknown[]) => {
+                mockUpdateWhere(...wargs)
+                return Promise.resolve()
+              },
+            }
+          },
+        })),
+
+        delete: vi.fn(() => ({
+          where: (...wargs: unknown[]) => {
+            mockDeleteWhere(...wargs)
+            return Promise.resolve()
+          },
+        })),
+      }
+      return fn(tx)
+    }
+  ),
+}))
+
+vi.mock('@/db/schema/role-submissions', () => ({
+  roleSubmissions: {
+    id: 'id', tenantId: 'tenant_id', roleId: 'role_id',
+    candidateId: 'candidate_id', status: 'status', sentAt: 'sent_at',
+    sentByUserId: 'sent_by_user_id', statusUpdatedAt: 'status_updated_at',
+    notes: 'notes', createdAt: 'created_at', shareToken: 'share_token',
+    shareTokenCreatedAt: 'share_token_created_at', updatedAt: 'updated_at',
+  },
+}))
+
+vi.mock('@/db/schema/candidates', () => ({
+  candidates: {
+    id: 'id', tenantId: 'tenant_id', firstName: 'first_name',
+    lastName: 'last_name', email: 'email', agencyId: 'agency_id',
+  },
+}))
+
+vi.mock('@/db/schema/roles', () => ({
+  roles: {
+    id: 'id', tenantId: 'tenant_id', title: 'title', customerId: 'customer_id',
+  },
+}))
+
+vi.mock('@/db/schema/tenants', () => ({
+  tenants: { id: 'id', name: 'name' },
+}))
+
+vi.mock('@/db/schema/customers', () => ({
+  customers: { id: 'id', name: 'name' },
+}))
+
+vi.mock('@/db/schema/audit-logs', () => ({
+  auditLogs: 'audit_logs_stub',
+}))
+
+vi.mock('drizzle-orm', () => ({
+  eq:      vi.fn(() => ({ type: 'eq' })),
+  and:     vi.fn((...args: unknown[]) => ({ type: 'and', args })),
+  inArray: vi.fn(() => ({ type: 'inArray' })),
+  sql:     vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
+    type: 'sql', strings, values,
+  })),
+}))
+
+const mockGetActionContext = vi.fn()
+vi.mock('@/lib/auth/action-context', () => ({
+  getActionContext: () => mockGetActionContext(),
+}))
+
+const mockWriteAuditLog = vi.fn().mockResolvedValue(undefined)
+vi.mock('@/lib/audit', () => ({
+  writeAuditLog: mockWriteAuditLog,
+}))
+
+const mockCheckShareRateLimit = vi.fn().mockReturnValue(null) // null = not rate-limited
+vi.mock('@/lib/api/share-rate-limit', () => ({
+  checkShareUpdateRateLimit: (...args: unknown[]) => mockCheckShareRateLimit(...args),
+}))
+
+const mockNotifyRecruiter = vi.fn().mockResolvedValue(undefined)
+vi.mock('@/lib/email/notify-recruiter-of-customer-update', () => ({
+  notifyRecruiterOfCustomerUpdate: (...args: unknown[]) => mockNotifyRecruiter(...args),
+}))
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}))
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function recruiterCtx() {
+  return { tenantId: TENANT_ID, userId: USER_ID, userRole: 'recruiter' as const }
+}
+
+function resetState() {
+  vi.clearAllMocks()
+  withTenantResults = []
+  withTenantCallCount = 0
+  dbExecuteResult = []
+  dbSelectChainRows = []
+  mockGetActionContext.mockResolvedValue(recruiterCtx())
+  mockCheckShareRateLimit.mockReturnValue(null)
+}
+
+// ── submitCandidatesToCustomer ────────────────────────────────────────────────
+
+describe('submitCandidatesToCustomer', () => {
+  beforeEach(resetState)
+
+  it('returns error when unauthenticated', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { submitCandidatesToCustomer } = await import('@/actions/role-submissions')
+
+    const result = await submitCandidatesToCustomer(ROLE_ID, [CANDIDATE_ID])
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/unauthorized/i)
+  })
+
+  it('returns error when role is viewer', async () => {
+    mockGetActionContext.mockResolvedValue({
+      tenantId: TENANT_ID, userId: USER_ID, userRole: 'viewer' as const,
+    })
+    const { submitCandidatesToCustomer } = await import('@/actions/role-submissions')
+
+    const result = await submitCandidatesToCustomer(ROLE_ID, [CANDIDATE_ID])
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/forbidden/i)
+  })
+
+  it('returns error when roleId is not a valid UUID', async () => {
+    const { submitCandidatesToCustomer } = await import('@/actions/role-submissions')
+
+    const result = await submitCandidatesToCustomer('not-a-uuid', [CANDIDATE_ID])
+
+    expect(result.success).toBe(false)
+  })
+
+  it('returns error when candidateIds is empty array', async () => {
+    const { submitCandidatesToCustomer } = await import('@/actions/role-submissions')
+
+    const result = await submitCandidatesToCustomer(ROLE_ID, [])
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/at least one/i)
+  })
+
+  it('inserts submission rows and writes audit log per inserted row', async () => {
+    // candidateRows lookup
+    withTenantResults = [
+      [CANDIDATE_ROW],                                             // candidate names fetch
+      [{ id: SUBMISSION_ID, candidateId: CANDIDATE_ID }],        // insert returning
+    ]
+    const { submitCandidatesToCustomer } = await import('@/actions/role-submissions')
+
+    const result = await submitCandidatesToCustomer(ROLE_ID, [CANDIDATE_ID], 'Strong TypeScript background')
+
+    expect(result.success).toBe(true)
+    const data = (result as { success: true; data: { inserted: number } }).data
+    expect(data.inserted).toBeGreaterThanOrEqual(0)
+    expect(mockWriteAuditLog).toHaveBeenCalledWith(
+      TENANT_ID,
+      expect.objectContaining({ action: 'candidate.submitted_to_customer' })
+    )
+  })
+
+  it('succeeds with notes undefined (no notes variant)', async () => {
+    withTenantResults = [
+      [CANDIDATE_ROW],
+      [{ id: SUBMISSION_ID, candidateId: CANDIDATE_ID }],
+    ]
+    const { submitCandidatesToCustomer } = await import('@/actions/role-submissions')
+
+    const result = await submitCandidatesToCustomer(ROLE_ID, [CANDIDATE_ID])
+
+    expect(result.success).toBe(true)
+  })
+})
+
+// ── updateSubmissionStatus ────────────────────────────────────────────────────
+
+describe('updateSubmissionStatus', () => {
+  beforeEach(resetState)
+
+  it('returns error when unauthenticated', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { updateSubmissionStatus } = await import('@/actions/role-submissions')
+
+    const result = await updateSubmissionStatus(SUBMISSION_ID, 'interview_scheduled')
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/unauthorized/i)
+  })
+
+  it('returns error when role is hiring_manager (below recruiter)', async () => {
+    mockGetActionContext.mockResolvedValue({
+      tenantId: TENANT_ID, userId: USER_ID, userRole: 'hiring_manager' as const,
+    })
+    const { updateSubmissionStatus } = await import('@/actions/role-submissions')
+
+    const result = await updateSubmissionStatus(SUBMISSION_ID, 'interview_scheduled')
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/forbidden/i)
+  })
+
+  it('returns error when submissionId is not a valid UUID', async () => {
+    const { updateSubmissionStatus } = await import('@/actions/role-submissions')
+
+    const result = await updateSubmissionStatus('bad-id', 'hired')
+
+    expect(result.success).toBe(false)
+  })
+
+  it('returns error when status value is not in the allowed enum', async () => {
+    const { updateSubmissionStatus } = await import('@/actions/role-submissions')
+
+    const result = await updateSubmissionStatus(SUBMISSION_ID, 'pending_review' as never)
+
+    expect(result.success).toBe(false)
+  })
+
+  it('returns not-found when submission row does not exist in tenant', async () => {
+    // existing row lookup returns empty
+    withTenantResults = [[]]
+    const { updateSubmissionStatus } = await import('@/actions/role-submissions')
+
+    const result = await updateSubmissionStatus(SUBMISSION_ID, 'hired')
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/not found/i)
+  })
+
+  it('updates status and writes submission.status_changed audit log', async () => {
+    withTenantResults = [
+      [SUBMISSION_ROW],                          // existing row lookup
+      [{ firstName: 'Jane', lastName: 'Doe' }],  // candidate name lookup
+      [{ title: 'Senior TypeScript Engineer' }], // role title lookup
+      [],                                        // update() call
+    ]
+    const { updateSubmissionStatus } = await import('@/actions/role-submissions')
+
+    const result = await updateSubmissionStatus(SUBMISSION_ID, 'interview_scheduled')
+
+    expect(result.success).toBe(true)
+    expect(mockUpdateSet).toHaveBeenCalledTimes(1)
+    const setArg = mockUpdateSet.mock.calls[0][0] as Record<string, unknown>
+    expect(setArg.status).toBe('interview_scheduled')
+    expect(mockWriteAuditLog).toHaveBeenCalledWith(
+      TENANT_ID,
+      expect.objectContaining({
+        action: 'submission.status_changed',
+        entityType: 'submission',
+        entityId: SUBMISSION_ID,
+        metadata: expect.objectContaining({
+          from: 'submitted',
+          to: 'interview_scheduled',
+        }),
+      })
+    )
+  })
+
+  it('includes notes in the update payload when provided', async () => {
+    withTenantResults = [
+      [SUBMISSION_ROW],
+      [CANDIDATE_ROW],
+      [ROLE_ROW],
+      [],
+    ]
+    const { updateSubmissionStatus } = await import('@/actions/role-submissions')
+
+    await updateSubmissionStatus(SUBMISSION_ID, 'hired', 'Great interview')
+
+    const setArg = mockUpdateSet.mock.calls[0][0] as Record<string, unknown>
+    expect(setArg.notes).toBe('Great interview')
+  })
+
+  it('does not include notes key when notes is undefined', async () => {
+    withTenantResults = [
+      [SUBMISSION_ROW],
+      [CANDIDATE_ROW],
+      [ROLE_ROW],
+      [],
+    ]
+    const { updateSubmissionStatus } = await import('@/actions/role-submissions')
+
+    await updateSubmissionStatus(SUBMISSION_ID, 'hired')
+
+    const setArg = mockUpdateSet.mock.calls[0][0] as Record<string, unknown>
+    expect(Object.prototype.hasOwnProperty.call(setArg, 'notes')).toBe(false)
+  })
+})
+
+// ── removeSubmission ──────────────────────────────────────────────────────────
+
+describe('removeSubmission', () => {
+  beforeEach(resetState)
+
+  it('returns error when unauthenticated', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { removeSubmission } = await import('@/actions/role-submissions')
+
+    const result = await removeSubmission(SUBMISSION_ID)
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/unauthorized/i)
+  })
+
+  it('returns error when role is viewer', async () => {
+    mockGetActionContext.mockResolvedValue({
+      tenantId: TENANT_ID, userId: USER_ID, userRole: 'viewer' as const,
+    })
+    const { removeSubmission } = await import('@/actions/role-submissions')
+
+    const result = await removeSubmission(SUBMISSION_ID)
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/forbidden/i)
+  })
+
+  it('returns not-found when submission row does not exist', async () => {
+    withTenantResults = [[]]
+    const { removeSubmission } = await import('@/actions/role-submissions')
+
+    const result = await removeSubmission(SUBMISSION_ID)
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/not found/i)
+  })
+
+  it('deletes submission and writes candidate.unsubmitted_from_customer audit', async () => {
+    withTenantResults = [
+      [SUBMISSION_ROW],  // existing row
+      [CANDIDATE_ROW],   // candidate name
+      [],                // delete
+    ]
+    const { removeSubmission } = await import('@/actions/role-submissions')
+
+    const result = await removeSubmission(SUBMISSION_ID)
+
+    expect(result.success).toBe(true)
+    expect(mockDeleteWhere).toHaveBeenCalledTimes(1)
+    expect(mockWriteAuditLog).toHaveBeenCalledWith(
+      TENANT_ID,
+      expect.objectContaining({
+        action: 'candidate.unsubmitted_from_customer',
+        entityType: 'candidate',
+        entityId: CANDIDATE_ID,
+        metadata: expect.objectContaining({
+          roleId: ROLE_ID,
+          submissionId: SUBMISSION_ID,
+          lastStatus: 'submitted',
+        }),
+      })
+    )
+  })
+})
+
+// ── generateShareToken ────────────────────────────────────────────────────────
+
+describe('generateShareToken', () => {
+  beforeEach(resetState)
+
+  it('returns error when unauthenticated', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { generateShareToken } = await import('@/actions/role-submissions')
+
+    const result = await generateShareToken(SUBMISSION_ID)
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/unauthorized/i)
+  })
+
+  it('returns error when role is hiring_manager', async () => {
+    mockGetActionContext.mockResolvedValue({
+      tenantId: TENANT_ID, userId: USER_ID, userRole: 'hiring_manager' as const,
+    })
+    const { generateShareToken } = await import('@/actions/role-submissions')
+
+    const result = await generateShareToken(SUBMISSION_ID)
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/forbidden/i)
+  })
+
+  it('returns error for invalid UUID submissionId', async () => {
+    const { generateShareToken } = await import('@/actions/role-submissions')
+
+    const result = await generateShareToken('not-a-uuid')
+
+    expect(result.success).toBe(false)
+  })
+
+  it('returns not-found when submission does not exist in tenant', async () => {
+    withTenantResults = [[]]
+    const { generateShareToken } = await import('@/actions/role-submissions')
+
+    const result = await generateShareToken(SUBMISSION_ID)
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/not found/i)
+  })
+
+  it('generates a token, persists it, and returns success with url', async () => {
+    const submissionWithNoToken = { ...SUBMISSION_ROW, shareToken: null }
+    withTenantResults = [
+      [submissionWithNoToken],                              // submission lookup
+      [{ firstName: 'Jane', lastName: 'Doe' }],            // candidate name
+      [{ title: 'Senior TypeScript Engineer' }],           // role title
+      [],                                                  // update call
+    ]
+    process.env.APP_URL = 'https://app.example.com'
+    const { generateShareToken } = await import('@/actions/role-submissions')
+
+    const result = await generateShareToken(SUBMISSION_ID)
+
+    expect(result.success).toBe(true)
+    const data = (result as { success: true; data: { token: string; url: string } }).data
+    expect(typeof data.token).toBe('string')
+    expect(data.token.length).toBeGreaterThan(0)
+    expect(data.url).toContain(data.token)
+    expect(data.url).toContain('https://app.example.com')
+
+    // The update should have set shareToken
+    expect(mockUpdateSet).toHaveBeenCalledTimes(1)
+    const setArg = mockUpdateSet.mock.calls[0][0] as Record<string, unknown>
+    expect(typeof setArg.shareToken).toBe('string')
+
+    // Audit log should be written
+    expect(mockWriteAuditLog).toHaveBeenCalledWith(
+      TENANT_ID,
+      expect.objectContaining({
+        action: 'submission.share_token_generated',
+        metadata: expect.objectContaining({ regenerated: false }),
+      })
+    )
+  })
+
+  it('sets regenerated=true in audit when token already existed', async () => {
+    withTenantResults = [
+      [SUBMISSION_ROW], // submission with existing shareToken
+      [CANDIDATE_ROW],
+      [ROLE_ROW],
+      [],
+    ]
+    const { generateShareToken } = await import('@/actions/role-submissions')
+
+    await generateShareToken(SUBMISSION_ID)
+
+    expect(mockWriteAuditLog).toHaveBeenCalledWith(
+      TENANT_ID,
+      expect.objectContaining({
+        metadata: expect.objectContaining({ regenerated: true }),
+      })
+    )
+  })
+})
+
+// ── revokeShareToken ──────────────────────────────────────────────────────────
+
+describe('revokeShareToken', () => {
+  beforeEach(resetState)
+
+  it('returns error when unauthenticated', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { revokeShareToken } = await import('@/actions/role-submissions')
+
+    const result = await revokeShareToken(SUBMISSION_ID)
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/unauthorized/i)
+  })
+
+  it('returns not-found when submission does not exist', async () => {
+    withTenantResults = [[]]
+    const { revokeShareToken } = await import('@/actions/role-submissions')
+
+    const result = await revokeShareToken(SUBMISSION_ID)
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/not found/i)
+  })
+
+  it('clears shareToken on the row and writes revocation audit log', async () => {
+    withTenantResults = [
+      [SUBMISSION_ROW],
+      [CANDIDATE_ROW],
+      [ROLE_ROW],
+      [],
+    ]
+    const { revokeShareToken } = await import('@/actions/role-submissions')
+
+    const result = await revokeShareToken(SUBMISSION_ID)
+
+    expect(result.success).toBe(true)
+    const setArg = mockUpdateSet.mock.calls[0][0] as Record<string, unknown>
+    expect(setArg.shareToken).toBeNull()
+    expect(setArg.shareTokenCreatedAt).toBeNull()
+    expect(mockWriteAuditLog).toHaveBeenCalledWith(
+      TENANT_ID,
+      expect.objectContaining({ action: 'submission.share_token_revoked' })
+    )
+  })
+})
+
+// ── updateSubmissionStatusByToken (public) ────────────────────────────────────
+
+describe('updateSubmissionStatusByToken', () => {
+  const OPTS = {
+    ipAddress: '1.2.3.4',
+    userAgent: 'TestAgent/1.0',
+  }
+
+  beforeEach(resetState)
+
+  it('returns error for empty token', async () => {
+    const { updateSubmissionStatusByToken } = await import('@/actions/role-submissions')
+
+    const result = await updateSubmissionStatusByToken('', 'hired', OPTS)
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/invalid token/i)
+  })
+
+  it('returns error for token longer than 64 chars', async () => {
+    const { updateSubmissionStatusByToken } = await import('@/actions/role-submissions')
+
+    const result = await updateSubmissionStatusByToken('x'.repeat(65), 'hired', OPTS)
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/invalid token/i)
+  })
+
+  it('returns error when status is "submitted" (not in CUSTOMER_ALLOWED)', async () => {
+    const { updateSubmissionStatusByToken } = await import('@/actions/role-submissions')
+
+    const result = await updateSubmissionStatusByToken(SHARE_TOKEN, 'submitted', OPTS)
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/not allowed/i)
+  })
+
+  it('returns error when status is "withdrawn" (not in CUSTOMER_ALLOWED)', async () => {
+    const { updateSubmissionStatusByToken } = await import('@/actions/role-submissions')
+
+    const result = await updateSubmissionStatusByToken(SHARE_TOKEN, 'withdrawn' as never, OPTS)
+
+    expect(result.success).toBe(false)
+  })
+
+  it('returns error when rate-limited', async () => {
+    mockCheckShareRateLimit.mockReturnValue({ retryAfterSeconds: 30 })
+    const { updateSubmissionStatusByToken } = await import('@/actions/role-submissions')
+
+    const result = await updateSubmissionStatusByToken(SHARE_TOKEN, 'hired', OPTS)
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/30s/i)
+  })
+
+  it('returns expired error when db.execute returns no row', async () => {
+    dbExecuteResult = []
+    const { updateSubmissionStatusByToken } = await import('@/actions/role-submissions')
+
+    const result = await updateSubmissionStatusByToken(SHARE_TOKEN, 'hired', OPTS)
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/expired|revoked/i)
+  })
+
+  it('returns expired error when share_token column is null (revoked)', async () => {
+    dbExecuteResult = [{
+      id: SUBMISSION_ID,
+      tenant_id: TENANT_ID,
+      role_id: ROLE_ID,
+      candidate_id: CANDIDATE_ID,
+      status: 'submitted',
+      share_token: null,
+    }]
+    const { updateSubmissionStatusByToken } = await import('@/actions/role-submissions')
+
+    const result = await updateSubmissionStatusByToken(SHARE_TOKEN, 'hired', OPTS)
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/expired|revoked/i)
+  })
+
+  it('updates status and returns success with new status + timestamp on happy path', async () => {
+    dbExecuteResult = [{
+      id: SUBMISSION_ID,
+      tenant_id: TENANT_ID,
+      role_id: ROLE_ID,
+      candidate_id: CANDIDATE_ID,
+      status: 'submitted',
+      share_token: SHARE_TOKEN,
+    }]
+    // withTenant calls: update, candidate name, role title, audit insert
+    withTenantResults = [[], [CANDIDATE_ROW], [ROLE_ROW], []]
+    const { updateSubmissionStatusByToken } = await import('@/actions/role-submissions')
+
+    const result = await updateSubmissionStatusByToken(SHARE_TOKEN, 'hired', OPTS)
+
+    expect(result.success).toBe(true)
+    const data = (result as { success: true; data: { status: string; statusUpdatedAt: Date } }).data
+    expect(data.status).toBe('hired')
+    expect(data.statusUpdatedAt).toBeInstanceOf(Date)
+    expect(mockUpdateSet).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ── getSubmissionByToken (public) ─────────────────────────────────────────────
+
+describe('getSubmissionByToken', () => {
+  beforeEach(resetState)
+
+  it('returns null for empty token', async () => {
+    const { getSubmissionByToken } = await import('@/actions/role-submissions')
+
+    const result = await getSubmissionByToken('')
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null for token longer than 64 chars', async () => {
+    const { getSubmissionByToken } = await import('@/actions/role-submissions')
+
+    const result = await getSubmissionByToken('x'.repeat(65))
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null when db.execute finds no row for the token', async () => {
+    dbExecuteResult = []
+    const { getSubmissionByToken } = await import('@/actions/role-submissions')
+
+    const result = await getSubmissionByToken(SHARE_TOKEN)
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null when share_token column is null (revoked)', async () => {
+    dbExecuteResult = [{
+      id: SUBMISSION_ID,
+      tenant_id: TENANT_ID,
+      role_id: ROLE_ID,
+      candidate_id: CANDIDATE_ID,
+      status: 'submitted',
+      sent_at: new Date(),
+      status_updated_at: new Date(),
+      share_token: null,
+    }]
+    const { getSubmissionByToken } = await import('@/actions/role-submissions')
+
+    const result = await getSubmissionByToken(SHARE_TOKEN)
+
+    expect(result).toBeNull()
+  })
+
+  it('returns CustomerVisibleSubmission on happy path', async () => {
+    const now = new Date('2026-05-01T10:00:00Z')
+    dbExecuteResult = [{
+      id: SUBMISSION_ID,
+      tenant_id: TENANT_ID,
+      role_id: ROLE_ID,
+      candidate_id: CANDIDATE_ID,
+      status: 'submitted',
+      sent_at: now,
+      status_updated_at: now,
+      share_token: SHARE_TOKEN,
+    }]
+    // Phase 2: withTenant enriched projection
+    withTenantResults = [[{
+      candidateFirstName: 'Jane',
+      candidateLastName: 'Doe',
+      roleTitle: 'Senior TypeScript Engineer',
+      customerName: 'ClientCo',
+    }]]
+    // Phase 3: db.select() for tenant name
+    dbSelectChainRows = [TENANT_ROW]
+
+    const { getSubmissionByToken } = await import('@/actions/role-submissions')
+
+    const result = await getSubmissionByToken(SHARE_TOKEN)
+
+    expect(result).not.toBeNull()
+    expect(result!.candidateFirstName).toBe('Jane')
+    expect(result!.candidateLastName).toBe('Doe')
+    expect(result!.roleTitle).toBe('Senior TypeScript Engineer')
+    expect(result!.customerName).toBe('ClientCo')
+    expect(result!.tenantName).toBe('Acme Recruiting Ltd')
+    expect(result!.status).toBe('submitted')
+
+    // Ensure no commercial fields are present
+    expect(result).not.toHaveProperty('candidateRate')
+    expect(result).not.toHaveProperty('margin')
+    expect(result).not.toHaveProperty('notes')
+    expect(result).not.toHaveProperty('agencyId')
+  })
+
+  it('returns null when tenant row does not exist', async () => {
+    dbExecuteResult = [{
+      id: SUBMISSION_ID,
+      tenant_id: TENANT_ID,
+      role_id: ROLE_ID,
+      candidate_id: CANDIDATE_ID,
+      status: 'submitted',
+      sent_at: new Date(),
+      status_updated_at: new Date(),
+      share_token: SHARE_TOKEN,
+    }]
+    withTenantResults = [[{
+      candidateFirstName: 'Jane',
+      candidateLastName: 'Doe',
+      roleTitle: 'Senior TypeScript Engineer',
+      customerName: null,
+    }]]
+    // tenant not found
+    dbSelectChainRows = []
+
+    const { getSubmissionByToken } = await import('@/actions/role-submissions')
+
+    const result = await getSubmissionByToken(SHARE_TOKEN)
+
+    expect(result).toBeNull()
+  })
+})

--- a/tests/unit/actions/search.test.ts
+++ b/tests/unit/actions/search.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Unit tests for src/actions/search.ts
+ *
+ * Covers:
+ *   searchGlobal — unauthenticated / role-gated degradation (returns EMPTY),
+ *     short-query guard, happy path (all four entity types populated),
+ *     no-results case, viewer silently returns empty.
+ *
+ * Mocks:
+ *   @/db                      — withTenant (tx with joinable select chain)
+ *   @/db/schema                — candidates, roles, customers, agencies stubs
+ *   drizzle-orm               — eq / and / or / ilike / desc pass-throughs
+ *   @/lib/auth/action-context  — getActionContext
+ *
+ * Note: searchGlobal uses Promise.all with four parallel tx.select() chains.
+ * The mock returns all four via a per-call queue.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const TENANT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const USER_ID   = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+
+// ── Fixture rows ──────────────────────────────────────────────────────────────
+
+const CANDIDATE_ROWS = [
+  { id: 'c1', firstName: 'Jane', lastName: 'Doe', email: 'jane@example.com', agencyName: 'Acme Staffing' },
+]
+const ROLE_ROWS = [
+  { id: 'r1', title: 'Senior TypeScript Engineer', customerRoleId: 'ENG-001', customerName: 'ClientCo' },
+]
+const CUSTOMER_ROWS = [
+  { id: 'cu1', name: 'ClientCo Ltd' },
+]
+const AGENCY_ROWS = [
+  { id: 'ag1', name: 'Acme Staffing', isInternal: false },
+]
+
+// ── Mock builder ──────────────────────────────────────────────────────────────
+
+/**
+ * Builds a thenable select-chain that supports the full
+ * .select().from().leftJoin().where().orderBy().limit() call chain.
+ * All chainable methods return `this`; limit returns a resolved promise.
+ */
+function makeSelectChain(rows: unknown[]) {
+  const c: Record<string, unknown> = {}
+  const resolved = Promise.resolve(rows)
+  c.then      = resolved.then.bind(resolved)
+  c.catch     = resolved.catch.bind(resolved)
+  c.from      = vi.fn(() => c)
+  c.leftJoin  = vi.fn(() => c)
+  c.innerJoin = vi.fn(() => c)
+  c.where     = vi.fn(() => c)
+  c.orderBy   = vi.fn(() => c)
+  c.limit     = vi.fn(() => Promise.resolve(rows))
+  return c
+}
+
+// ── Per-test state ────────────────────────────────────────────────────────────
+
+// Queue of result sets to return in order — one per tx.select() call.
+// searchGlobal calls Promise.all([...4 queries...]); each select() pop from the front.
+let selectQueue: unknown[][] = []
+let selectCallCount = 0
+
+vi.mock('@/db', () => ({
+  db: {},
+  withTenant: vi.fn().mockImplementation(
+    async (_tenantId: string, fn: (tx: unknown) => unknown) => {
+      const tx = {
+        select: vi.fn(() => {
+          const rows = selectQueue[selectCallCount] ?? []
+          selectCallCount++
+          return makeSelectChain(rows)
+        }),
+      }
+      return fn(tx)
+    }
+  ),
+}))
+
+vi.mock('@/db/schema', () => ({
+  candidates: {
+    id: 'id', firstName: 'first_name', lastName: 'last_name',
+    email: 'email', agencyId: 'agency_id', isActive: 'is_active',
+    createdAt: 'created_at',
+  },
+  roles: {
+    id: 'id', title: 'title', customerRoleId: 'customer_role_id',
+    customerId: 'customer_id', isActive: 'is_active', createdAt: 'created_at',
+  },
+  customers: {
+    id: 'id', name: 'name', isActive: 'is_active', createdAt: 'created_at',
+  },
+  agencies: {
+    id: 'id', name: 'name', isInternal: 'is_internal',
+    isActive: 'is_active', createdAt: 'created_at',
+  },
+}))
+
+vi.mock('drizzle-orm', () => ({
+  eq:    vi.fn(() => ({ type: 'eq' })),
+  and:   vi.fn((...args: unknown[]) => ({ type: 'and', args })),
+  or:    vi.fn((...args: unknown[]) => ({ type: 'or', args })),
+  ilike: vi.fn(() => ({ type: 'ilike' })),
+  desc:  vi.fn(() => ({ type: 'desc' })),
+}))
+
+const mockGetActionContext = vi.fn()
+vi.mock('@/lib/auth/action-context', () => ({
+  getActionContext: () => mockGetActionContext(),
+}))
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function recruiterCtx() {
+  return { tenantId: TENANT_ID, userId: USER_ID, userRole: 'recruiter' as const }
+}
+
+const EMPTY = { candidates: [], roles: [], customers: [], agencies: [] }
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('searchGlobal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    selectQueue = []
+    selectCallCount = 0
+    mockGetActionContext.mockResolvedValue(recruiterCtx())
+  })
+
+  // ── Auth + role degradation ───────────────────────────────────────────────
+
+  it('returns empty when unauthenticated (no context)', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { searchGlobal } = await import('@/actions/search')
+
+    const result = await searchGlobal('Jane')
+
+    expect(result).toEqual(EMPTY)
+  })
+
+  it('returns empty when role is viewer (below recruiter threshold)', async () => {
+    mockGetActionContext.mockResolvedValue({
+      tenantId: TENANT_ID, userId: USER_ID, userRole: 'viewer' as const,
+    })
+    const { searchGlobal } = await import('@/actions/search')
+
+    const result = await searchGlobal('Jane')
+
+    expect(result).toEqual(EMPTY)
+  })
+
+  it('returns empty when role is hiring_manager (below recruiter threshold)', async () => {
+    mockGetActionContext.mockResolvedValue({
+      tenantId: TENANT_ID, userId: USER_ID, userRole: 'hiring_manager' as const,
+    })
+    const { searchGlobal } = await import('@/actions/search')
+
+    const result = await searchGlobal('Jane')
+
+    expect(result).toEqual(EMPTY)
+  })
+
+  // ── Short query guard ─────────────────────────────────────────────────────
+
+  it('returns empty for empty string (< 2 chars)', async () => {
+    const { searchGlobal } = await import('@/actions/search')
+
+    const result = await searchGlobal('')
+
+    expect(result).toEqual(EMPTY)
+  })
+
+  it('returns empty for single-character query', async () => {
+    const { searchGlobal } = await import('@/actions/search')
+
+    const result = await searchGlobal('J')
+
+    expect(result).toEqual(EMPTY)
+  })
+
+  it('returns empty for whitespace-only query that trims to < 2 chars', async () => {
+    const { searchGlobal } = await import('@/actions/search')
+
+    const result = await searchGlobal('  ')
+
+    expect(result).toEqual(EMPTY)
+  })
+
+  // ── No-results case ───────────────────────────────────────────────────────
+
+  it('returns all-empty arrays when no DB rows match', async () => {
+    // All four select() calls return []
+    selectQueue = [[], [], [], []]
+    const { searchGlobal } = await import('@/actions/search')
+
+    const result = await searchGlobal('xyz-no-match')
+
+    expect(result).toEqual(EMPTY)
+  })
+
+  // ── Happy path ────────────────────────────────────────────────────────────
+
+  it('returns candidate, role, customer, agency hits with correct kind tags', async () => {
+    selectQueue = [CANDIDATE_ROWS, ROLE_ROWS, CUSTOMER_ROWS, AGENCY_ROWS]
+    const { searchGlobal } = await import('@/actions/search')
+
+    const result = await searchGlobal('Jane')
+
+    // Candidates
+    expect(result.candidates).toHaveLength(1)
+    expect(result.candidates[0]).toMatchObject({
+      kind: 'candidate',
+      id: 'c1',
+      firstName: 'Jane',
+      lastName: 'Doe',
+      email: 'jane@example.com',
+      agencyName: 'Acme Staffing',
+    })
+
+    // Roles
+    expect(result.roles).toHaveLength(1)
+    expect(result.roles[0]).toMatchObject({
+      kind: 'role',
+      id: 'r1',
+      title: 'Senior TypeScript Engineer',
+      customerName: 'ClientCo',
+      customerRoleId: 'ENG-001',
+    })
+
+    // Customers
+    expect(result.customers).toHaveLength(1)
+    expect(result.customers[0]).toMatchObject({
+      kind: 'customer',
+      id: 'cu1',
+      name: 'ClientCo Ltd',
+    })
+
+    // Agencies
+    expect(result.agencies).toHaveLength(1)
+    expect(result.agencies[0]).toMatchObject({
+      kind: 'agency',
+      id: 'ag1',
+      name: 'Acme Staffing',
+      isInternal: false,
+    })
+  })
+
+  it('coerces null agencyName to null in candidate hit', async () => {
+    selectQueue = [
+      [{ id: 'c2', firstName: 'Bob', lastName: 'Smith', email: null, agencyName: undefined }],
+      [], [], [],
+    ]
+    const { searchGlobal } = await import('@/actions/search')
+
+    const result = await searchGlobal('Bob')
+
+    expect(result.candidates[0].agencyName).toBeNull()
+    expect(result.candidates[0].email).toBeNull()
+  })
+
+  it('succeeds for admin role', async () => {
+    selectQueue = [[], [], [], []]
+    mockGetActionContext.mockResolvedValue({
+      tenantId: TENANT_ID, userId: USER_ID, userRole: 'admin' as const,
+    })
+    const { searchGlobal } = await import('@/actions/search')
+
+    const result = await searchGlobal('query')
+
+    expect(result).toEqual(EMPTY)
+  })
+
+  it('accepts exactly 2-character query (boundary)', async () => {
+    selectQueue = [[], [], [], []]
+    const { searchGlobal } = await import('@/actions/search')
+
+    const result = await searchGlobal('Jo')
+
+    expect(result).toEqual(EMPTY)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds 82 unit tests across 4 server-action surfaces (Group D of 4), following the mock-heavy pattern from `scores/candidates/enrichment.test.ts`
- No changes to any action source files — tests only
- All 82 new tests pass; 2 pre-existing failing files (`calendar.test.ts`, `interview.test.ts`) are unchanged (11 failures pre-date this branch)

## Test counts

| File | Tests | Suites |
|---|---|---|
| `tests/unit/actions/search.test.ts` | 11 | 1 (`searchGlobal`) |
| `tests/unit/actions/matching.test.ts` | 14 | 2 (`getSuggestedCandidates`, `getRoleFitSuggestionsForCandidate`) |
| `tests/unit/actions/frameworks.test.ts` | 16 | 3 (`saveCustomerFramework`, `deleteCustomerFramework`, `getCustomerFramework`) |
| `tests/unit/actions/role-submissions.test.ts` | 41 | 7 (`submitCandidatesToCustomer`, `updateSubmissionStatus`, `removeSubmission`, `generateShareToken`, `revokeShareToken`, `updateSubmissionStatusByToken`, `getSubmissionByToken`) |
| **Total** | **82** | |

## Skipped scenarios and reasons

| Scenario | Reason |
|---|---|
| `searchGlobal` pagination / LIMIT enforcement | `withTenant` mock returns all fixture rows; LIMIT is SQL-side and would require a full DB to verify |
| `getSuggestedCandidates` exclude-already-scored path assertion | The `excludeIds` array is threaded into a raw `sql\`...\`` template; the mock captures execute without inspecting the SQL string |
| `getRecentSubmissionsForTenant` | Read-only loader with no auth gate or mutations — straightforward query chain; considered low risk vs the mutations/sharing tested instead |
| `getAllSubmissionsForTenant` | Large filter-builder with 7 optional conditions; the pattern is identical to the candidate-list filter builder already covered in `candidates.test.ts` |
| `getSubmissionsForRole` | Read-only auth-context loader with no mutations; lower risk than public/sharing paths |
| `updateSubmissionStatusByToken` email notification | `notifyRecruiterOfCustomerUpdate` is fire-and-forget (`.catch()` swallowed); assertion would require introspecting implementation details |

## Test plan

- [x] `npm test` (inside Docker container) green for all 4 new files: `82 passed`
- [x] `npx tsc --noEmit` produces zero errors in new test files
- [x] Pre-existing failures in `calendar.test.ts` / `interview.test.ts` (11 tests) confirmed unchanged — present on `core-mvp-foundation` before this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)