### PR TITLE
test(actions): add coverage for interview, transcripts, notes

### DIFF
--- a/tests/unit/actions/interview.test.ts
+++ b/tests/unit/actions/interview.test.ts
@@ -1,0 +1,416 @@
+/**
+ * Unit tests for src/actions/interview.ts
+ *
+ * Covers:
+ *   createInterviewPack  — auth gate, role gate (viewer/hiring_manager blocked),
+ *                          validation (invalid UUID), candidate-not-found, happy path
+ *                          (pack row inserted, packId returned).
+ *   retryInterviewPack   — auth gate, pack-not-found, pack-already-complete guard,
+ *                          happy path (status reset to pending).
+ *   deleteInterviewPack  — auth gate, pack-not-found, happy path (row deleted).
+ *   updateQuestionNotes  — auth gate, question-not-found, happy path (notes updated).
+ *
+ * Mocks:
+ *   @/db                          — withTenant
+ *   @/db/schema                   — candidates, interviewPacks, interviewQuestions stubs
+ *   drizzle-orm                   — eq / and pass-throughs
+ *   @/lib/auth/action-context     — getActionContext
+ *   @/lib/ai/interview-helpers    — inferExperienceLevel (returns 'mid')
+ *   next/cache                    — revalidatePath silenced
+ *
+ * Note: requireRole is NOT mocked — the real implementation is a pure function
+ * with no I/O dependencies and its behaviour is load-bearing for the role-gate tests.
+ *
+ * Note: @/lib/ai/language is NOT mocked. The real SUPPORTED_LANGUAGES contains
+ * 'en' which is used in all FormData fixtures, so no mock is necessary.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+// UUIDs: v4 requires the variant nibble (first nibble of the 4th group) to be
+// 8, 9, a, or b. All constants below satisfy this constraint.
+const TENANT_ID    = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const CANDIDATE_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const ROLE_ID      = '11111111-1111-4111-8111-111111111111'
+const PACK_ID      = '22222222-2222-4222-8222-222222222222'
+const QUESTION_ID  = '33333333-3333-4333-8333-333333333333'
+const USER_ID      = '44444444-4444-4444-8444-444444444444'
+
+// ── Chainable mock builder ────────────────────────────────────────────────────
+
+function makeSelectChain(rows: unknown[]) {
+  const c: Record<string, unknown> = {}
+  const resolved = Promise.resolve(rows)
+  c.then      = resolved.then.bind(resolved)
+  c.catch     = resolved.catch.bind(resolved)
+  c.from      = vi.fn(() => c)
+  c.where     = vi.fn(() => c)
+  c.limit     = vi.fn(() => Promise.resolve(rows))
+  c.innerJoin = vi.fn(() => c)
+  return c
+}
+
+// ── Per-test state ────────────────────────────────────────────────────────────
+
+// Controls what withTenant select calls return.
+// Many actions do a single select; selectQueue lets tests push multiple rows
+// in sequence for actions that call select more than once.
+type SelectFactory = () => ReturnType<typeof makeSelectChain>
+let selectFactory: SelectFactory
+
+const mockInsertValues = vi.fn()
+const mockUpdateSet    = vi.fn()
+const mockUpdateWhere  = vi.fn()
+const mockDeleteWhere  = vi.fn()
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('@/db', () => ({
+  withTenant: vi.fn().mockImplementation(
+    async (_tenantId: string, fn: (tx: unknown) => unknown) => {
+      const tx = {
+        select: vi.fn(() => selectFactory()),
+
+        insert: vi.fn(() => ({
+          values: (...args: unknown[]) => {
+            mockInsertValues(...args)
+            return Promise.resolve()
+          },
+        })),
+
+        update: vi.fn(() => ({
+          set: (...args: unknown[]) => {
+            mockUpdateSet(...args)
+            return {
+              where: (...wargs: unknown[]) => {
+                mockUpdateWhere(...wargs)
+                return Promise.resolve()
+              },
+            }
+          },
+        })),
+
+        delete: vi.fn(() => ({
+          where: (...wargs: unknown[]) => {
+            mockDeleteWhere(...wargs)
+            return Promise.resolve()
+          },
+        })),
+      }
+      return fn(tx)
+    }
+  ),
+}))
+
+vi.mock('@/db/schema', () => ({
+  candidates: {
+    id:          'id',
+    tenantId:    'tenant_id',
+    cvText:      'cv_text',
+  },
+  interviewPacks: {
+    id:               'id',
+    tenantId:         'tenant_id',
+    candidateId:      'candidate_id',
+    generationStatus: 'generation_status',
+    errorMessage:     'error_message',
+    updatedAt:        'updated_at',
+  },
+  interviewQuestions: {
+    id:      'id',
+    packId:  'pack_id',
+    notes:   'notes',
+  },
+}))
+
+vi.mock('drizzle-orm', () => ({
+  eq:  vi.fn(() => ({ type: 'eq' })),
+  and: vi.fn((...args: unknown[]) => ({ type: 'and', args })),
+}))
+
+const mockGetActionContext = vi.fn()
+vi.mock('@/lib/auth/action-context', () => ({
+  getActionContext: () => mockGetActionContext(),
+}))
+
+vi.mock('@/lib/ai/interview-helpers', () => ({
+  inferExperienceLevel: vi.fn().mockReturnValue('mid'),
+}))
+
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function recruiterCtx() {
+  return { tenantId: TENANT_ID, userId: USER_ID, userRole: 'recruiter' as const }
+}
+
+function viewerCtx() {
+  return { tenantId: TENANT_ID, userId: USER_ID, userRole: 'viewer' as const }
+}
+
+function hiringManagerCtx() {
+  return { tenantId: TENANT_ID, userId: USER_ID, userRole: 'hiring_manager' as const }
+}
+
+/** Minimal valid FormData for createInterviewPack */
+function basePackFormData(overrides: Record<string, string> = {}): FormData {
+  const fd = new FormData()
+  fd.set('candidateId', CANDIDATE_ID)
+  fd.set('roleId', ROLE_ID)
+  fd.set('packType', 'full')
+  fd.set('language', 'en')
+  for (const [k, v] of Object.entries(overrides)) fd.set(k, v)
+  return fd
+}
+
+/** A minimal candidate row */
+function candidateRow() {
+  return { id: CANDIDATE_ID, cvText: 'Senior TypeScript engineer with 8 years experience.' }
+}
+
+/** A minimal pack row that is still pending */
+function pendingPackRow() {
+  return { id: PACK_ID, candidateId: CANDIDATE_ID, generationStatus: 'pending' }
+}
+
+/** A pack row that has completed generation */
+function completedPackRow() {
+  return { id: PACK_ID, candidateId: CANDIDATE_ID, generationStatus: 'complete' }
+}
+
+/** A question row linked to PACK_ID */
+function questionRow() {
+  return { id: QUESTION_ID, packId: PACK_ID }
+}
+
+// ── createInterviewPack ───────────────────────────────────────────────────────
+
+describe('createInterviewPack', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetActionContext.mockResolvedValue(recruiterCtx())
+    // Default: candidate exists
+    selectFactory = () => makeSelectChain([candidateRow()])
+  })
+
+  it('returns Unauthorized when no action context', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { createInterviewPack } = await import('@/actions/interview')
+
+    const result = await createInterviewPack(null, basePackFormData())
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/unauthorized/i)
+  })
+
+  it('returns Forbidden when role is viewer', async () => {
+    mockGetActionContext.mockResolvedValue(viewerCtx())
+    const { createInterviewPack } = await import('@/actions/interview')
+
+    const result = await createInterviewPack(null, basePackFormData())
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/forbidden/i)
+  })
+
+  it('returns Forbidden when role is hiring_manager (rank 0.5 < recruiter rank 1)', async () => {
+    mockGetActionContext.mockResolvedValue(hiringManagerCtx())
+    const { createInterviewPack } = await import('@/actions/interview')
+
+    const result = await createInterviewPack(null, basePackFormData())
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/forbidden/i)
+  })
+
+  it('returns Invalid input when candidateId is not a valid UUID', async () => {
+    const { createInterviewPack } = await import('@/actions/interview')
+    const fd = basePackFormData({ candidateId: 'not-a-uuid' })
+
+    const result = await createInterviewPack(null, fd)
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/invalid input/i)
+    expect(mockInsertValues).not.toHaveBeenCalled()
+  })
+
+  it('returns Candidate not found when select returns no rows', async () => {
+    selectFactory = () => makeSelectChain([]) // no candidate
+    const { createInterviewPack } = await import('@/actions/interview')
+
+    const result = await createInterviewPack(null, basePackFormData())
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/candidate not found/i)
+    expect(mockInsertValues).not.toHaveBeenCalled()
+  })
+
+  it('inserts pack row with correct fields and returns packId on happy path', async () => {
+    const { createInterviewPack } = await import('@/actions/interview')
+
+    const result = await createInterviewPack(null, basePackFormData())
+
+    expect(result.success).toBe(true)
+    const packId = (result as { success: true; packId: string }).packId
+    expect(packId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)
+
+    expect(mockInsertValues).toHaveBeenCalledTimes(1)
+    const arg = mockInsertValues.mock.calls[0][0] as Record<string, unknown>
+    expect(arg.tenantId).toBe(TENANT_ID)
+    expect(arg.candidateId).toBe(CANDIDATE_ID)
+    expect(arg.roleId).toBe(ROLE_ID)
+    expect(arg.generationStatus).toBe('pending')
+    expect(arg.packType).toBe('full')
+    expect(arg.language).toBe('en')
+    expect(arg.createdBy).toBe(USER_ID)
+  })
+
+  it('forces includesCodeChallenge=false when packType is pre_screening', async () => {
+    const { createInterviewPack } = await import('@/actions/interview')
+    const fd = basePackFormData({ packType: 'pre_screening', includeCodeChallenge: 'true' })
+
+    await createInterviewPack(null, fd)
+
+    const arg = mockInsertValues.mock.calls[0][0] as Record<string, unknown>
+    expect(arg.includesCodeChallenge).toBe(false)
+  })
+})
+
+// ── retryInterviewPack ────────────────────────────────────────────────────────
+
+describe('retryInterviewPack', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetActionContext.mockResolvedValue(recruiterCtx())
+    selectFactory = () => makeSelectChain([pendingPackRow()])
+  })
+
+  it('returns Unauthorized when no action context', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { retryInterviewPack } = await import('@/actions/interview')
+
+    const result = await retryInterviewPack(PACK_ID)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/unauthorized/i)
+  })
+
+  it('returns Pack not found when select returns no rows', async () => {
+    selectFactory = () => makeSelectChain([])
+    const { retryInterviewPack } = await import('@/actions/interview')
+
+    const result = await retryInterviewPack(PACK_ID)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/not found/i)
+    expect(mockUpdateSet).not.toHaveBeenCalled()
+  })
+
+  it('returns error when pack is already complete', async () => {
+    selectFactory = () => makeSelectChain([completedPackRow()])
+    const { retryInterviewPack } = await import('@/actions/interview')
+
+    const result = await retryInterviewPack(PACK_ID)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/already complete/i)
+    expect(mockUpdateSet).not.toHaveBeenCalled()
+  })
+
+  it('resets generationStatus to pending on happy path', async () => {
+    const { retryInterviewPack } = await import('@/actions/interview')
+
+    const result = await retryInterviewPack(PACK_ID)
+
+    expect(result.success).toBe(true)
+    expect(mockUpdateSet).toHaveBeenCalledTimes(1)
+    const arg = mockUpdateSet.mock.calls[0][0] as Record<string, unknown>
+    expect(arg.generationStatus).toBe('pending')
+    expect(arg.errorMessage).toBeNull()
+  })
+})
+
+// ── deleteInterviewPack ───────────────────────────────────────────────────────
+
+describe('deleteInterviewPack', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetActionContext.mockResolvedValue(recruiterCtx())
+    selectFactory = () => makeSelectChain([{ candidateId: CANDIDATE_ID }])
+  })
+
+  it('returns Unauthorized when no action context', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { deleteInterviewPack } = await import('@/actions/interview')
+
+    const result = await deleteInterviewPack(PACK_ID)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/unauthorized/i)
+  })
+
+  it('returns Pack not found when select returns no rows', async () => {
+    selectFactory = () => makeSelectChain([])
+    const { deleteInterviewPack } = await import('@/actions/interview')
+
+    const result = await deleteInterviewPack(PACK_ID)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/not found/i)
+    expect(mockDeleteWhere).not.toHaveBeenCalled()
+  })
+
+  it('deletes pack row and returns success:true on happy path', async () => {
+    const { deleteInterviewPack } = await import('@/actions/interview')
+
+    const result = await deleteInterviewPack(PACK_ID)
+
+    expect(result.success).toBe(true)
+    expect(mockDeleteWhere).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ── updateQuestionNotes ───────────────────────────────────────────────────────
+
+describe('updateQuestionNotes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetActionContext.mockResolvedValue(recruiterCtx())
+    selectFactory = () => makeSelectChain([questionRow()])
+  })
+
+  it('returns Unauthorized when no action context', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { updateQuestionNotes } = await import('@/actions/interview')
+
+    const result = await updateQuestionNotes(QUESTION_ID, 'my notes')
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/unauthorized/i)
+  })
+
+  it('returns Question not found when select returns no rows', async () => {
+    selectFactory = () => makeSelectChain([])
+    const { updateQuestionNotes } = await import('@/actions/interview')
+
+    const result = await updateQuestionNotes(QUESTION_ID, 'my notes')
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/not found/i)
+    expect(mockUpdateSet).not.toHaveBeenCalled()
+  })
+
+  it('updates notes field and returns success:true on happy path', async () => {
+    const { updateQuestionNotes } = await import('@/actions/interview')
+
+    const result = await updateQuestionNotes(QUESTION_ID, 'candidate answered well')
+
+    expect(result.success).toBe(true)
+    expect(mockUpdateSet).toHaveBeenCalledTimes(1)
+    const arg = mockUpdateSet.mock.calls[0][0] as Record<string, unknown>
+    expect(arg.notes).toBe('candidate answered well')
+  })
+})

--- a/tests/unit/actions/notes.test.ts
+++ b/tests/unit/actions/notes.test.ts
@@ -1,0 +1,383 @@
+/**
+ * Unit tests for src/actions/notes.ts
+ *
+ * Covers:
+ *   createNote  — happy path, auth gate, role gate (viewer forbidden), body
+ *                 validation (empty / too long), is_shareable flag persisted.
+ *   updateNote  — happy path, auth gate, note-not-found, ownership guard
+ *                 (non-author + non-admin blocked), is_shareable toggled.
+ *   deleteNote  — happy path, auth gate, note-not-found, ownership guard.
+ *
+ * Mocks:
+ *   @/db                          — withTenant
+ *   @/db/schema                   — notes table stub
+ *   drizzle-orm                   — eq / and pass-throughs
+ *   @/lib/auth/action-context     — getActionContext
+ *   next/cache                    — revalidatePath silenced
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const TENANT_ID    = 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa'
+const CANDIDATE_ID = 'bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb'
+const NOTE_ID      = 'cccccccc-cccc-4ccc-cccc-cccccccccccc'
+const USER_ID      = 'dddddddd-dddd-4ddd-dddd-dddddddddddd'
+const OTHER_USER   = 'eeeeeeee-eeee-4eee-eeee-eeeeeeeeeeee'
+
+// ── Chainable mock builder ────────────────────────────────────────────────────
+
+function makeSelectChain(rows: unknown[]) {
+  const c: Record<string, unknown> = {}
+  const resolved = Promise.resolve(rows)
+  c.then   = resolved.then.bind(resolved)
+  c.catch  = resolved.catch.bind(resolved)
+  c.from   = vi.fn(() => c)
+  c.where  = vi.fn(() => c)
+  c.limit  = vi.fn(() => Promise.resolve(rows))
+  return c
+}
+
+// ── Per-test state ────────────────────────────────────────────────────────────
+
+// selectRows drives what withTenant select calls return (used by updateNote /
+// deleteNote to simulate "note exists" / "note not found").
+let selectRows: unknown[] = []
+
+const mockInsertValues = vi.fn()
+const mockUpdateSet    = vi.fn()
+const mockUpdateWhere  = vi.fn()
+const mockDeleteWhere  = vi.fn()
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('@/db', () => ({
+  withTenant: vi.fn().mockImplementation(
+    async (_tenantId: string, fn: (tx: unknown) => unknown) => {
+      const tx = {
+        select: vi.fn(() => makeSelectChain(selectRows)),
+
+        insert: vi.fn(() => ({
+          values: (...args: unknown[]) => {
+            mockInsertValues(...args)
+            return Promise.resolve()
+          },
+        })),
+
+        update: vi.fn(() => ({
+          set: (...args: unknown[]) => {
+            mockUpdateSet(...args)
+            return {
+              where: (...wargs: unknown[]) => {
+                mockUpdateWhere(...wargs)
+                return Promise.resolve()
+              },
+            }
+          },
+        })),
+
+        delete: vi.fn(() => ({
+          where: (...wargs: unknown[]) => {
+            mockDeleteWhere(...wargs)
+            return Promise.resolve()
+          },
+        })),
+      }
+      return fn(tx)
+    }
+  ),
+}))
+
+vi.mock('@/db/schema', () => ({
+  notes: {
+    id:          'id',
+    tenantId:    'tenant_id',
+    candidateId: 'candidate_id',
+    authorId:    'author_id',
+    body:        'body',
+    isShareable: 'is_shareable',
+  },
+}))
+
+vi.mock('drizzle-orm', () => ({
+  eq:  vi.fn(() => ({ type: 'eq' })),
+  and: vi.fn((...args: unknown[]) => ({ type: 'and', args })),
+}))
+
+const mockGetActionContext = vi.fn()
+vi.mock('@/lib/auth/action-context', () => ({
+  getActionContext: () => mockGetActionContext(),
+}))
+
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function recruiterCtx(userId = USER_ID) {
+  return { tenantId: TENANT_ID, userId, userRole: 'recruiter' as const }
+}
+
+function adminCtx(userId = USER_ID) {
+  return { tenantId: TENANT_ID, userId, userRole: 'admin' as const }
+}
+
+function viewerCtx() {
+  return { tenantId: TENANT_ID, userId: USER_ID, userRole: 'viewer' as const }
+}
+
+function hiringManagerCtx() {
+  return { tenantId: TENANT_ID, userId: USER_ID, userRole: 'hiring_manager' as const }
+}
+
+/** A note row owned by USER_ID */
+function ownedNote() {
+  return { id: NOTE_ID, authorId: USER_ID, tenantId: TENANT_ID }
+}
+
+/** A note row owned by a different user */
+function foreignNote() {
+  return { id: NOTE_ID, authorId: OTHER_USER, tenantId: TENANT_ID }
+}
+
+// ── createNote ────────────────────────────────────────────────────────────────
+
+describe('createNote', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    selectRows = []
+    mockGetActionContext.mockResolvedValue(recruiterCtx())
+  })
+
+  it('returns Unauthorized when no action context', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { createNote } = await import('@/actions/notes')
+
+    const result = await createNote(CANDIDATE_ID, 'A good note')
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/unauthorized/i)
+  })
+
+  it('returns Forbidden when role is viewer', async () => {
+    mockGetActionContext.mockResolvedValue(viewerCtx())
+    const { createNote } = await import('@/actions/notes')
+
+    const result = await createNote(CANDIDATE_ID, 'A good note')
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/forbidden/i)
+  })
+
+  it('returns error when body is empty', async () => {
+    const { createNote } = await import('@/actions/notes')
+
+    const result = await createNote(CANDIDATE_ID, '')
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/note cannot be empty/i)
+    expect(mockInsertValues).not.toHaveBeenCalled()
+  })
+
+  it('returns error when body exceeds 5000 chars', async () => {
+    const { createNote } = await import('@/actions/notes')
+
+    const result = await createNote(CANDIDATE_ID, 'x'.repeat(5001))
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/too long/i)
+    expect(mockInsertValues).not.toHaveBeenCalled()
+  })
+
+  it('inserts note with correct tenant + author + body on happy path', async () => {
+    const { createNote } = await import('@/actions/notes')
+
+    const result = await createNote(CANDIDATE_ID, 'Excellent communication skills')
+
+    expect(result.success).toBe(true)
+    expect(mockInsertValues).toHaveBeenCalledTimes(1)
+    const arg = mockInsertValues.mock.calls[0][0] as Record<string, unknown>
+    expect(arg.tenantId).toBe(TENANT_ID)
+    expect(arg.candidateId).toBe(CANDIDATE_ID)
+    expect(arg.authorId).toBe(USER_ID)
+    expect(arg.body).toBe('Excellent communication skills')
+  })
+
+  it('persists isShareable=true when caller passes true', async () => {
+    const { createNote } = await import('@/actions/notes')
+
+    await createNote(CANDIDATE_ID, 'Shareable note for HM', true)
+
+    const arg = mockInsertValues.mock.calls[0][0] as Record<string, unknown>
+    expect(arg.isShareable).toBe(true)
+  })
+
+  it('defaults isShareable=false when not provided', async () => {
+    const { createNote } = await import('@/actions/notes')
+
+    await createNote(CANDIDATE_ID, 'Private note')
+
+    const arg = mockInsertValues.mock.calls[0][0] as Record<string, unknown>
+    expect(arg.isShareable).toBe(false)
+  })
+
+  it('allows hiring_manager role to create notes (rank >= viewer, blocked only for viewer)', async () => {
+    // hiring_manager (rank 0.5) is not viewer (rank 0) so must be allowed.
+    mockGetActionContext.mockResolvedValue(hiringManagerCtx())
+    const { createNote } = await import('@/actions/notes')
+
+    const result = await createNote(CANDIDATE_ID, 'Manager note')
+
+    // The action only blocks role === 'viewer', hiring_manager should succeed.
+    expect(result.success).toBe(true)
+  })
+})
+
+// ── updateNote ────────────────────────────────────────────────────────────────
+
+describe('updateNote', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    selectRows = [ownedNote()]
+    mockGetActionContext.mockResolvedValue(recruiterCtx())
+  })
+
+  it('returns Unauthorized when no action context', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { updateNote } = await import('@/actions/notes')
+
+    const result = await updateNote(NOTE_ID, CANDIDATE_ID, 'updated body')
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/unauthorized/i)
+  })
+
+  it('returns Forbidden when role is viewer', async () => {
+    mockGetActionContext.mockResolvedValue(viewerCtx())
+    const { updateNote } = await import('@/actions/notes')
+
+    const result = await updateNote(NOTE_ID, CANDIDATE_ID, 'updated body')
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/forbidden/i)
+  })
+
+  it('returns error when note is not found (no DB row)', async () => {
+    selectRows = [] // no note in tenant
+    const { updateNote } = await import('@/actions/notes')
+
+    const result = await updateNote(NOTE_ID, CANDIDATE_ID, 'updated body')
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/not found/i)
+    expect(mockUpdateSet).not.toHaveBeenCalled()
+  })
+
+  it('returns error when body is empty', async () => {
+    const { updateNote } = await import('@/actions/notes')
+
+    const result = await updateNote(NOTE_ID, CANDIDATE_ID, '')
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/note cannot be empty/i)
+    expect(mockUpdateSet).not.toHaveBeenCalled()
+  })
+
+  it('returns Forbidden when non-author non-admin tries to update', async () => {
+    // The stored note is owned by OTHER_USER, requester is USER_ID (recruiter, not admin)
+    selectRows = [foreignNote()]
+    const { updateNote } = await import('@/actions/notes')
+
+    const result = await updateNote(NOTE_ID, CANDIDATE_ID, 'sneaky edit')
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/forbidden/i)
+    expect(mockUpdateSet).not.toHaveBeenCalled()
+  })
+
+  it('allows admin to update another user\'s note', async () => {
+    selectRows = [foreignNote()] // owned by OTHER_USER, but caller is admin
+    mockGetActionContext.mockResolvedValue(adminCtx())
+    const { updateNote } = await import('@/actions/notes')
+
+    const result = await updateNote(NOTE_ID, CANDIDATE_ID, 'admin edit')
+
+    expect(result.success).toBe(true)
+    expect(mockUpdateSet).toHaveBeenCalledTimes(1)
+  })
+
+  it('updates body and isShareable on happy path (author editing own note)', async () => {
+    const { updateNote } = await import('@/actions/notes')
+
+    const result = await updateNote(NOTE_ID, CANDIDATE_ID, 'new body text', true)
+
+    expect(result.success).toBe(true)
+    expect(mockUpdateSet).toHaveBeenCalledTimes(1)
+    const setArg = mockUpdateSet.mock.calls[0][0] as Record<string, unknown>
+    expect(setArg.body).toBe('new body text')
+    expect(setArg.isShareable).toBe(true)
+    expect(setArg.isEdited).toBe(true)
+  })
+})
+
+// ── deleteNote ────────────────────────────────────────────────────────────────
+
+describe('deleteNote', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    selectRows = [ownedNote()]
+    mockGetActionContext.mockResolvedValue(recruiterCtx())
+  })
+
+  it('returns Unauthorized when no action context', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { deleteNote } = await import('@/actions/notes')
+
+    const result = await deleteNote(NOTE_ID, CANDIDATE_ID)
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/unauthorized/i)
+  })
+
+  it('returns error when note is not found', async () => {
+    selectRows = []
+    const { deleteNote } = await import('@/actions/notes')
+
+    const result = await deleteNote(NOTE_ID, CANDIDATE_ID)
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/not found/i)
+    expect(mockDeleteWhere).not.toHaveBeenCalled()
+  })
+
+  it('returns Forbidden when non-author non-admin tries to delete', async () => {
+    selectRows = [foreignNote()]
+    const { deleteNote } = await import('@/actions/notes')
+
+    const result = await deleteNote(NOTE_ID, CANDIDATE_ID)
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/forbidden/i)
+    expect(mockDeleteWhere).not.toHaveBeenCalled()
+  })
+
+  it('deletes the note when called by the author', async () => {
+    const { deleteNote } = await import('@/actions/notes')
+
+    const result = await deleteNote(NOTE_ID, CANDIDATE_ID)
+
+    expect(result.success).toBe(true)
+    expect(mockDeleteWhere).toHaveBeenCalledTimes(1)
+  })
+
+  it('allows admin to delete another user\'s note', async () => {
+    selectRows = [foreignNote()]
+    mockGetActionContext.mockResolvedValue(adminCtx())
+    const { deleteNote } = await import('@/actions/notes')
+
+    const result = await deleteNote(NOTE_ID, CANDIDATE_ID)
+
+    expect(result.success).toBe(true)
+    expect(mockDeleteWhere).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/unit/actions/transcripts.test.ts
+++ b/tests/unit/actions/transcripts.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Unit tests for src/actions/transcripts.ts
+ *
+ * Covers:
+ *   uploadTranscript — auth gate, role gate (viewer blocked), required-field
+ *     validation (missing candidateId/roleId), no content guard (no file + no
+ *     paste), file-too-large guard, parse error surfaced, invalid interviewDate,
+ *     happy path with pasted text (DB insert + triggerTranscriptAnalysis called),
+ *     happy path with file upload (transcriptId returned).
+ *
+ * Mocks:
+ *   @/db                                  — withTenant (returns transcript row on insert.returning)
+ *   @/db/schema                           — interviewTranscripts stub
+ *   drizzle-orm                           — eq pass-through (unused path, for completeness)
+ *   @/lib/auth/action-context             — getActionContext
+ *   @/lib/parsers/transcript              — parseTranscriptFile, sanitizeText, sanitizeCues
+ *   @/lib/ai/transcript-analysis         — triggerTranscriptAnalysis
+ *   next/server                           — after fires callback synchronously
+ *
+ * Note: requireRole is NOT mocked — the real pure implementation is used so that
+ * role-gate tests exercise the actual rank comparison.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const TENANT_ID     = 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa'
+const CANDIDATE_ID  = 'bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb'
+const ROLE_ID       = 'cccccccc-cccc-4ccc-cccc-cccccccccccc'
+const TRANSCRIPT_ID = 'dddddddd-dddd-4ddd-dddd-dddddddddddd'
+const USER_ID       = 'eeeeeeee-eeee-4eee-eeee-eeeeeeeeeeee'
+
+// ── Per-test state ────────────────────────────────────────────────────────────
+
+const mockInsertValues  = vi.fn()
+const mockReturning     = vi.fn()
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('@/db', () => ({
+  withTenant: vi.fn().mockImplementation(
+    async (_tenantId: string, fn: (tx: unknown) => unknown) => {
+      const tx = {
+        insert: vi.fn(() => ({
+          values: (...args: unknown[]) => {
+            mockInsertValues(...args)
+            return {
+              returning: (...rargs: unknown[]) => {
+                mockReturning(...rargs)
+                return Promise.resolve([{ id: TRANSCRIPT_ID }])
+              },
+            }
+          },
+        })),
+      }
+      return fn(tx)
+    }
+  ),
+}))
+
+vi.mock('@/db/schema', () => ({
+  interviewTranscripts: {
+    id:        'id',
+    tenantId:  'tenant_id',
+  },
+}))
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn(() => ({ type: 'eq' })),
+}))
+
+const mockGetActionContext = vi.fn()
+vi.mock('@/lib/auth/action-context', () => ({
+  getActionContext: () => mockGetActionContext(),
+}))
+
+const mockParseTranscriptFile = vi.fn()
+const mockSanitizeText        = vi.fn((t: string) => t)
+const mockSanitizeCues        = vi.fn((c: unknown[]) => c)
+
+vi.mock('@/lib/parsers/transcript', () => ({
+  parseTranscriptFile: (...args: unknown[]) => mockParseTranscriptFile(...args),
+  sanitizeText:        (t: string)          => mockSanitizeText(t),
+  sanitizeCues:        (c: unknown[])       => mockSanitizeCues(c),
+  // TranscriptParseError is used by the action only for instanceof checks;
+  // since we throw plain Error in tests, this is sufficient.
+  TranscriptParseError: class TranscriptParseError extends Error {
+    constructor(msg: string) { super(msg); this.name = 'TranscriptParseError' }
+  },
+}))
+
+const mockTriggerTranscriptAnalysis = vi.fn().mockResolvedValue(undefined)
+vi.mock('@/lib/ai/transcript-analysis', () => ({
+  triggerTranscriptAnalysis: (...args: unknown[]) => mockTriggerTranscriptAnalysis(...args),
+}))
+
+// after() fires the callback synchronously so we can assert on side effects
+vi.mock('next/server', () => ({
+  after: vi.fn((fn: () => void) => {
+    try { fn() } catch {}
+  }),
+}))
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function recruiterCtx() {
+  return { tenantId: TENANT_ID, userId: USER_ID, userRole: 'recruiter' as const }
+}
+
+function viewerCtx() {
+  return { tenantId: TENANT_ID, userId: USER_ID, userRole: 'viewer' as const }
+}
+
+/** Default parse result for happy-path tests */
+function successfulParseResult() {
+  return {
+    rawText: 'Interviewer: Tell me about yourself.\nCandidate: Sure.',
+    cues: [
+      { speaker: 'Interviewer', timestamp: 0, text: 'Tell me about yourself.' },
+      { speaker: 'Candidate',   timestamp: 5000, text: 'Sure.' },
+    ],
+  }
+}
+
+/** Minimal valid FormData for uploadTranscript using paste */
+function pasteFormData(overrides: Record<string, string> = {}): FormData {
+  const fd = new FormData()
+  fd.set('candidateId', CANDIDATE_ID)
+  fd.set('roleId', ROLE_ID)
+  fd.set('text', 'Candidate: Hello.\nInterviewer: Hi.')
+  for (const [k, v] of Object.entries(overrides)) fd.set(k, v)
+  return fd
+}
+
+/** Minimal valid FormData for uploadTranscript using a file */
+function fileFormData(file: File, overrides: Record<string, string> = {}): FormData {
+  const fd = new FormData()
+  fd.set('candidateId', CANDIDATE_ID)
+  fd.set('roleId', ROLE_ID)
+  fd.set('file', file)
+  for (const [k, v] of Object.entries(overrides)) fd.set(k, v)
+  return fd
+}
+
+function fakeTxtFile(content = 'Speaker: text', sizeOverride?: number) {
+  const body = sizeOverride ? 'x'.repeat(sizeOverride) : content
+  return new File([body], 'transcript.txt', { type: 'text/plain' })
+}
+
+// ── uploadTranscript ──────────────────────────────────────────────────────────
+
+describe('uploadTranscript', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetActionContext.mockResolvedValue(recruiterCtx())
+    mockParseTranscriptFile.mockResolvedValue(successfulParseResult())
+  })
+
+  // ── Auth checks ──────────────────────────────────────────────────────────────
+
+  it('returns Unauthorised when no action context', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { uploadTranscript } = await import('@/actions/transcripts')
+
+    const result = await uploadTranscript(null, pasteFormData())
+
+    expect(result.success).toBe(false)
+    // The action uses British spelling "Unauthorised"
+    expect((result as { success: false; error: string }).error).toMatch(/unauthori[sz]ed/i)
+  })
+
+  it('returns Insufficient permissions when role is viewer', async () => {
+    mockGetActionContext.mockResolvedValue(viewerCtx())
+    const { uploadTranscript } = await import('@/actions/transcripts')
+
+    const result = await uploadTranscript(null, pasteFormData())
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/insufficient permissions/i)
+  })
+
+  // ── Required-field validation ─────────────────────────────────────────────────
+
+  it('returns error when candidateId is missing', async () => {
+    const { uploadTranscript } = await import('@/actions/transcripts')
+    const fd = pasteFormData()
+    fd.delete('candidateId')
+
+    const result = await uploadTranscript(null, fd)
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/candidateid.*roleid/i)
+    expect(mockInsertValues).not.toHaveBeenCalled()
+  })
+
+  it('returns error when roleId is missing', async () => {
+    const { uploadTranscript } = await import('@/actions/transcripts')
+    const fd = pasteFormData()
+    fd.delete('roleId')
+
+    const result = await uploadTranscript(null, fd)
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/candidateid.*roleid/i)
+    expect(mockInsertValues).not.toHaveBeenCalled()
+  })
+
+  it('returns error when neither file nor pasted text is provided', async () => {
+    const { uploadTranscript } = await import('@/actions/transcripts')
+    const fd = new FormData()
+    fd.set('candidateId', CANDIDATE_ID)
+    fd.set('roleId', ROLE_ID)
+    // No file, no text
+
+    const result = await uploadTranscript(null, fd)
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/upload a file or paste/i)
+    expect(mockInsertValues).not.toHaveBeenCalled()
+  })
+
+  // ── File validation ───────────────────────────────────────────────────────────
+
+  it('returns error when file exceeds 5 MB', async () => {
+    const bigFile = fakeTxtFile('', 5 * 1024 * 1024 + 1)
+    const { uploadTranscript } = await import('@/actions/transcripts')
+
+    const result = await uploadTranscript(null, fileFormData(bigFile))
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/5 mb/i)
+    expect(mockInsertValues).not.toHaveBeenCalled()
+  })
+
+  // ── Parse error ───────────────────────────────────────────────────────────────
+
+  it('surfaces parse error message when parseTranscriptFile throws', async () => {
+    mockParseTranscriptFile.mockRejectedValue(new Error('Malformed VTT header'))
+    const { uploadTranscript } = await import('@/actions/transcripts')
+
+    const result = await uploadTranscript(null, pasteFormData())
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/failed to parse transcript/i)
+    expect((result as { success: false; error: string }).error).toContain('Malformed VTT header')
+    expect(mockInsertValues).not.toHaveBeenCalled()
+  })
+
+  // ── Date validation ───────────────────────────────────────────────────────────
+
+  it('returns error for invalid interviewDate format', async () => {
+    const { uploadTranscript } = await import('@/actions/transcripts')
+    const fd = pasteFormData({ interviewDate: 'not-a-date' })
+
+    const result = await uploadTranscript(null, fd)
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/invalid interviewdate/i)
+    expect(mockInsertValues).not.toHaveBeenCalled()
+  })
+
+  // ── Happy path: paste ─────────────────────────────────────────────────────────
+
+  it('inserts transcript row and returns transcriptId on paste happy path', async () => {
+    const { uploadTranscript } = await import('@/actions/transcripts')
+
+    const result = await uploadTranscript(null, pasteFormData())
+
+    expect(result.success).toBe(true)
+    expect((result as { success: true; transcriptId: string }).transcriptId).toBe(TRANSCRIPT_ID)
+
+    expect(mockInsertValues).toHaveBeenCalledTimes(1)
+    const arg = mockInsertValues.mock.calls[0][0] as Record<string, unknown>
+    expect(arg.tenantId).toBe(TENANT_ID)
+    expect(arg.candidateId).toBe(CANDIDATE_ID)
+    expect(arg.roleId).toBe(ROLE_ID)
+    expect(arg.analysisStatus).toBe('pending')
+    expect(arg.sourceFormat).toBe('paste')
+  })
+
+  it('calls triggerTranscriptAnalysis with transcriptId and tenantId after insert', async () => {
+    const { uploadTranscript } = await import('@/actions/transcripts')
+
+    await uploadTranscript(null, pasteFormData())
+
+    // after() fires synchronously in tests; allow micro-task queue to drain
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(mockTriggerTranscriptAnalysis).toHaveBeenCalledWith(TRANSCRIPT_ID, TENANT_ID)
+  })
+
+  // ── Happy path: file upload ───────────────────────────────────────────────────
+
+  it('inserts transcript row and returns transcriptId on file upload happy path', async () => {
+    const file = fakeTxtFile()
+    const { uploadTranscript } = await import('@/actions/transcripts')
+
+    const result = await uploadTranscript(null, fileFormData(file))
+
+    expect(result.success).toBe(true)
+    expect((result as { success: true; transcriptId: string }).transcriptId).toBe(TRANSCRIPT_ID)
+
+    expect(mockInsertValues).toHaveBeenCalledTimes(1)
+    const arg = mockInsertValues.mock.calls[0][0] as Record<string, unknown>
+    expect(arg.analysisStatus).toBe('pending')
+    // .txt file → sourceFormat 'txt'
+    expect(arg.sourceFormat).toBe('txt')
+  })
+})


### PR DESCRIPTION
## Summary

Adds 48 Vitest unit tests across three server actions that had zero coverage. All tests follow the established mock pattern from `scores.test.ts`, `candidates.test.ts`, and `enrichment.test.ts` — no DB writes, no real integrations, no changes to action source files.

## Test count table

| Action file | Test file | Tests | Scenarios covered |
|---|---|---|---|
| `src/actions/interview.ts` | `tests/unit/actions/interview.test.ts` | 17 | `createInterviewPack`: auth gate, viewer blocked, hiring_manager blocked, invalid UUID, candidate-not-found, happy path (pack inserted + packId returned), `pre_screening` forces `includesCodeChallenge=false`; `retryInterviewPack`: auth, pack-not-found, already-complete guard, happy path; `deleteInterviewPack`: auth, pack-not-found, happy path; `updateQuestionNotes`: auth, question-not-found, happy path |
| `src/actions/transcripts.ts` | `tests/unit/actions/transcripts.test.ts` | 11 | `uploadTranscript`: auth (Unauthorised), role gate (viewer), missing candidateId, missing roleId, no file + no paste, file >5 MB, parse error surfaced, invalid interviewDate, paste happy path (insert + `triggerTranscriptAnalysis` called), file upload happy path, `transcriptId` returned |
| `src/actions/notes.ts` | `tests/unit/actions/notes.test.ts` | 20 | `createNote`: auth, viewer forbidden, empty body, body >5000 chars, happy path (tenant/author/body verified), `isShareable=true` persisted, `isShareable=false` default, hiring_manager allowed; `updateNote`: auth, viewer forbidden, note-not-found, empty body, non-author non-admin blocked, admin override, happy path (body + isShareable + isEdited set); `deleteNote`: auth, note-not-found, non-author blocked, author happy path, admin override |

**Total: 48 tests**

## Scenarios skipped with reason

| Scenario | Reason |
|---|---|
| `createInterviewPack` audit log assertion | Action does not call `writeAuditLog` — interview pack creation writes no audit entry. Tested what is actually there. |
| `uploadTranscript` DOCX/PDF format paths | `parseTranscriptFile` is fully mocked; format routing is tested implicitly via the `.txt` happy path. DOCX/PDF paths require `mammoth`/`pdf-parse` which are external libraries with no benefit to mock |
| `notes` — audit log assertion | `createNote`/`updateNote`/`deleteNote` do not call `writeAuditLog` — the notes action has no audit writes. Tested what is actually there. |

## Bugs found

**UUID variant constraint in Zod's `z.string().uuid()`**: Zod validates UUID v4 variant bits — the first nibble of the 4th group must be `8`, `9`, `a`, or `b`. Test constants using repeating hex digits outside this range (e.g. `cccccccc-cccc-4ccc-cccc-cccccccccccc` where the 4th group starts with `c`) fail `z.string().uuid()` silently causing the action to return `{ success: false, error: "Invalid input" }` before reaching the candidate lookup. This is a test-authoring footgun, not a bug in the actions. Fixed by using valid v4 UUID constants (`11111111-1111-4111-8111-111111111111`, etc.) in the interview test.

## Pre-existing test failures (not introduced by this PR)

`tests/unit/actions/calendar.test.ts` has 8 failures on the base branch from another agent's untracked work-in-progress. These failures exist before and after this PR and are unrelated to the three files added here.

## Test plan

- [x] `npm test` green on `test/actions-interview-transcripts-notes` (48 new + 157 existing = 205 committed tests pass; calendar.test.ts failures are pre-existing untracked WIP)
- [x] `npx tsc --noEmit` — no errors attributable to new test files
- [x] No source action files changed
- [x] No DB writes in any test

🤖 Generated with [Claude Code](https://claude.com/claude-code)