### PR TITLE
test(actions): add coverage for calendar, invitations, settings

### DIFF
--- a/tests/unit/actions/calendar.test.ts
+++ b/tests/unit/actions/calendar.test.ts
@@ -1,0 +1,672 @@
+/**
+ * Unit tests for src/actions/calendar.ts
+ *
+ * Covers the *action* layer only. The sync-loop (runCalendarSync) is already
+ * covered in tests/unit/lib/calendar/sync-loop.test.ts — we do NOT duplicate
+ * that here.
+ *
+ * Actions under test:
+ *   createInterviewSlot   — happy path, auth guard, validation guard, calendar
+ *                           sync non-fatal failure.
+ *   updateInterviewSlot   — happy path, slot-not-found, cancelled-slot guard.
+ *   cancelInterviewSlot   — happy path, slot-not-found, auth guard.
+ *   disconnectCalendar    — happy path (deletes row), no-ctx guard.
+ *   getCalendarConnections — happy path for connected / empty.
+ *   importIcsSlots        — happy path, auth guard, empty-file guard,
+ *                           oversized-file guard, no-events guard, past-event skip.
+ *
+ * Mocks:
+ *   @/db                            — db (direct delete/select), withTenant
+ *   @/db/schema                     — interviewSlots, calendarConnections stubs
+ *   drizzle-orm                     — eq / and / desc pass-throughs
+ *   @/lib/auth/action-context       — getActionContext
+ *   @/lib/audit                     — writeAuditLog
+ *   @/lib/calendar/sync             — syncSlotToCalendars, deleteSlotFromCalendars
+ *   @/lib/ics-parser                — parseIcsFile
+ *   next/cache                      — revalidatePath silenced
+ *   next/server                     — after silenced
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Constants ──────────────────────────────────────────────────────────────────
+
+const TENANT_ID    = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const USER_ID      = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const CANDIDATE_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+const ROLE_ID      = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
+const SLOT_ID      = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee'
+
+// ── DB mock helpers ────────────────────────────────────────────────────────────
+
+function makeSelectChain(rows: unknown[]) {
+  const c: Record<string, unknown> = {}
+  const resolved = Promise.resolve(rows)
+  c.then    = resolved.then.bind(resolved)
+  c.catch   = resolved.catch.bind(resolved)
+  c.from    = vi.fn(() => c)
+  c.where   = vi.fn(() => c)
+  c.limit   = vi.fn(() => Promise.resolve(rows))
+  c.orderBy = vi.fn(() => c)
+  return c
+}
+
+// Per-test mutable state — each withTenant select call can return different rows
+type SelectFactory = () => ReturnType<typeof makeSelectChain>
+let selectFactory: SelectFactory
+
+// Captured mutation calls
+const mockInsertValues          = vi.fn()
+const mockInsertReturning       = vi.fn()
+const mockUpdateSet             = vi.fn()
+const mockUpdateWhere           = vi.fn()
+const mockUpdateReturning       = vi.fn()
+const mockDeleteWhere           = vi.fn()
+// direct db.* calls (disconnectCalendar, getCalendarConnections)
+const mockDbDeleteWhere         = vi.fn()
+const mockDbSelectChainRows     = vi.fn().mockReturnValue([])
+
+// ── Module mocks ───────────────────────────────────────────────────────────────
+
+vi.mock('@/db', () => ({
+  db: {
+    select: vi.fn(() => {
+      const rows = mockDbSelectChainRows()
+      return makeSelectChain(rows)
+    }),
+    delete: vi.fn(() => ({
+      where: (...args: unknown[]) => {
+        mockDbDeleteWhere(...args)
+        return Promise.resolve()
+      },
+    })),
+  },
+  withTenant: vi.fn().mockImplementation(
+    async (_tenantId: string, fn: (tx: unknown) => unknown) => {
+      const tx = {
+        select: vi.fn(() => selectFactory()),
+
+        insert: vi.fn(() => ({
+          values: (...args: unknown[]) => {
+            mockInsertValues(...args)
+            return {
+              returning: (...rargs: unknown[]) => {
+                mockInsertReturning(...rargs)
+                return Promise.resolve([{ id: SLOT_ID }])
+              },
+            }
+          },
+        })),
+
+        update: vi.fn(() => ({
+          set: (...args: unknown[]) => {
+            mockUpdateSet(...args)
+            return {
+              where: (...wargs: unknown[]) => {
+                mockUpdateWhere(...wargs)
+                return {
+                  returning: (...rargs: unknown[]) => {
+                    mockUpdateReturning(...rargs)
+                    return Promise.resolve()
+                  },
+                }
+              },
+            }
+          },
+        })),
+
+        delete: vi.fn(() => ({
+          where: (...wargs: unknown[]) => {
+            mockDeleteWhere(...wargs)
+            return Promise.resolve()
+          },
+        })),
+      }
+      return fn(tx)
+    }
+  ),
+}))
+
+vi.mock('@/db/schema', () => ({
+  interviewSlots: {
+    id:                 'id',
+    tenantId:           'tenant_id',
+    candidateId:        'candidate_id',
+    roleId:             'role_id',
+    title:              'title',
+    scheduledAt:        'scheduled_at',
+    durationMinutes:    'duration_minutes',
+    location:           'location',
+    meetingUrl:         'meeting_url',
+    slotNotes:          'slot_notes',
+    status:             'status',
+    createdBy:          'created_by',
+    googleEventId:      'google_event_id',
+    microsoftEventId:   'microsoft_event_id',
+    updatedAt:          'updated_at',
+  },
+  calendarConnections: {
+    id:       'id',
+    userId:   'user_id',
+    provider: 'provider',
+    tenantId: 'tenant_id',
+  },
+}))
+
+vi.mock('drizzle-orm', () => ({
+  eq:   vi.fn(() => ({ type: 'eq' })),
+  and:  vi.fn((...args: unknown[]) => ({ type: 'and', args })),
+  desc: vi.fn(() => ({ type: 'desc' })),
+  or:   vi.fn((...args: unknown[]) => ({ type: 'or', args })),
+}))
+
+const mockGetActionContext = vi.fn()
+vi.mock('@/lib/auth/action-context', () => ({
+  getActionContext: () => mockGetActionContext(),
+}))
+
+const mockWriteAuditLog = vi.fn().mockResolvedValue(undefined)
+vi.mock('@/lib/audit', () => ({
+  writeAuditLog: mockWriteAuditLog,
+}))
+
+const mockSyncSlotToCalendars    = vi.fn()
+const mockDeleteSlotFromCalendars = vi.fn()
+vi.mock('@/lib/calendar/sync', () => ({
+  syncSlotToCalendars:     (...args: unknown[]) => mockSyncSlotToCalendars(...args),
+  deleteSlotFromCalendars: (...args: unknown[]) => mockDeleteSlotFromCalendars(...args),
+}))
+
+const mockParseIcsFile = vi.fn()
+vi.mock('@/lib/ics-parser', () => ({
+  parseIcsFile: (...args: unknown[]) => mockParseIcsFile(...args),
+}))
+
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+vi.mock('next/server', () => ({
+  after: vi.fn((fn: () => void) => {
+    try { fn() } catch {}
+  }),
+}))
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function recruiterCtx() {
+  return { tenantId: TENANT_ID, userId: USER_ID, userRole: 'recruiter' as const }
+}
+
+function adminCtx() {
+  return { tenantId: TENANT_ID, userId: USER_ID, userRole: 'admin' as const }
+}
+
+function makeSlot(overrides: Record<string, unknown> = {}) {
+  return {
+    id:               SLOT_ID,
+    tenantId:         TENANT_ID,
+    candidateId:      CANDIDATE_ID,
+    roleId:           ROLE_ID,
+    title:            'Technical Interview',
+    scheduledAt:      new Date('2026-06-15T10:00:00Z'),
+    durationMinutes:  60,
+    location:         null,
+    meetingUrl:       null,
+    slotNotes:        null,
+    status:           'scheduled',
+    createdBy:        USER_ID,
+    googleEventId:    null,
+    microsoftEventId: null,
+    updatedAt:        new Date('2026-05-01T00:00:00Z'),
+    ...overrides,
+  }
+}
+
+const BASE_SLOT_INPUT = {
+  candidateId:     CANDIDATE_ID,
+  roleId:          ROLE_ID,
+  title:           'Technical Interview',
+  scheduledAt:     '2026-06-15T10:00:00+00:00',
+  durationMinutes: 60,
+  syncToCalendar:  false,
+}
+
+// ── createInterviewSlot ────────────────────────────────────────────────────────
+
+describe('createInterviewSlot', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetActionContext.mockResolvedValue(recruiterCtx())
+    selectFactory = () => makeSelectChain([makeSlot()])
+    mockSyncSlotToCalendars.mockResolvedValue({ googleEventId: null, microsoftEventId: null })
+    mockDeleteSlotFromCalendars.mockResolvedValue(undefined)
+  })
+
+  it('returns Unauthorized when no action context', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { createInterviewSlot } = await import('@/actions/calendar')
+
+    const result = await createInterviewSlot(BASE_SLOT_INPUT)
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/unauthorized/i)
+  })
+
+  it('returns error when scheduledAt is missing', async () => {
+    const { createInterviewSlot } = await import('@/actions/calendar')
+
+    const result = await createInterviewSlot({
+      ...BASE_SLOT_INPUT,
+      scheduledAt: '',
+    })
+
+    expect(result.success).toBe(false)
+    expect(mockInsertValues).not.toHaveBeenCalled()
+  })
+
+  it('returns error when title is empty', async () => {
+    const { createInterviewSlot } = await import('@/actions/calendar')
+
+    const result = await createInterviewSlot({
+      ...BASE_SLOT_INPUT,
+      title: '',
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('inserts slot row and returns slotId on happy path', async () => {
+    const { createInterviewSlot } = await import('@/actions/calendar')
+
+    const result = await createInterviewSlot(BASE_SLOT_INPUT)
+
+    expect(result.success).toBe(true)
+    expect((result as { success: true; slotId: string }).slotId).toBe(SLOT_ID)
+    expect(mockInsertValues).toHaveBeenCalledTimes(1)
+    const insertArg = mockInsertValues.mock.calls[0][0] as Record<string, unknown>
+    expect(insertArg.tenantId).toBe(TENANT_ID)
+    expect(insertArg.candidateId).toBe(CANDIDATE_ID)
+    expect(insertArg.status).toBe('scheduled')
+    expect(insertArg.createdBy).toBe(USER_ID)
+  })
+
+  it('writes interview_slot.created audit log on happy path', async () => {
+    const { createInterviewSlot } = await import('@/actions/calendar')
+
+    await createInterviewSlot(BASE_SLOT_INPUT)
+
+    expect(mockWriteAuditLog).toHaveBeenCalledWith(
+      TENANT_ID,
+      expect.objectContaining({
+        action: 'interview_slot.created',
+        entityType: 'interview_slot',
+        entityId: SLOT_ID,
+      })
+    )
+  })
+
+  it('does not call syncSlotToCalendars when syncToCalendar=false', async () => {
+    const { createInterviewSlot } = await import('@/actions/calendar')
+
+    await createInterviewSlot({ ...BASE_SLOT_INPUT, syncToCalendar: false })
+
+    expect(mockSyncSlotToCalendars).not.toHaveBeenCalled()
+  })
+
+  it('calls syncSlotToCalendars when syncToCalendar=true and stores returned event IDs', async () => {
+    mockSyncSlotToCalendars.mockResolvedValue({
+      googleEventId:    'google-evt-123',
+      microsoftEventId: null,
+    })
+    const { createInterviewSlot } = await import('@/actions/calendar')
+
+    const result = await createInterviewSlot({ ...BASE_SLOT_INPUT, syncToCalendar: true })
+
+    expect(result.success).toBe(true)
+    expect(mockSyncSlotToCalendars).toHaveBeenCalledTimes(1)
+    // Second withTenant call stores the calendar IDs
+    expect(mockUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ googleEventId: 'google-evt-123', microsoftEventId: null })
+    )
+  })
+
+  it('still succeeds when calendar sync throws (non-fatal)', async () => {
+    mockSyncSlotToCalendars.mockRejectedValue(new Error('Google token expired'))
+    const { createInterviewSlot } = await import('@/actions/calendar')
+
+    const result = await createInterviewSlot({ ...BASE_SLOT_INPUT, syncToCalendar: true })
+
+    // Calendar failure is swallowed — the slot was still created
+    expect(result.success).toBe(true)
+  })
+})
+
+// ── updateInterviewSlot ────────────────────────────────────────────────────────
+
+describe('updateInterviewSlot', () => {
+  const UPDATE_INPUT = {
+    slotId:          SLOT_ID,
+    candidateId:     CANDIDATE_ID,
+    roleId:          ROLE_ID,
+    title:           'Updated Interview',
+    scheduledAt:     '2026-07-10T14:00:00+00:00',
+    durationMinutes: 90,
+    syncToCalendar:  false,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetActionContext.mockResolvedValue(recruiterCtx())
+    // First select returns the existing slot
+    selectFactory = () => makeSelectChain([makeSlot()])
+    mockSyncSlotToCalendars.mockResolvedValue({ googleEventId: null, microsoftEventId: null })
+    mockDeleteSlotFromCalendars.mockResolvedValue(undefined)
+  })
+
+  it('returns Unauthorized when no action context', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { updateInterviewSlot } = await import('@/actions/calendar')
+
+    const result = await updateInterviewSlot(UPDATE_INPUT)
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/unauthorized/i)
+  })
+
+  it('returns slot-not-found error when slot does not exist', async () => {
+    selectFactory = () => makeSelectChain([])  // no slot row
+    const { updateInterviewSlot } = await import('@/actions/calendar')
+
+    const result = await updateInterviewSlot(UPDATE_INPUT)
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/not found/i)
+  })
+
+  it('returns error when slot is cancelled', async () => {
+    selectFactory = () => makeSelectChain([makeSlot({ status: 'cancelled' })])
+    const { updateInterviewSlot } = await import('@/actions/calendar')
+
+    const result = await updateInterviewSlot(UPDATE_INPUT)
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/cancelled/i)
+  })
+
+  it('updates slot and writes audit log on happy path', async () => {
+    const { updateInterviewSlot } = await import('@/actions/calendar')
+
+    const result = await updateInterviewSlot(UPDATE_INPUT)
+
+    expect(result.success).toBe(true)
+    expect(mockUpdateSet).toHaveBeenCalledTimes(1)
+    const setArg = mockUpdateSet.mock.calls[0][0] as Record<string, unknown>
+    expect(setArg.title).toBe('Updated Interview')
+
+    expect(mockWriteAuditLog).toHaveBeenCalledWith(
+      TENANT_ID,
+      expect.objectContaining({
+        action: 'interview_slot.updated',
+        entityType: 'interview_slot',
+        entityId: SLOT_ID,
+      })
+    )
+  })
+
+  it('deletes old calendar events when slot previously had a googleEventId', async () => {
+    selectFactory = () =>
+      makeSelectChain([makeSlot({ googleEventId: 'old-google-event-id' })])
+    const { updateInterviewSlot } = await import('@/actions/calendar')
+
+    await updateInterviewSlot({ ...UPDATE_INPUT, syncToCalendar: false })
+
+    // Existing calendar event should be deleted even if user did not request new sync
+    expect(mockDeleteSlotFromCalendars).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ── cancelInterviewSlot ────────────────────────────────────────────────────────
+
+describe('cancelInterviewSlot', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetActionContext.mockResolvedValue(recruiterCtx())
+    selectFactory = () => makeSelectChain([makeSlot()])
+    mockDeleteSlotFromCalendars.mockResolvedValue(undefined)
+  })
+
+  it('returns Unauthorized when no action context', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { cancelInterviewSlot } = await import('@/actions/calendar')
+
+    const result = await cancelInterviewSlot(SLOT_ID, CANDIDATE_ID)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/unauthorized/i)
+  })
+
+  it('returns slot-not-found error when slot does not exist', async () => {
+    selectFactory = () => makeSelectChain([])
+    const { cancelInterviewSlot } = await import('@/actions/calendar')
+
+    const result = await cancelInterviewSlot(SLOT_ID, CANDIDATE_ID)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/not found/i)
+  })
+
+  it('sets status=cancelled and writes audit log on happy path', async () => {
+    const { cancelInterviewSlot } = await import('@/actions/calendar')
+
+    const result = await cancelInterviewSlot(SLOT_ID, CANDIDATE_ID)
+
+    expect(result.success).toBe(true)
+    expect(mockUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'cancelled' })
+    )
+    expect(mockWriteAuditLog).toHaveBeenCalledWith(
+      TENANT_ID,
+      expect.objectContaining({
+        action: 'interview_slot.cancelled',
+        entityType: 'interview_slot',
+        entityId: SLOT_ID,
+      })
+    )
+  })
+
+  it('still cancels even when deleteSlotFromCalendars throws (non-fatal)', async () => {
+    mockDeleteSlotFromCalendars.mockRejectedValue(new Error('API error'))
+    const { cancelInterviewSlot } = await import('@/actions/calendar')
+
+    const result = await cancelInterviewSlot(SLOT_ID, CANDIDATE_ID)
+
+    // Calendar deletion failure is non-fatal
+    expect(result.success).toBe(true)
+  })
+})
+
+// ── disconnectCalendar ─────────────────────────────────────────────────────────
+
+describe('disconnectCalendar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetActionContext.mockResolvedValue(recruiterCtx())
+  })
+
+  it('silently returns when no action context (no crash)', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { disconnectCalendar } = await import('@/actions/calendar')
+
+    // Should not throw
+    await expect(disconnectCalendar('google')).resolves.toBeUndefined()
+    expect(mockDbDeleteWhere).not.toHaveBeenCalled()
+  })
+
+  it('deletes the calendar connection row for the specified provider', async () => {
+    const { disconnectCalendar } = await import('@/actions/calendar')
+
+    await disconnectCalendar('google')
+
+    expect(mockDbDeleteWhere).toHaveBeenCalledTimes(1)
+  })
+
+  it('works for microsoft provider', async () => {
+    const { disconnectCalendar } = await import('@/actions/calendar')
+
+    await disconnectCalendar('microsoft')
+
+    expect(mockDbDeleteWhere).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ── getCalendarConnections ─────────────────────────────────────────────────────
+
+describe('getCalendarConnections', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns {google: true, microsoft: false} when only google is connected', async () => {
+    mockDbSelectChainRows.mockReturnValue([{ provider: 'google' }])
+    const { getCalendarConnections } = await import('@/actions/calendar')
+
+    const result = await getCalendarConnections(USER_ID)
+
+    expect(result.google).toBe(true)
+    expect(result.microsoft).toBe(false)
+  })
+
+  it('returns {google: false, microsoft: false} when no connections exist', async () => {
+    mockDbSelectChainRows.mockReturnValue([])
+    const { getCalendarConnections } = await import('@/actions/calendar')
+
+    const result = await getCalendarConnections(USER_ID)
+
+    expect(result.google).toBe(false)
+    expect(result.microsoft).toBe(false)
+  })
+
+  it('returns {google: true, microsoft: true} when both are connected', async () => {
+    mockDbSelectChainRows.mockReturnValue([
+      { provider: 'google' },
+      { provider: 'microsoft' },
+    ])
+    const { getCalendarConnections } = await import('@/actions/calendar')
+
+    const result = await getCalendarConnections(USER_ID)
+
+    expect(result.google).toBe(true)
+    expect(result.microsoft).toBe(true)
+  })
+})
+
+// ── importIcsSlots ─────────────────────────────────────────────────────────────
+
+describe('importIcsSlots', () => {
+  const FUTURE_DATE = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
+  const PAST_DATE   = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000)
+
+  function makeParsedEvent(overrides: Partial<{
+    summary: string
+    start: Date
+    durationMinutes: number
+    location: string | null
+    meetingUrl: string | null
+    description: string | null
+  }> = {}) {
+    return {
+      summary:         'Technical Screen',
+      start:           FUTURE_DATE,
+      durationMinutes: 60,
+      location:        null,
+      meetingUrl:      null,
+      description:     null,
+      ...overrides,
+    }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetActionContext.mockResolvedValue(recruiterCtx())
+    selectFactory = () => makeSelectChain([])
+    mockParseIcsFile.mockReturnValue([makeParsedEvent()])
+  })
+
+  it('returns Unauthorized when no action context', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { importIcsSlots } = await import('@/actions/calendar')
+
+    const result = await importIcsSlots(CANDIDATE_ID, null, 'BEGIN:VCALENDAR\nEND:VCALENDAR')
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/unauthorized/i)
+  })
+
+  it('returns error when file content is empty', async () => {
+    const { importIcsSlots } = await import('@/actions/calendar')
+
+    const result = await importIcsSlots(CANDIDATE_ID, null, '')
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/empty/i)
+  })
+
+  it('returns error when file content exceeds 500 KB', async () => {
+    const { importIcsSlots } = await import('@/actions/calendar')
+    const oversized = 'X'.repeat(500 * 1024 + 1)
+
+    const result = await importIcsSlots(CANDIDATE_ID, null, oversized)
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/too large/i)
+  })
+
+  it('returns error when no valid events are found in file', async () => {
+    mockParseIcsFile.mockReturnValue([])
+    const { importIcsSlots } = await import('@/actions/calendar')
+
+    const result = await importIcsSlots(CANDIDATE_ID, null, 'BEGIN:VCALENDAR\nEND:VCALENDAR')
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/no valid events/i)
+  })
+
+  it('imports future events and returns correct counts', async () => {
+    mockParseIcsFile.mockReturnValue([
+      makeParsedEvent({ start: FUTURE_DATE }),
+      makeParsedEvent({ summary: 'Second Interview', start: new Date(FUTURE_DATE.getTime() + 86400000) }),
+    ])
+    const { importIcsSlots } = await import('@/actions/calendar')
+
+    const result = await importIcsSlots(CANDIDATE_ID, null, 'BEGIN:VCALENDAR\nEND:VCALENDAR')
+
+    expect(result.success).toBe(true)
+    const r = result as { success: true; imported: number; skipped: number }
+    expect(r.imported).toBe(2)
+    expect(r.skipped).toBe(0)
+    expect(mockInsertValues).toHaveBeenCalledTimes(2)
+  })
+
+  it('skips past events and counts them as skipped', async () => {
+    mockParseIcsFile.mockReturnValue([
+      makeParsedEvent({ start: PAST_DATE }),     // past — should skip
+      makeParsedEvent({ start: FUTURE_DATE }),   // future — should import
+    ])
+    const { importIcsSlots } = await import('@/actions/calendar')
+
+    const result = await importIcsSlots(CANDIDATE_ID, null, 'BEGIN:VCALENDAR\nEND:VCALENDAR')
+
+    expect(result.success).toBe(true)
+    const r = result as { success: true; imported: number; skipped: number }
+    expect(r.imported).toBe(1)
+    expect(r.skipped).toBe(1)
+  })
+
+  it('associates the roleId with inserted slots when provided', async () => {
+    const { importIcsSlots } = await import('@/actions/calendar')
+
+    await importIcsSlots(CANDIDATE_ID, ROLE_ID, 'BEGIN:VCALENDAR\nEND:VCALENDAR')
+
+    expect(mockInsertValues).toHaveBeenCalledTimes(1)
+    const insertArg = mockInsertValues.mock.calls[0][0] as Record<string, unknown>
+    expect(insertArg.roleId).toBe(ROLE_ID)
+  })
+})

--- a/tests/unit/actions/invitations.test.ts
+++ b/tests/unit/actions/invitations.test.ts
@@ -1,0 +1,519 @@
+/**
+ * Unit tests for src/actions/invitations.ts
+ *
+ * Actions under test:
+ *   createInvitation    — happy path, auth guard (no tenantId), role guard
+ *                         (non-admin), invalid email, returns inviteUrl.
+ *   revokeInvitation    — happy path (deletes row), auth guard, role guard.
+ *   acceptInvitation    — happy path (inserts user, marks used), token-not-found,
+ *                         already-used guard, expired-token guard, email-mismatch
+ *                         guard, password-mismatch validation.
+ *   listPendingInvitations — admin sees list; non-admin sees []; no-tenant returns [].
+ *
+ * NOTE on resendInvitation:
+ *   There is no `resendInvitation` export in src/actions/invitations.ts. The
+ *   function does not exist in the codebase — no test is written for it.
+ *
+ * Mocks:
+ *   @/db                            — db (direct select/insert/update/delete),
+ *                                     withTenant
+ *   @/db/schema                     — users, userInvitations stubs
+ *   drizzle-orm                     — eq / and / gt / isNull pass-throughs
+ *   @/lib/auth                      — auth (returns mock session)
+ *   @/lib/auth/require-role         — requireRole (real logic via vi.fn — throws for
+ *                                     non-admin)
+ *   next/headers                    — headers (returns mock header list)
+ *   next/cache                      — revalidatePath silenced
+ *   bcryptjs                        — hash / compare silenced
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Constants ──────────────────────────────────────────────────────────────────
+
+const TENANT_ID     = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const USER_ID       = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const INVITATION_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+const INVITE_TOKEN  = 'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890'
+
+// ── DB mock helpers ────────────────────────────────────────────────────────────
+
+function makeSelectChain(rows: unknown[]) {
+  const c: Record<string, unknown> = {}
+  const resolved = Promise.resolve(rows)
+  c.then    = resolved.then.bind(resolved)
+  c.catch   = resolved.catch.bind(resolved)
+  c.from    = vi.fn(() => c)
+  c.where   = vi.fn(() => c)
+  c.limit   = vi.fn(() => Promise.resolve(rows))
+  c.orderBy = vi.fn(() => c)
+  return c
+}
+
+// Rows returned by db.select() calls — controlled per test
+let dbSelectRows: unknown[] = []
+
+// Captured mutation calls
+const mockDbInsertValues   = vi.fn()
+const mockDbUpdateSet      = vi.fn()
+const mockDbUpdateWhere    = vi.fn()
+const mockDbDeleteWhere    = vi.fn()
+const mockWithTenantInsert = vi.fn()
+
+// ── Module mocks ───────────────────────────────────────────────────────────────
+
+vi.mock('@/db', () => ({
+  db: {
+    select: vi.fn(() => makeSelectChain(dbSelectRows)),
+
+    insert: vi.fn(() => ({
+      values: (...args: unknown[]) => {
+        mockDbInsertValues(...args)
+        return Promise.resolve()
+      },
+    })),
+
+    update: vi.fn(() => ({
+      set: (...args: unknown[]) => {
+        mockDbUpdateSet(...args)
+        return {
+          where: (...wargs: unknown[]) => {
+            mockDbUpdateWhere(...wargs)
+            return Promise.resolve()
+          },
+        }
+      },
+    })),
+
+    delete: vi.fn(() => ({
+      where: (...wargs: unknown[]) => {
+        mockDbDeleteWhere(...wargs)
+        return Promise.resolve()
+      },
+    })),
+  },
+
+  withTenant: vi.fn().mockImplementation(
+    async (_tenantId: string, fn: (tx: unknown) => unknown) => {
+      const tx = {
+        insert: vi.fn(() => ({
+          values: (...args: unknown[]) => {
+            mockWithTenantInsert(...args)
+            return Promise.resolve()
+          },
+        })),
+      }
+      return fn(tx)
+    }
+  ),
+}))
+
+vi.mock('@/db/schema', () => ({
+  users: {
+    id:            'id',
+    tenantId:      'tenant_id',
+    email:         'email',
+    name:          'name',
+    role:          'role',
+    passwordHash:  'password_hash',
+    isActive:      'is_active',
+  },
+  userInvitations: {
+    id:         'id',
+    tenantId:   'tenant_id',
+    token:      'token',
+    email:      'email',
+    role:       'role',
+    createdBy:  'created_by',
+    expiresAt:  'expires_at',
+    usedAt:     'used_at',
+    createdAt:  'created_at',
+  },
+}))
+
+vi.mock('drizzle-orm', () => ({
+  eq:     vi.fn(() => ({ type: 'eq' })),
+  and:    vi.fn((...args: unknown[]) => ({ type: 'and', args })),
+  gt:     vi.fn(() => ({ type: 'gt' })),
+  isNull: vi.fn(() => ({ type: 'isNull' })),
+  or:     vi.fn((...args: unknown[]) => ({ type: 'or', args })),
+}))
+
+// Mock headers — controlled per test
+const mockHeadersGet = vi.fn()
+vi.mock('next/headers', () => ({
+  headers: () =>
+    Promise.resolve({
+      get: (key: string) => mockHeadersGet(key),
+    }),
+}))
+
+// Mock auth session — controlled per test
+const mockAuth = vi.fn()
+vi.mock('@/lib/auth', () => ({
+  auth: () => mockAuth(),
+}))
+
+// requireRole — use real logic (throws for insufficient role)
+// We import the real implementation so the role gate behaves correctly
+vi.mock('@/lib/auth/require-role', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/auth/require-role')>()
+  return { requireRole: actual.requireRole }
+})
+
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+
+// bcryptjs — hash is fast; don't actually bcrypt in unit tests
+vi.mock('bcryptjs', () => ({
+  default: {
+    hash:    vi.fn().mockResolvedValue('$2b$12$hashedpassword'),
+    compare: vi.fn().mockResolvedValue(true),
+  },
+  hash:    vi.fn().mockResolvedValue('$2b$12$hashedpassword'),
+  compare: vi.fn().mockResolvedValue(true),
+}))
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function setAdminHeaders() {
+  mockHeadersGet.mockImplementation((key: string) => {
+    if (key === 'x-tenant-id') return TENANT_ID
+    if (key === 'x-user-id')   return USER_ID
+    if (key === 'x-user-role') return 'admin'
+    return null
+  })
+}
+
+function setRecruiterHeaders() {
+  mockHeadersGet.mockImplementation((key: string) => {
+    if (key === 'x-tenant-id') return TENANT_ID
+    if (key === 'x-user-id')   return USER_ID
+    if (key === 'x-user-role') return 'recruiter'
+    return null
+  })
+}
+
+function setNoAuthHeaders() {
+  mockHeadersGet.mockReturnValue(null)
+}
+
+function setAdminSession() {
+  mockAuth.mockResolvedValue({
+    user: { id: USER_ID, tenantId: TENANT_ID, role: 'admin' },
+  })
+}
+
+function setRecruiterSession() {
+  mockAuth.mockResolvedValue({
+    user: { id: USER_ID, tenantId: TENANT_ID, role: 'recruiter' },
+  })
+}
+
+function setNoSession() {
+  mockAuth.mockResolvedValue(null)
+}
+
+function makeInvitation(overrides: Partial<{
+  id: string
+  tenantId: string
+  token: string
+  email: string | null
+  role: string
+  usedAt: Date | null
+  expiresAt: Date
+}> = {}) {
+  return {
+    id:         INVITATION_ID,
+    tenantId:   TENANT_ID,
+    token:      INVITE_TOKEN,
+    email:      null,
+    role:       'recruiter',
+    createdBy:  USER_ID,
+    usedAt:     null,
+    expiresAt:  new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days future
+    createdAt:  new Date(),
+    ...overrides,
+  }
+}
+
+function makeInviteFormData(overrides: Record<string, string> = {}): FormData {
+  const fd = new FormData()
+  fd.set('role', 'recruiter')
+  for (const [k, v] of Object.entries(overrides)) fd.set(k, v)
+  return fd
+}
+
+function makeAcceptFormData(overrides: Record<string, string> = {}): FormData {
+  const fd = new FormData()
+  fd.set('token',           INVITE_TOKEN)
+  fd.set('name',            'Jane Doe')
+  fd.set('email',           'jane.doe@example.com')
+  fd.set('password',        'SecurePassword!2026')
+  fd.set('confirmPassword', 'SecurePassword!2026')
+  for (const [k, v] of Object.entries(overrides)) fd.set(k, v)
+  return fd
+}
+
+// ── createInvitation ───────────────────────────────────────────────────────────
+
+describe('createInvitation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setAdminHeaders()
+    dbSelectRows = []
+  })
+
+  it('returns Unauthorized when no tenantId header', async () => {
+    setNoAuthHeaders()
+    const { createInvitation } = await import('@/actions/invitations')
+
+    const result = await createInvitation(null, makeInviteFormData())
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/unauthorized/i)
+  })
+
+  it('returns error when role is recruiter (non-admin)', async () => {
+    setRecruiterHeaders()
+    const { createInvitation } = await import('@/actions/invitations')
+
+    const result = await createInvitation(null, makeInviteFormData())
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/admin/i)
+  })
+
+  it('returns fieldErrors when email is invalid', async () => {
+    const { createInvitation } = await import('@/actions/invitations')
+    const fd = makeInviteFormData({ email: 'not-an-email' })
+
+    const result = await createInvitation(null, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.fieldErrors).toBeDefined()
+  })
+
+  it('creates invitation row and returns inviteUrl on happy path', async () => {
+    const { createInvitation } = await import('@/actions/invitations')
+    const fd = makeInviteFormData({ email: 'new.recruiter@example.com', role: 'recruiter' })
+
+    const result = await createInvitation(null, fd)
+
+    expect(result.success).toBe(true)
+    expect(result.inviteUrl).toMatch(/\/invite\//)
+    expect(mockDbInsertValues).toHaveBeenCalledTimes(1)
+    const insertArg = mockDbInsertValues.mock.calls[0][0] as Record<string, unknown>
+    expect(insertArg.tenantId).toBe(TENANT_ID)
+    expect(insertArg.role).toBe('recruiter')
+    expect(typeof insertArg.token).toBe('string')
+    expect((insertArg.token as string).length).toBeGreaterThan(20)
+  })
+
+  it('creates invitation without email (open link) when email is omitted', async () => {
+    const { createInvitation } = await import('@/actions/invitations')
+    const fd = makeInviteFormData() // no email field set
+
+    const result = await createInvitation(null, fd)
+
+    expect(result.success).toBe(true)
+    const insertArg = mockDbInsertValues.mock.calls[0][0] as Record<string, unknown>
+    expect(insertArg.email).toBeNull()
+  })
+
+  it('creates invitation with admin role when specified', async () => {
+    const { createInvitation } = await import('@/actions/invitations')
+    const fd = makeInviteFormData({ role: 'admin' })
+
+    const result = await createInvitation(null, fd)
+
+    expect(result.success).toBe(true)
+    const insertArg = mockDbInsertValues.mock.calls[0][0] as Record<string, unknown>
+    expect(insertArg.role).toBe('admin')
+  })
+})
+
+// ── revokeInvitation ───────────────────────────────────────────────────────────
+
+describe('revokeInvitation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setAdminSession()
+  })
+
+  it('silently returns when no session (no crash)', async () => {
+    setNoSession()
+    const { revokeInvitation } = await import('@/actions/invitations')
+
+    await expect(revokeInvitation(INVITATION_ID)).resolves.toBeUndefined()
+    expect(mockDbDeleteWhere).not.toHaveBeenCalled()
+  })
+
+  it('throws Forbidden when user is recruiter (not admin)', async () => {
+    setRecruiterSession()
+    const { revokeInvitation } = await import('@/actions/invitations')
+
+    await expect(revokeInvitation(INVITATION_ID)).rejects.toThrow(/forbidden/i)
+  })
+
+  it('deletes the invitation row on happy path', async () => {
+    const { revokeInvitation } = await import('@/actions/invitations')
+
+    await revokeInvitation(INVITATION_ID)
+
+    expect(mockDbDeleteWhere).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ── acceptInvitation ───────────────────────────────────────────────────────────
+
+describe('acceptInvitation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Default: db.select returns a valid, unused, non-expired invitation
+    dbSelectRows = [makeInvitation()]
+  })
+
+  it('returns fieldErrors when token is missing', async () => {
+    const { acceptInvitation } = await import('@/actions/invitations')
+    const fd = makeAcceptFormData()
+    fd.delete('token')
+
+    const result = await acceptInvitation(null, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.fieldErrors).toBeDefined()
+  })
+
+  it('returns fieldErrors when password is too short (<12 chars)', async () => {
+    const { acceptInvitation } = await import('@/actions/invitations')
+    const fd = makeAcceptFormData({ password: 'short', confirmPassword: 'short' })
+
+    const result = await acceptInvitation(null, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.fieldErrors).toBeDefined()
+    expect(result.fieldErrors?.password).toBeDefined()
+  })
+
+  it('returns fieldErrors when passwords do not match', async () => {
+    const { acceptInvitation } = await import('@/actions/invitations')
+    const fd = makeAcceptFormData({
+      password:        'SecurePassword!2026',
+      confirmPassword: 'DifferentPassword2026!',
+    })
+
+    const result = await acceptInvitation(null, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.fieldErrors).toBeDefined()
+  })
+
+  it('returns error when invitation token is not found', async () => {
+    dbSelectRows = []  // no invitation row
+    const { acceptInvitation } = await import('@/actions/invitations')
+
+    const result = await acceptInvitation(null, makeAcceptFormData())
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/not found|already used/i)
+  })
+
+  it('returns error when invitation has already been used', async () => {
+    dbSelectRows = [makeInvitation({ usedAt: new Date('2026-01-01') })]
+    const { acceptInvitation } = await import('@/actions/invitations')
+
+    const result = await acceptInvitation(null, makeAcceptFormData())
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/already been used/i)
+  })
+
+  it('returns error when invitation has expired', async () => {
+    dbSelectRows = [makeInvitation({ expiresAt: new Date('2020-01-01') })]
+    const { acceptInvitation } = await import('@/actions/invitations')
+
+    const result = await acceptInvitation(null, makeAcceptFormData())
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/expired/i)
+  })
+
+  it('returns error when email does not match the invitation email', async () => {
+    dbSelectRows = [makeInvitation({ email: 'specific@example.com' })]
+    const { acceptInvitation } = await import('@/actions/invitations')
+    const fd = makeAcceptFormData({ email: 'different@example.com' })
+
+    const result = await acceptInvitation(null, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/different email/i)
+  })
+
+  it('inserts user row, marks invitation used, and returns success on happy path', async () => {
+    const { acceptInvitation } = await import('@/actions/invitations')
+
+    const result = await acceptInvitation(null, makeAcceptFormData())
+
+    expect(result.success).toBe(true)
+    // User inserted via withTenant
+    expect(mockWithTenantInsert).toHaveBeenCalledTimes(1)
+    const userInsert = mockWithTenantInsert.mock.calls[0][0] as Record<string, unknown>
+    expect(userInsert.email).toBe('jane.doe@example.com')
+    expect(userInsert.name).toBe('Jane Doe')
+    expect(userInsert.isActive).toBe(true)
+    // Invitation marked used via db.update
+    expect(mockDbUpdateSet).toHaveBeenCalledTimes(1)
+    const updateArg = mockDbUpdateSet.mock.calls[0][0] as Record<string, unknown>
+    expect(updateArg.usedAt).toBeInstanceOf(Date)
+  })
+
+  it('accepts when invitation has no email restriction (open link)', async () => {
+    dbSelectRows = [makeInvitation({ email: null })]
+    const { acceptInvitation } = await import('@/actions/invitations')
+
+    const result = await acceptInvitation(
+      null,
+      makeAcceptFormData({ email: 'anyone@example.com' })
+    )
+
+    expect(result.success).toBe(true)
+  })
+})
+
+// ── listPendingInvitations ─────────────────────────────────────────────────────
+
+describe('listPendingInvitations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns [] when no tenantId header', async () => {
+    setNoAuthHeaders()
+    const { listPendingInvitations } = await import('@/actions/invitations')
+
+    const result = await listPendingInvitations()
+
+    expect(result).toEqual([])
+  })
+
+  it('returns [] when user is not admin', async () => {
+    setRecruiterHeaders()
+    const { listPendingInvitations } = await import('@/actions/invitations')
+
+    const result = await listPendingInvitations()
+
+    expect(result).toEqual([])
+  })
+
+  it('returns pending invitation list for admin', async () => {
+    setAdminHeaders()
+    dbSelectRows = [makeInvitation(), makeInvitation({ id: 'other-id', token: 'other-token' })]
+    const { listPendingInvitations } = await import('@/actions/invitations')
+
+    const result = await listPendingInvitations()
+
+    // db.select() chain is called — result is whatever db returns (the chain resolves to rows)
+    // The function returns the chain itself (not awaited by caller), so we just verify no throw
+    expect(result).toBeDefined()
+  })
+})

--- a/tests/unit/actions/settings.test.ts
+++ b/tests/unit/actions/settings.test.ts
@@ -1,0 +1,859 @@
+/**
+ * Unit tests for src/actions/settings.ts
+ *
+ * Actions under test:
+ *   saveApiKey              — happy path (encrypted write, upsert), auth guard,
+ *                             role guard, invalid key guard; OAuth key emits
+ *                             settings.oauth_credentials_updated audit.
+ *   removeApiKey            — happy path (delete row), auth guard, role guard,
+ *                             invalid key guard; OAuth key emits
+ *                             settings.oauth_credentials_removed audit.
+ *   getConfiguredKeys       — returns only keys from ALLOWED_KEYS list.
+ *   saveGeneralSetting      — happy path (plain-text upsert), auth guard,
+ *                             role guard, invalid key.
+ *   saveTrustedHosts        — happy path, hostname validation, max-count guard,
+ *                             dedupe, auth guard, role guard.
+ *   saveDefaultPackLanguage — happy path, unsupported language guard, auth guard.
+ *   saveSmtpSetting         — happy path; smtp_pass is encrypted; others plain-text;
+ *                             invalid key guard; auth guard.
+ *   saveNotificationSetting — happy path; webhook URL encrypted; toggle plain-text;
+ *                             auth guard; invalid key guard.
+ *   removeNotificationSetting — happy path, invalid key guard.
+ *   getNotificationSettings — returns defaults when non-admin; reads db when admin.
+ *
+ * Mocks:
+ *   @/db                              — db (direct), withTenant
+ *   @/db/schema                       — tenantSettings, users stubs
+ *   drizzle-orm                       — eq / and / inArray / notInArray
+ *   @/lib/auth/action-context         — getActionContext
+ *   @/lib/audit-middleware            — emitAudit (fire-and-forget)
+ *   @/lib/crypto                      — encrypt / decrypt (no real entropy)
+ *   @/lib/ai/language                 — isSupportedLanguage
+ *   @/lib/email/sender                — getSenderForTenant silenced
+ *   @/lib/notifications/dispatcher   — testWebhookDelivery silenced
+ *   next/cache                        — revalidatePath silenced
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Constants ──────────────────────────────────────────────────────────────────
+
+const TENANT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const USER_ID   = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+
+// ── DB mock helpers ────────────────────────────────────────────────────────────
+
+function makeSelectChain(rows: unknown[]) {
+  const c: Record<string, unknown> = {}
+  const resolved = Promise.resolve(rows)
+  c.then    = resolved.then.bind(resolved)
+  c.catch   = resolved.catch.bind(resolved)
+  c.from    = vi.fn(() => c)
+  c.where   = vi.fn(() => c)
+  c.limit   = vi.fn(() => Promise.resolve(rows))
+  c.orderBy = vi.fn(() => c)
+  return c
+}
+
+// Per-test state
+type SelectFactory = () => ReturnType<typeof makeSelectChain>
+let selectFactory: SelectFactory
+
+// Captured mutation calls
+const mockInsertValues         = vi.fn()
+const mockOnConflictDoUpdate   = vi.fn()
+const mockDeleteWhere          = vi.fn()
+const mockDbSelectRows         = vi.fn().mockReturnValue([])
+
+// ── Module mocks ───────────────────────────────────────────────────────────────
+
+vi.mock('@/db', () => ({
+  db: {
+    select: vi.fn(() => {
+      const rows = mockDbSelectRows()
+      return makeSelectChain(rows)
+    }),
+  },
+  withTenant: vi.fn().mockImplementation(
+    async (_tenantId: string, fn: (tx: unknown) => unknown) => {
+      const tx = {
+        select: vi.fn(() => selectFactory()),
+
+        insert: vi.fn(() => ({
+          values: (...args: unknown[]) => {
+            mockInsertValues(...args)
+            return {
+              onConflictDoUpdate: (...oArgs: unknown[]) => {
+                mockOnConflictDoUpdate(...oArgs)
+                return Promise.resolve()
+              },
+            }
+          },
+        })),
+
+        delete: vi.fn(() => ({
+          where: (...wargs: unknown[]) => {
+            mockDeleteWhere(...wargs)
+            return Promise.resolve()
+          },
+        })),
+      }
+      return fn(tx)
+    }
+  ),
+}))
+
+vi.mock('@/db/schema', () => ({
+  tenantSettings: {
+    tenantId:  'tenant_id',
+    key:       'key',
+    value:     'value',
+    updatedBy: 'updated_by',
+    updatedAt: 'updated_at',
+  },
+  users: {
+    id:    'id',
+    email: 'email',
+    name:  'name',
+  },
+}))
+
+vi.mock('drizzle-orm', () => ({
+  eq:        vi.fn(() => ({ type: 'eq' })),
+  and:       vi.fn((...args: unknown[]) => ({ type: 'and', args })),
+  inArray:   vi.fn(() => ({ type: 'inArray' })),
+  notInArray: vi.fn(() => ({ type: 'notInArray' })),
+  or:        vi.fn((...args: unknown[]) => ({ type: 'or', args })),
+}))
+
+const mockGetActionContext = vi.fn()
+vi.mock('@/lib/auth/action-context', () => ({
+  getActionContext: () => mockGetActionContext(),
+}))
+
+const mockEmitAudit = vi.fn()
+vi.mock('@/lib/audit-middleware', () => ({
+  emitAudit: (...args: unknown[]) => mockEmitAudit(...args),
+}))
+
+// encrypt returns a deterministic stub; decrypt reverses it
+const mockEncrypt = vi.fn((v: string) => `enc:${v}`)
+const mockDecrypt = vi.fn((v: string) => v.replace(/^enc:/, ''))
+vi.mock('@/lib/crypto', () => ({
+  encrypt: (v: string) => mockEncrypt(v),
+  decrypt: (v: string) => mockDecrypt(v),
+}))
+
+// isSupportedLanguage — real list: en, pl, de, fr, es, it, pt, nl, cs, sv
+vi.mock('@/lib/ai/language', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/ai/language')>()
+  return { isSupportedLanguage: actual.isSupportedLanguage }
+})
+
+vi.mock('@/lib/email/sender', () => ({
+  getSenderForTenant: vi.fn().mockResolvedValue(null),
+}))
+
+vi.mock('@/lib/notifications/dispatcher', () => ({
+  testWebhookDelivery: vi.fn().mockResolvedValue({
+    slack: { configured: false, ok: false },
+    teams: { configured: false, ok: false },
+  }),
+}))
+
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function adminCtx() {
+  return { tenantId: TENANT_ID, userId: USER_ID, userRole: 'admin' as const }
+}
+
+function recruiterCtx() {
+  return { tenantId: TENANT_ID, userId: USER_ID, userRole: 'recruiter' as const }
+}
+
+function makeSettingFormData(key: string, value: string): FormData {
+  const fd = new FormData()
+  fd.set('key', key)
+  fd.set('value', value)
+  return fd
+}
+
+// ── saveApiKey ─────────────────────────────────────────────────────────────────
+
+describe('saveApiKey', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetActionContext.mockResolvedValue(adminCtx())
+    selectFactory = () => makeSelectChain([])
+  })
+
+  it('returns Unauthorized when no action context', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { saveApiKey } = await import('@/actions/settings')
+
+    const result = await saveApiKey(null, makeSettingFormData('anthropic_api_key', 'sk-ant-test'))
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/unauthorized/i)
+  })
+
+  it('returns error when user is recruiter (not admin)', async () => {
+    mockGetActionContext.mockResolvedValue(recruiterCtx())
+    const { saveApiKey } = await import('@/actions/settings')
+
+    const result = await saveApiKey(null, makeSettingFormData('anthropic_api_key', 'sk-ant-test'))
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/admin/i)
+  })
+
+  it('returns error when key is not in ALLOWED_KEYS', async () => {
+    const { saveApiKey } = await import('@/actions/settings')
+
+    const result = await saveApiKey(null, makeSettingFormData('evil_key', 'value'))
+
+    expect(result.success).toBe(false)
+  })
+
+  it('returns error when value is empty', async () => {
+    const { saveApiKey } = await import('@/actions/settings')
+
+    const result = await saveApiKey(null, makeSettingFormData('anthropic_api_key', ''))
+
+    expect(result.success).toBe(false)
+  })
+
+  it('encrypts value before upsert on happy path', async () => {
+    const { saveApiKey } = await import('@/actions/settings')
+
+    const result = await saveApiKey(null, makeSettingFormData('anthropic_api_key', 'sk-ant-realkey'))
+
+    expect(result.success).toBe(true)
+    expect(mockEncrypt).toHaveBeenCalledWith('sk-ant-realkey')
+    expect(mockInsertValues).toHaveBeenCalledTimes(1)
+    const insertArg = mockInsertValues.mock.calls[0][0] as Record<string, unknown>
+    expect(insertArg.value).toBe('enc:sk-ant-realkey')
+    expect(insertArg.tenantId).toBe(TENANT_ID)
+    expect(insertArg.key).toBe('anthropic_api_key')
+    // onConflictDoUpdate called to implement upsert
+    expect(mockOnConflictDoUpdate).toHaveBeenCalledTimes(1)
+  })
+
+  it('emits settings.oauth_credentials_updated audit for google_oauth_client_id', async () => {
+    const { saveApiKey } = await import('@/actions/settings')
+
+    await saveApiKey(null, makeSettingFormData('google_oauth_client_id', 'client-id-value'))
+
+    expect(mockEmitAudit).toHaveBeenCalledWith(
+      TENANT_ID,
+      expect.objectContaining({
+        action: 'settings.oauth_credentials_updated',
+        metadata: expect.objectContaining({ provider: 'google', field: 'client_id' }),
+      })
+    )
+  })
+
+  it('emits settings.oauth_credentials_updated audit for microsoft_oauth_client_secret', async () => {
+    const { saveApiKey } = await import('@/actions/settings')
+
+    await saveApiKey(null, makeSettingFormData('microsoft_oauth_client_secret', 'secret-val'))
+
+    expect(mockEmitAudit).toHaveBeenCalledWith(
+      TENANT_ID,
+      expect.objectContaining({
+        action: 'settings.oauth_credentials_updated',
+        metadata: expect.objectContaining({ provider: 'microsoft', field: 'client_secret' }),
+      })
+    )
+  })
+
+  it('does NOT emit OAuth audit for non-OAuth keys (anthropic_api_key)', async () => {
+    const { saveApiKey } = await import('@/actions/settings')
+
+    await saveApiKey(null, makeSettingFormData('anthropic_api_key', 'sk-ant-key'))
+
+    expect(mockEmitAudit).not.toHaveBeenCalled()
+  })
+})
+
+// ── removeApiKey ───────────────────────────────────────────────────────────────
+
+describe('removeApiKey', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetActionContext.mockResolvedValue(adminCtx())
+    selectFactory = () => makeSelectChain([])
+  })
+
+  it('returns Unauthorized when no action context', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { removeApiKey } = await import('@/actions/settings')
+
+    const result = await removeApiKey(null, makeSettingFormData('anthropic_api_key', ''))
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/unauthorized/i)
+  })
+
+  it('returns error when user is recruiter', async () => {
+    mockGetActionContext.mockResolvedValue(recruiterCtx())
+    const { removeApiKey } = await import('@/actions/settings')
+
+    const result = await removeApiKey(null, makeSettingFormData('anthropic_api_key', ''))
+
+    expect(result.success).toBe(false)
+  })
+
+  it('returns error for unknown key', async () => {
+    const { removeApiKey } = await import('@/actions/settings')
+
+    const result = await removeApiKey(null, makeSettingFormData('not_a_key', ''))
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/invalid key/i)
+  })
+
+  it('deletes the setting row on happy path', async () => {
+    const { removeApiKey } = await import('@/actions/settings')
+
+    const result = await removeApiKey(null, makeSettingFormData('openai_api_key', ''))
+
+    expect(result.success).toBe(true)
+    expect(mockDeleteWhere).toHaveBeenCalledTimes(1)
+  })
+
+  it('emits settings.oauth_credentials_removed audit for OAuth keys', async () => {
+    const { removeApiKey } = await import('@/actions/settings')
+
+    await removeApiKey(null, makeSettingFormData('google_oauth_client_secret', ''))
+
+    expect(mockEmitAudit).toHaveBeenCalledWith(
+      TENANT_ID,
+      expect.objectContaining({
+        action: 'settings.oauth_credentials_removed',
+        metadata: expect.objectContaining({ provider: 'google', field: 'client_secret' }),
+      })
+    )
+  })
+})
+
+// ── getConfiguredKeys ──────────────────────────────────────────────────────────
+
+describe('getConfiguredKeys', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns only ALLOWED_KEYS that are present', async () => {
+    selectFactory = () =>
+      makeSelectChain([
+        { key: 'anthropic_api_key' },
+        { key: 'openai_api_key' },
+        { key: 'unknown_key' }, // should be filtered out
+      ])
+    const { getConfiguredKeys } = await import('@/actions/settings')
+
+    const result = await getConfiguredKeys(TENANT_ID)
+
+    expect(result).toContain('anthropic_api_key')
+    expect(result).toContain('openai_api_key')
+    expect(result).not.toContain('unknown_key')
+  })
+
+  it('returns empty array when no keys configured', async () => {
+    selectFactory = () => makeSelectChain([])
+    const { getConfiguredKeys } = await import('@/actions/settings')
+
+    const result = await getConfiguredKeys(TENANT_ID)
+
+    expect(result).toEqual([])
+  })
+})
+
+// ── saveGeneralSetting ─────────────────────────────────────────────────────────
+
+describe('saveGeneralSetting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetActionContext.mockResolvedValue(adminCtx())
+    selectFactory = () => makeSelectChain([])
+  })
+
+  it('returns Unauthorized when no action context', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { saveGeneralSetting } = await import('@/actions/settings')
+    const fd = new FormData()
+    fd.set('value', 'claude-sonnet-4-6')
+
+    const result = await saveGeneralSetting('default_ai_model', null, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/unauthorized/i)
+  })
+
+  it('returns error when user is recruiter', async () => {
+    mockGetActionContext.mockResolvedValue(recruiterCtx())
+    const { saveGeneralSetting } = await import('@/actions/settings')
+    const fd = new FormData()
+    fd.set('value', 'claude-sonnet-4-6')
+
+    const result = await saveGeneralSetting('default_ai_model', null, fd)
+
+    expect(result.success).toBe(false)
+  })
+
+  it('stores plain-text value (not encrypted) on happy path', async () => {
+    const { saveGeneralSetting } = await import('@/actions/settings')
+    const fd = new FormData()
+    fd.set('value', 'claude-sonnet-4-6')
+
+    const result = await saveGeneralSetting('default_ai_model', null, fd)
+
+    expect(result.success).toBe(true)
+    expect(mockEncrypt).not.toHaveBeenCalled()
+    const insertArg = mockInsertValues.mock.calls[0][0] as Record<string, unknown>
+    expect(insertArg.value).toBe('claude-sonnet-4-6')
+  })
+})
+
+// ── saveTrustedHosts ───────────────────────────────────────────────────────────
+
+describe('saveTrustedHosts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetActionContext.mockResolvedValue(adminCtx())
+    // Default: getTrustedHosts reads empty (no existing setting)
+    selectFactory = () => makeSelectChain([])
+  })
+
+  it('returns Unauthorized when no action context', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { saveTrustedHosts } = await import('@/actions/settings')
+
+    const result = await saveTrustedHosts(['example.com'])
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/unauthorized/i)
+  })
+
+  it('returns error for non-admin role', async () => {
+    mockGetActionContext.mockResolvedValue(recruiterCtx())
+    const { saveTrustedHosts } = await import('@/actions/settings')
+
+    const result = await saveTrustedHosts(['example.com'])
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/admin/i)
+  })
+
+  it('returns error when a hostname is invalid', async () => {
+    const { saveTrustedHosts } = await import('@/actions/settings')
+
+    const result = await saveTrustedHosts(['not a valid hostname!'])
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/invalid hostname/i)
+  })
+
+  it('returns error when hostname exceeds max length', async () => {
+    const { saveTrustedHosts } = await import('@/actions/settings')
+    const longHost = 'a'.repeat(254) + '.com'
+
+    const result = await saveTrustedHosts([longHost])
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/too long/i)
+  })
+
+  it('returns error when more than 20 hosts are provided', async () => {
+    const { saveTrustedHosts } = await import('@/actions/settings')
+    const hosts = Array.from({ length: 21 }, (_, i) => `host${i}.example.com`)
+
+    const result = await saveTrustedHosts(hosts)
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/20/i)
+  })
+
+  it('deduplicates hostnames (case-insensitive)', async () => {
+    const { saveTrustedHosts } = await import('@/actions/settings')
+
+    const result = await saveTrustedHosts(['Example.com', 'example.com', 'EXAMPLE.COM'])
+
+    expect(result.success).toBe(true)
+    expect(mockInsertValues).toHaveBeenCalledTimes(1)
+    const insertArg = mockInsertValues.mock.calls[0][0] as Record<string, unknown>
+    const stored = JSON.parse(insertArg.value as string) as string[]
+    expect(stored).toHaveLength(1)
+    expect(stored[0]).toBe('example.com')
+  })
+
+  it('upserts JSON-serialised host list on happy path', async () => {
+    const { saveTrustedHosts } = await import('@/actions/settings')
+
+    const result = await saveTrustedHosts(['app.example.com', 'api.example.com'])
+
+    expect(result.success).toBe(true)
+    expect(mockInsertValues).toHaveBeenCalledTimes(1)
+    const insertArg = mockInsertValues.mock.calls[0][0] as Record<string, unknown>
+    const stored = JSON.parse(insertArg.value as string) as string[]
+    expect(stored).toContain('app.example.com')
+    expect(stored).toContain('api.example.com')
+  })
+
+  it('emits audit when hosts change', async () => {
+    // Simulate previous hosts = ['old.example.com']
+    let selectCallCount = 0
+    selectFactory = () => {
+      selectCallCount++
+      if (selectCallCount === 1) {
+        return makeSelectChain([{ value: JSON.stringify(['old.example.com']) }])
+      }
+      return makeSelectChain([])
+    }
+    const { saveTrustedHosts } = await import('@/actions/settings')
+
+    await saveTrustedHosts(['new.example.com'])
+
+    expect(mockEmitAudit).toHaveBeenCalledWith(
+      TENANT_ID,
+      expect.objectContaining({ action: 'settings.trusted_hosts_updated' })
+    )
+  })
+})
+
+// ── saveDefaultPackLanguage ────────────────────────────────────────────────────
+
+describe('saveDefaultPackLanguage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetActionContext.mockResolvedValue(adminCtx())
+    selectFactory = () => makeSelectChain([])
+  })
+
+  it('returns Unauthorized when no action context', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { saveDefaultPackLanguage } = await import('@/actions/settings')
+
+    const result = await saveDefaultPackLanguage('en')
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/unauthorized/i)
+  })
+
+  it('returns error for unsupported language code', async () => {
+    const { saveDefaultPackLanguage } = await import('@/actions/settings')
+
+    const result = await saveDefaultPackLanguage('klingon')
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/unsupported/i)
+  })
+
+  it('saves supported language code as plain text', async () => {
+    const { saveDefaultPackLanguage } = await import('@/actions/settings')
+
+    const result = await saveDefaultPackLanguage('de')
+
+    expect(result.success).toBe(true)
+    expect(mockEncrypt).not.toHaveBeenCalled()
+    const insertArg = mockInsertValues.mock.calls[0][0] as Record<string, unknown>
+    expect(insertArg.value).toBe('de')
+  })
+
+  it('emits audit when language changes', async () => {
+    // First selectFactory call for getDefaultPackLanguage = returns 'en'
+    let count = 0
+    selectFactory = () => {
+      count++
+      return count === 1
+        ? makeSelectChain([{ value: 'en' }])
+        : makeSelectChain([])
+    }
+    const { saveDefaultPackLanguage } = await import('@/actions/settings')
+
+    await saveDefaultPackLanguage('de')
+
+    expect(mockEmitAudit).toHaveBeenCalledWith(
+      TENANT_ID,
+      expect.objectContaining({ action: 'settings.default_pack_language_updated' })
+    )
+  })
+
+  it('does NOT emit audit when language is unchanged', async () => {
+    selectFactory = () => makeSelectChain([{ value: 'en' }])
+    const { saveDefaultPackLanguage } = await import('@/actions/settings')
+
+    await saveDefaultPackLanguage('en')
+
+    expect(mockEmitAudit).not.toHaveBeenCalled()
+  })
+})
+
+// ── saveSmtpSetting ────────────────────────────────────────────────────────────
+
+describe('saveSmtpSetting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetActionContext.mockResolvedValue(adminCtx())
+    selectFactory = () => makeSelectChain([])
+  })
+
+  it('returns Unauthorized when no action context', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { saveSmtpSetting } = await import('@/actions/settings')
+
+    const result = await saveSmtpSetting('smtp_host', 'smtp.example.com')
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/unauthorized/i)
+  })
+
+  it('returns error for unknown SMTP key', async () => {
+    const { saveSmtpSetting } = await import('@/actions/settings')
+
+    const result = await saveSmtpSetting('not_smtp_key', 'value')
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/invalid/i)
+  })
+
+  it('returns error when value is empty', async () => {
+    const { saveSmtpSetting } = await import('@/actions/settings')
+
+    const result = await saveSmtpSetting('smtp_host', '')
+
+    expect(result.success).toBe(false)
+  })
+
+  it('stores smtp_host as plain text (not encrypted)', async () => {
+    const { saveSmtpSetting } = await import('@/actions/settings')
+
+    const result = await saveSmtpSetting('smtp_host', 'smtp.example.com')
+
+    expect(result.success).toBe(true)
+    expect(mockEncrypt).not.toHaveBeenCalled()
+    const insertArg = mockInsertValues.mock.calls[0][0] as Record<string, unknown>
+    expect(insertArg.value).toBe('smtp.example.com')
+  })
+
+  it('encrypts smtp_pass before storing', async () => {
+    const { saveSmtpSetting } = await import('@/actions/settings')
+
+    const result = await saveSmtpSetting('smtp_pass', 'super-secret-pass')
+
+    expect(result.success).toBe(true)
+    expect(mockEncrypt).toHaveBeenCalledWith('super-secret-pass')
+    const insertArg = mockInsertValues.mock.calls[0][0] as Record<string, unknown>
+    expect(insertArg.value).toBe('enc:super-secret-pass')
+  })
+
+  it('emits settings.smtp_updated audit on save', async () => {
+    const { saveSmtpSetting } = await import('@/actions/settings')
+
+    await saveSmtpSetting('smtp_port', '587')
+
+    expect(mockEmitAudit).toHaveBeenCalledWith(
+      TENANT_ID,
+      expect.objectContaining({
+        action: 'settings.smtp_updated',
+        metadata: expect.objectContaining({ key: 'smtp_port' }),
+      })
+    )
+  })
+})
+
+// ── saveNotificationSetting ────────────────────────────────────────────────────
+
+describe('saveNotificationSetting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetActionContext.mockResolvedValue(adminCtx())
+    selectFactory = () => makeSelectChain([])
+  })
+
+  it('returns Unauthorized when no action context', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { saveNotificationSetting } = await import('@/actions/settings')
+
+    const result = await saveNotificationSetting('notify_high_score_enabled', 'true')
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/unauthorized/i)
+  })
+
+  it('returns error for non-admin role', async () => {
+    mockGetActionContext.mockResolvedValue(recruiterCtx())
+    const { saveNotificationSetting } = await import('@/actions/settings')
+
+    const result = await saveNotificationSetting('notify_high_score_enabled', 'true')
+
+    expect(result.success).toBe(false)
+  })
+
+  it('returns error for unknown notification key', async () => {
+    const { saveNotificationSetting } = await import('@/actions/settings')
+
+    const result = await saveNotificationSetting('invalid_key', 'value')
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/invalid/i)
+  })
+
+  it('stores toggle key as plain text (not encrypted)', async () => {
+    const { saveNotificationSetting } = await import('@/actions/settings')
+
+    const result = await saveNotificationSetting('notify_high_score_enabled', 'true')
+
+    expect(result.success).toBe(true)
+    expect(mockEncrypt).not.toHaveBeenCalled()
+    const insertArg = mockInsertValues.mock.calls[0][0] as Record<string, unknown>
+    expect(insertArg.value).toBe('true')
+  })
+
+  it('encrypts slack_webhook_url before storing', async () => {
+    const { saveNotificationSetting } = await import('@/actions/settings')
+
+    const result = await saveNotificationSetting(
+      'slack_webhook_url',
+      'https://hooks.slack.com/services/T000/B000/secret'
+    )
+
+    expect(result.success).toBe(true)
+    expect(mockEncrypt).toHaveBeenCalledWith(
+      'https://hooks.slack.com/services/T000/B000/secret'
+    )
+    const insertArg = mockInsertValues.mock.calls[0][0] as Record<string, unknown>
+    expect(insertArg.value).toMatch(/^enc:/)
+  })
+
+  it('encrypts teams_webhook_url before storing', async () => {
+    const { saveNotificationSetting } = await import('@/actions/settings')
+
+    const result = await saveNotificationSetting(
+      'teams_webhook_url',
+      'https://outlook.office.com/webhook/xxx/IncomingWebhook/yyy'
+    )
+
+    expect(result.success).toBe(true)
+    expect(mockEncrypt).toHaveBeenCalledTimes(1)
+  })
+
+  it('emits settings.notification_updated audit on save', async () => {
+    const { saveNotificationSetting } = await import('@/actions/settings')
+
+    await saveNotificationSetting('notify_score_threshold', '90')
+
+    expect(mockEmitAudit).toHaveBeenCalledWith(
+      TENANT_ID,
+      expect.objectContaining({
+        action: 'settings.notification_updated',
+        metadata: expect.objectContaining({ key: 'notify_score_threshold' }),
+      })
+    )
+  })
+})
+
+// ── removeNotificationSetting ──────────────────────────────────────────────────
+
+describe('removeNotificationSetting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetActionContext.mockResolvedValue(adminCtx())
+    selectFactory = () => makeSelectChain([])
+  })
+
+  it('returns error for unknown key', async () => {
+    const { removeNotificationSetting } = await import('@/actions/settings')
+
+    const result = await removeNotificationSetting('bad_key')
+
+    expect(result.success).toBe(false)
+    expect((result as { success: false; error: string }).error).toMatch(/invalid/i)
+  })
+
+  it('deletes the notification setting row on happy path', async () => {
+    const { removeNotificationSetting } = await import('@/actions/settings')
+
+    const result = await removeNotificationSetting('slack_webhook_url')
+
+    expect(result.success).toBe(true)
+    expect(mockDeleteWhere).toHaveBeenCalledTimes(1)
+  })
+
+  it('emits settings.notification_updated audit with removed=true', async () => {
+    const { removeNotificationSetting } = await import('@/actions/settings')
+
+    await removeNotificationSetting('teams_webhook_url')
+
+    expect(mockEmitAudit).toHaveBeenCalledWith(
+      TENANT_ID,
+      expect.objectContaining({
+        action: 'settings.notification_updated',
+        metadata: expect.objectContaining({ removed: true }),
+      })
+    )
+  })
+})
+
+// ── getNotificationSettings ────────────────────────────────────────────────────
+
+describe('getNotificationSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns fallback defaults when no action context', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { getNotificationSettings } = await import('@/actions/settings')
+
+    const result = await getNotificationSettings()
+
+    expect(result.slack_webhook_configured).toBe(false)
+    expect(result.teams_webhook_configured).toBe(false)
+    expect(result.notify_high_score_enabled).toBe(true)
+    expect(result.notify_score_threshold).toBe(85)
+  })
+
+  it('returns fallback defaults when user is recruiter (non-admin)', async () => {
+    mockGetActionContext.mockResolvedValue(recruiterCtx())
+    const { getNotificationSettings } = await import('@/actions/settings')
+
+    const result = await getNotificationSettings()
+
+    expect(result.slack_webhook_configured).toBe(false)
+  })
+
+  it('returns configured=true for webhooks that exist in DB', async () => {
+    mockGetActionContext.mockResolvedValue(adminCtx())
+    selectFactory = () =>
+      makeSelectChain([
+        { key: 'slack_webhook_url',                value: 'enc:https://hooks.slack.com/...' },
+        { key: 'notify_high_score_enabled',         value: 'false' },
+        { key: 'notify_score_threshold',            value: '92' },
+      ])
+    const { getNotificationSettings } = await import('@/actions/settings')
+
+    const result = await getNotificationSettings()
+
+    expect(result.slack_webhook_configured).toBe(true)
+    expect(result.teams_webhook_configured).toBe(false)
+    expect(result.notify_high_score_enabled).toBe(false)
+    expect(result.notify_score_threshold).toBe(92)
+  })
+
+  it('uses parseInt default (85) when score threshold is not a valid number', async () => {
+    mockGetActionContext.mockResolvedValue(adminCtx())
+    selectFactory = () =>
+      makeSelectChain([
+        { key: 'notify_score_threshold', value: 'not-a-number' },
+      ])
+    const { getNotificationSettings } = await import('@/actions/settings')
+
+    const result = await getNotificationSettings()
+
+    expect(result.notify_score_threshold).toBe(85)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds **102 unit tests** across three server action modules, following the PR #179 mock pattern (makeSelectChain, vi.mock with captured mutation fns, dynamic import per-test)
- No production code changed; all tests are mock-heavy and run in < 1.5 s total
- Closes coverage gap for calendar slot management, user invitations, and tenant settings CRUD

## Test count by file

| File | Tests | Actions covered |
|------|-------|-----------------|
| `tests/unit/actions/calendar.test.ts` | 30 | createInterviewSlot, updateInterviewSlot, cancelInterviewSlot, disconnectCalendar, getCalendarConnections, importIcsSlots |
| `tests/unit/actions/invitations.test.ts` | 20 | createInvitation, revokeInvitation, acceptInvitation, listPendingInvitations |
| `tests/unit/actions/settings.test.ts` | 52 | saveApiKey, removeApiKey, getConfiguredKeys, saveGeneralSetting, saveTrustedHosts, saveDefaultPackLanguage, saveSmtpSetting, saveNotificationSetting, removeNotificationSetting, getNotificationSettings |
| **Total** | **102** | |

## Scenarios skipped and reasons

| Scenario | Reason |
|----------|--------|
| `resendInvitation` | Function does not exist in `src/actions/invitations.ts` — no such export found during source review |
| `sendSmtpTestEmail` happy path with real delivery | Would require a working SMTP sender mock with nodemailer internals; deferred — a dedicated SMTP test can be added when the transport layer is abstracted |
| `testNotificationDelivery` webhook round-trip | Requires mocking external HTTP POST; covered at the action boundary (auth + key lookup) but not end-to-end delivery |

## Mock strategy notes

- `@/lib/crypto` `encrypt`/`decrypt` mocked as `enc:${v}` prefix so tests don't need real AES entropy
- `settings.ts` uses `emitAudit` from `@/lib/audit-middleware` (fire-and-forget), NOT `writeAuditLog` — mocked accordingly
- `invitations.ts` uses `headers()` from `next/headers` for createInvitation/listPendingInvitations and `auth()` from `@/lib/auth` for revokeInvitation — different from the `getActionContext` pattern used elsewhere
- Zod v4 UUID RFC 4122 variant bits enforced: all test UUIDs use `[89ab]` in 17th char position (e.g. `xxxxxxxx-xxxx-4xxx-8xxx-xxxxxxxxxxxx`)

## Test plan

- [x] `npm test` (all 102 new tests + full 618-test suite) passes green
- [x] `npx tsc --noEmit` exits 0 (no TypeScript errors)
- [x] No production code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)