### PR TITLE
feat(schema): add EU/UK compliance fields to candidates (closes #191)

### DIFF
--- a/src/db/migrations/0029_compliance_fields.sql
+++ b/src/db/migrations/0029_compliance_fields.sql
@@ -1,0 +1,47 @@
+-- Migration: EU/UK right-to-work + compliance fields on candidates (issue #191)
+-- Part of Epic #190.
+--
+-- Purely additive: 3 new pg-enums + 11 new nullable columns (except
+-- sponsorship_required which is NOT NULL DEFAULT false — safe because
+-- existing rows get the false default immediately on ALTER TABLE).
+--
+-- Uses IF NOT EXISTS / DO $$ ... $$ guards so re-running the migration
+-- is idempotent.
+
+-- 1. New enums
+DO $$ BEGIN
+  CREATE TYPE "public"."right_to_work_status"
+    AS ENUM ('checked', 'pending', 'fail', 'exempted', 'not_required');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE "public"."right_to_work_document_type"
+    AS ENUM (
+      'passport_uk', 'passport_eu', 'passport_other',
+      'brp', 'share_code', 'visa',
+      'settled_status', 'presettled_status', 'other'
+    );
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE "public"."gdpr_processing_consent_by"
+    AS ENUM ('candidate', 'recruiter', 'agency');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;
+
+-- 2. New columns on candidates
+ALTER TABLE "candidates"
+  ADD COLUMN IF NOT EXISTS "right_to_work_status"       "right_to_work_status",
+  ADD COLUMN IF NOT EXISTS "right_to_work_document_type" "right_to_work_document_type",
+  ADD COLUMN IF NOT EXISTS "right_to_work_expiry"        date,
+  ADD COLUMN IF NOT EXISTS "right_to_work_checked_at"    timestamp with time zone,
+  ADD COLUMN IF NOT EXISTS "right_to_work_checked_by"    uuid
+    REFERENCES "users"("id") ON DELETE NO ACTION,
+  ADD COLUMN IF NOT EXISTS "share_code"                  varchar(20),
+  ADD COLUMN IF NOT EXISTS "sponsorship_required"        boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS "nationality"                 varchar(100),
+  ADD COLUMN IF NOT EXISTS "notice_period_days"          integer,
+  ADD COLUMN IF NOT EXISTS "gdpr_processing_consent_at"  timestamp with time zone,
+  ADD COLUMN IF NOT EXISTS "gdpr_processing_consent_by"  "gdpr_processing_consent_by";

--- a/src/db/schema/candidates.ts
+++ b/src/db/schema/candidates.ts
@@ -8,6 +8,7 @@ import {
   boolean,
   timestamp,
   numeric,
+  integer,
   index,
   date,
   jsonb,
@@ -40,6 +41,41 @@ export const availabilityStatusEnum = pgEnum('availability_status', [
 ])
 
 export type AvailabilityStatus = (typeof availabilityStatusEnum.enumValues)[number]
+
+// EU/UK right-to-work check status
+export const rightToWorkStatusEnum = pgEnum('right_to_work_status', [
+  'checked',
+  'pending',
+  'fail',
+  'exempted',
+  'not_required',
+])
+
+export type RightToWorkStatus = (typeof rightToWorkStatusEnum.enumValues)[number]
+
+// Acceptable right-to-work document types
+export const rightToWorkDocumentTypeEnum = pgEnum('right_to_work_document_type', [
+  'passport_uk',
+  'passport_eu',
+  'passport_other',
+  'brp',
+  'share_code',
+  'visa',
+  'settled_status',
+  'presettled_status',
+  'other',
+])
+
+export type RightToWorkDocumentType = (typeof rightToWorkDocumentTypeEnum.enumValues)[number]
+
+// Who provided GDPR processing consent
+export const gdprProcessingConsentByEnum = pgEnum('gdpr_processing_consent_by', [
+  'candidate',
+  'recruiter',
+  'agency',
+])
+
+export type GdprProcessingConsentBy = (typeof gdprProcessingConsentByEnum.enumValues)[number]
 
 export const candidates = pgTable(
   'candidates',
@@ -78,6 +114,19 @@ export const candidates = pgTable(
     synechronCvData: jsonb('synechron_cv_data'),
     synechronCandidateId: varchar('synechron_candidate_id', { length: 64 }),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+
+    // EU/UK right-to-work + compliance fields (all nullable — non-destructive addition)
+    rightToWorkStatus: rightToWorkStatusEnum('right_to_work_status'),
+    rightToWorkDocumentType: rightToWorkDocumentTypeEnum('right_to_work_document_type'),
+    rightToWorkExpiry: date('right_to_work_expiry'),
+    rightToWorkCheckedAt: timestamp('right_to_work_checked_at', { withTimezone: true }),
+    rightToWorkCheckedBy: uuid('right_to_work_checked_by').references(() => users.id),
+    shareCode: varchar('share_code', { length: 20 }),
+    sponsorshipRequired: boolean('sponsorship_required').notNull().default(false),
+    nationality: varchar('nationality', { length: 100 }),
+    noticePeriodDays: integer('notice_period_days'),
+    gdprProcessingConsentAt: timestamp('gdpr_processing_consent_at', { withTimezone: true }),
+    gdprProcessingConsentBy: gdprProcessingConsentByEnum('gdpr_processing_consent_by'),
   },
   (t) => [
     index('idx_candidates_tenant').on(t.tenantId),


### PR DESCRIPTION
## Summary

Part of Epic #190. Closes #191.

Adds 3 new pg-enums and 11 new columns to the `candidates` table to support EU/UK right-to-work checks and GDPR processing consent tracking. All additions are **purely non-destructive** — every column is nullable (except `sponsorship_required` which is `NOT NULL DEFAULT false`, safe because the default is backfilled immediately on `ALTER TABLE`).

### New pg-enums

| Enum | Values |
|---|---|
| `right_to_work_status` | `checked`, `pending`, `fail`, `exempted`, `not_required` |
| `right_to_work_document_type` | `passport_uk`, `passport_eu`, `passport_other`, `brp`, `share_code`, `visa`, `settled_status`, `presettled_status`, `other` |
| `gdpr_processing_consent_by` | `candidate`, `recruiter`, `agency` |

### New columns on `candidates`

| Column | Type | Nullable |
|---|---|---|
| `right_to_work_status` | enum | yes |
| `right_to_work_document_type` | enum | yes |
| `right_to_work_expiry` | date | yes |
| `right_to_work_checked_at` | timestamptz | yes |
| `right_to_work_checked_by` | uuid FK → users.id | yes |
| `share_code` | varchar(20) | yes |
| `sponsorship_required` | boolean NOT NULL | default false |
| `nationality` | varchar(100) | yes |
| `notice_period_days` | integer | yes |
| `gdpr_processing_consent_at` | timestamptz | yes |
| `gdpr_processing_consent_by` | enum | yes |

### Migration: `src/db/migrations/0029_compliance_fields.sql`

- Idempotent: enum creation wrapped in `DO $$ BEGIN ... EXCEPTION WHEN duplicate_object THEN null END $$`; columns use `ADD COLUMN IF NOT EXISTS`
- **Zero destructive statements** — no `DROP`, `TRUNCATE`, `RENAME` anywhere
- Follows the hand-written migration convention established for migrations after `0012`
- Applied via the existing `migrate` service in compose — **do not run `drizzle-kit push` against live DB**

## Test plan

- [ ] Review `src/db/schema/candidates.ts` diff — 3 enum exports + 11 column additions, `integer` import added
- [ ] Review `src/db/migrations/0029_compliance_fields.sql` — confirm purely additive, no DROP statements
- [ ] CI: `npm test` passes (no test files changed; existing tests unaffected)
- [ ] CI: `tsc --noEmit` passes (new columns are all nullable optionals in the inferred type)
- [ ] CI: `npm run build` passes
- [ ] Apply migration via migrate service on a staging/test DB before touching live portal

🤖 Generated with [Claude Code](https://claude.com/claude-code)