### PR TITLE
feat(export): audience-gated compliance section in PDF + DSAR

### DIFF
--- a/src/db/schema/candidates.ts
+++ b/src/db/schema/candidates.ts
@@ -8,6 +8,7 @@ import {
   boolean,
   timestamp,
   numeric,
+  integer,
   index,
   date,
   jsonb,
@@ -40,6 +41,41 @@ export const availabilityStatusEnum = pgEnum('availability_status', [
 ])
 
 export type AvailabilityStatus = (typeof availabilityStatusEnum.enumValues)[number]
+
+// EU/UK right-to-work check status
+export const rightToWorkStatusEnum = pgEnum('right_to_work_status', [
+  'checked',
+  'pending',
+  'fail',
+  'exempted',
+  'not_required',
+])
+
+export type RightToWorkStatus = (typeof rightToWorkStatusEnum.enumValues)[number]
+
+// Acceptable right-to-work document types
+export const rightToWorkDocumentTypeEnum = pgEnum('right_to_work_document_type', [
+  'passport_uk',
+  'passport_eu',
+  'passport_other',
+  'brp',
+  'share_code',
+  'visa',
+  'settled_status',
+  'presettled_status',
+  'other',
+])
+
+export type RightToWorkDocumentType = (typeof rightToWorkDocumentTypeEnum.enumValues)[number]
+
+// Who provided GDPR processing consent
+export const gdprProcessingConsentByEnum = pgEnum('gdpr_processing_consent_by', [
+  'candidate',
+  'recruiter',
+  'agency',
+])
+
+export type GdprProcessingConsentBy = (typeof gdprProcessingConsentByEnum.enumValues)[number]
 
 export const candidates = pgTable(
   'candidates',
@@ -78,6 +114,19 @@ export const candidates = pgTable(
     synechronCvData: jsonb('synechron_cv_data'),
     synechronCandidateId: varchar('synechron_candidate_id', { length: 64 }),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+
+    // EU/UK right-to-work + compliance fields (all nullable — non-destructive addition)
+    rightToWorkStatus: rightToWorkStatusEnum('right_to_work_status'),
+    rightToWorkDocumentType: rightToWorkDocumentTypeEnum('right_to_work_document_type'),
+    rightToWorkExpiry: date('right_to_work_expiry'),
+    rightToWorkCheckedAt: timestamp('right_to_work_checked_at', { withTimezone: true }),
+    rightToWorkCheckedBy: uuid('right_to_work_checked_by').references(() => users.id),
+    shareCode: varchar('share_code', { length: 20 }),
+    sponsorshipRequired: boolean('sponsorship_required').notNull().default(false),
+    nationality: varchar('nationality', { length: 100 }),
+    noticePeriodDays: integer('notice_period_days'),
+    gdprProcessingConsentAt: timestamp('gdpr_processing_consent_at', { withTimezone: true }),
+    gdprProcessingConsentBy: gdprProcessingConsentByEnum('gdpr_processing_consent_by'),
   },
   (t) => [
     index('idx_candidates_tenant').on(t.tenantId),

--- a/src/lib/pdf/candidate-pdf.tsx
+++ b/src/lib/pdf/candidate-pdf.tsx
@@ -433,6 +433,20 @@ function statusLabel(status: Candidate['status']): string {
   return map[status]
 }
 
+/** Returns true when at least one compliance field is populated on the candidate. */
+function hasComplianceData(c: Candidate): boolean {
+  return !!(
+    c.rightToWorkStatus ||
+    c.rightToWorkDocumentType ||
+    c.rightToWorkExpiry ||
+    c.rightToWorkCheckedAt ||
+    c.shareCode ||
+    c.nationality ||
+    c.noticePeriodDays !== null ||
+    c.gdprProcessingConsentAt
+  )
+}
+
 // ---------------------------------------------------------------------------
 // Sub-components
 // ---------------------------------------------------------------------------
@@ -966,6 +980,158 @@ function EnrichmentSection({ enrichment }: { enrichment: EnrichmentData }) {
 }
 
 // ---------------------------------------------------------------------------
+// Section: Compliance & Eligibility (internal / recruiter only)
+// Never rendered for customer audience — gated at the call-site.
+// ---------------------------------------------------------------------------
+function ComplianceSection({ candidate }: { candidate: Candidate }) {
+  // Only render when at least one compliance field is populated
+  if (!hasComplianceData(candidate)) return null
+
+  // Human-readable labels for enum values
+  function rtwStatusLabel(v: string | null): string {
+    if (!v) return '—'
+    const map: Record<string, string> = {
+      checked: 'Checked',
+      pending: 'Pending',
+      fail: 'Fail',
+      exempted: 'Exempted',
+      not_required: 'Not Required',
+    }
+    return map[v] ?? v
+  }
+
+  function rtwDocLabel(v: string | null): string {
+    if (!v) return '—'
+    const map: Record<string, string> = {
+      passport_uk: 'UK Passport',
+      passport_eu: 'EU Passport',
+      passport_other: 'Other Passport',
+      brp: 'BRP',
+      share_code: 'Share Code',
+      visa: 'Visa',
+      settled_status: 'Settled Status',
+      presettled_status: 'Pre-Settled Status',
+      other: 'Other',
+    }
+    return map[v] ?? v
+  }
+
+  function consentByLabel(v: string | null): string {
+    if (!v) return '—'
+    const map: Record<string, string> = {
+      candidate: 'Candidate',
+      recruiter: 'Recruiter',
+      agency: 'Agency',
+    }
+    return map[v] ?? v
+  }
+
+  // Reusable row: label + value
+  function FieldRow({ label, value }: { label: string; value: string }) {
+    return (
+      <View style={{ flexDirection: 'row', marginBottom: 4 }}>
+        <Text
+          style={{
+            fontSize: 8,
+            fontFamily: 'Helvetica-Bold',
+            color: colors.slate500,
+            width: 160,
+          }}
+        >
+          {label}
+        </Text>
+        <Text style={{ fontSize: 9, color: colors.slate700, flex: 1 }}>{value}</Text>
+      </View>
+    )
+  }
+
+  // Right-to-work status badge color
+  function rtwStatusColors(v: string | null): { bg: string; text: string } {
+    switch (v) {
+      case 'checked': return { bg: colors.green50, text: colors.green700 }
+      case 'fail': return { bg: colors.red50, text: colors.red700 }
+      case 'pending': return { bg: colors.amber50, text: colors.amber700 }
+      default: return { bg: colors.slate100, text: colors.slate500 }
+    }
+  }
+
+  const rtwC = rtwStatusColors(candidate.rightToWorkStatus ?? null)
+
+  return (
+    <View>
+      <View style={s.sectionHeaderRow}>
+        <Text style={[base.h2, { marginTop: 0, marginBottom: 0 }]}>
+          Compliance &amp; Eligibility
+        </Text>
+        {candidate.rightToWorkStatus && (
+          <View
+            style={[
+              base.badge,
+              { backgroundColor: rtwC.bg },
+            ]}
+          >
+            <Text style={{ color: rtwC.text, fontSize: 8, fontFamily: 'Helvetica-Bold' }}>
+              RIGHT TO WORK: {rtwStatusLabel(candidate.rightToWorkStatus).toUpperCase()}
+            </Text>
+          </View>
+        )}
+      </View>
+
+      <View style={[base.card, { marginTop: 6 }]}>
+        {/* Right to Work */}
+        {candidate.rightToWorkStatus && (
+          <FieldRow label="Right to Work Status" value={rtwStatusLabel(candidate.rightToWorkStatus)} />
+        )}
+        {candidate.rightToWorkDocumentType && (
+          <FieldRow label="Document Type" value={rtwDocLabel(candidate.rightToWorkDocumentType)} />
+        )}
+        {candidate.rightToWorkExpiry && (
+          <FieldRow label="Document Expiry" value={candidate.rightToWorkExpiry} />
+        )}
+        {candidate.rightToWorkCheckedAt && (
+          <FieldRow label="Check Date" value={fmt(candidate.rightToWorkCheckedAt)} />
+        )}
+        {candidate.shareCode && (
+          <FieldRow label="Share Code" value={candidate.shareCode} />
+        )}
+
+        {/* Sponsorship & Nationality */}
+        <FieldRow
+          label="Sponsorship Required"
+          value={candidate.sponsorshipRequired ? 'Yes' : 'No'}
+        />
+        {candidate.nationality && (
+          <FieldRow label="Nationality" value={candidate.nationality} />
+        )}
+
+        {/* Notice period */}
+        {candidate.noticePeriodDays !== null && candidate.noticePeriodDays !== undefined && (
+          <FieldRow
+            label="Notice Period"
+            value={
+              candidate.noticePeriodDays === 0
+                ? 'Immediate'
+                : `${candidate.noticePeriodDays} day${candidate.noticePeriodDays === 1 ? '' : 's'}`
+            }
+          />
+        )}
+
+        {/* GDPR consent */}
+        {candidate.gdprProcessingConsentAt && (
+          <FieldRow label="GDPR Consent Date" value={fmt(candidate.gdprProcessingConsentAt)} />
+        )}
+        {candidate.gdprProcessingConsentBy && (
+          <FieldRow
+            label="GDPR Consent Provided By"
+            value={consentByLabel(candidate.gdprProcessingConsentBy)}
+          />
+        )}
+      </View>
+    </View>
+  )
+}
+
+// ---------------------------------------------------------------------------
 // Section: CV Text
 // ---------------------------------------------------------------------------
 function CvTextSection({ cvText, cvTextFormatted }: { cvText: string; cvTextFormatted?: string | null }) {
@@ -1054,6 +1220,14 @@ export function CandidatePDF({
         {!isCustomer && notes.length > 0 && (
           <>
             <NotesSection notes={notes} />
+            <View style={base.divider} />
+          </>
+        )}
+
+        {/* ── 5b. Compliance & Eligibility (internal only) ─────────── */}
+        {!isCustomer && hasComplianceData(candidate) && (
+          <>
+            <ComplianceSection candidate={candidate} />
             <View style={base.divider} />
           </>
         )}

--- a/tests/unit/lib/gdpr/dsar-builder.test.ts
+++ b/tests/unit/lib/gdpr/dsar-builder.test.ts
@@ -195,6 +195,55 @@ describe('buildDsarZip', () => {
     // Should produce a ZIP with ERROR.txt
     expect(buffer.includes(Buffer.from('ERROR.txt'))).toBe(true)
   })
+
+  it('candidate.json includes all compliance fields when candidate has them populated', async () => {
+    // Override the candidate fixture with all compliance fields set
+    const complianceCandidate = {
+      ...mockCandidate,
+      rightToWorkStatus: 'checked',
+      rightToWorkDocumentType: 'passport_uk',
+      rightToWorkExpiry: '2030-06-30',
+      rightToWorkCheckedAt: new Date('2025-03-15T10:00:00Z'),
+      rightToWorkCheckedBy: null,
+      shareCode: 'ABC-DEF-GHI',
+      sponsorshipRequired: false,
+      nationality: 'British',
+      noticePeriodDays: 30,
+      gdprProcessingConsentAt: new Date('2025-01-02T09:00:00Z'),
+      gdprProcessingConsentBy: 'candidate',
+    }
+
+    let callCount = 0
+    mockTx.select = vi.fn(() => {
+      callCount++
+      if (callCount === 1) return makeChain([complianceCandidate])
+      return makeChain([])
+    })
+
+    const { buildDsarZip } = await import('@/lib/gdpr/dsar-builder')
+    const archive = await buildDsarZip(CANDIDATE_ID, TENANT_ID)
+    const zipBuffer = await collectStream(archive)
+
+    // Extract candidate.json from the compressed ZIP using JSZip
+    const JSZip = (await import('jszip')).default
+    const zip = await JSZip.loadAsync(zipBuffer)
+    const candidateEntry = zip.file('candidate.json')
+    expect(candidateEntry).not.toBeNull()
+
+    const candidateJson = JSON.parse(await candidateEntry!.async('text'))
+
+    // Verify all compliance fields are present in the exported JSON
+    expect(candidateJson.rightToWorkStatus).toBe('checked')
+    expect(candidateJson.rightToWorkDocumentType).toBe('passport_uk')
+    expect(candidateJson.rightToWorkExpiry).toBe('2030-06-30')
+    expect(candidateJson.shareCode).toBe('ABC-DEF-GHI')
+    expect(candidateJson.sponsorshipRequired).toBe(false)
+    expect(candidateJson.nationality).toBe('British')
+    expect(candidateJson.noticePeriodDays).toBe(30)
+    expect(candidateJson.gdprProcessingConsentBy).toBe('candidate')
+    // gdprProcessingConsentAt is a Date so serialises to ISO string
+    expect(typeof candidateJson.gdprProcessingConsentAt).toBe('string')
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/pdf/candidate-pdf.test.ts
+++ b/tests/unit/pdf/candidate-pdf.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Audience-gating regression tests for CandidatePDF.
+ *
+ * Strategy:
+ *   - Render the PDF with a candidate that has ALL compliance fields set
+ *   - For audience='customer': assert none of the compliance field text
+ *     appears in the extracted PDF text
+ *   - For audience='internal': assert the section heading appears
+ *
+ * PDF text extraction uses @react-pdf/renderer renderToBuffer +
+ * pdf-parse, matching the pattern in synechron-cv-pdf.test.ts.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { renderToBuffer } from '@react-pdf/renderer'
+import React from 'react'
+import { CandidatePDF } from '@/lib/pdf'
+
+// ---------------------------------------------------------------------------
+// Minimal candidate fixture with all compliance fields populated
+// ---------------------------------------------------------------------------
+
+const baseCandidate = {
+  id: 'cand-001',
+  tenantId: 'tenant-001',
+  agencyId: null,
+  firstName: 'Alice',
+  lastName: 'Tester',
+  email: 'alice@example.com',
+  phone: null,
+  cvText: 'Experienced software engineer with 10 years of experience.',
+  cvTextFormatted: null,
+  filePath: null,
+  fileType: 'pdf' as const,
+  linkedinUrl: null,
+  githubUsername: null,
+  embedding: null,
+  status: 'new' as const,
+  statusConfirmedBy: null,
+  statusConfirmedAt: null,
+  country: 'UK',
+  city: 'London',
+  languagesSpoken: ['English'],
+  willingToRelocate: false,
+  candidateRate: null,
+  customerRate: null,
+  rateCurrency: null,
+  availabilityStatus: 'available' as const,
+  availableFrom: null,
+  isActive: true,
+  synechronCvData: null,
+  synechronCandidateId: null,
+  createdAt: new Date('2025-01-01'),
+  // Compliance fields — all populated so we can verify audience gating
+  rightToWorkStatus: 'checked' as const,
+  rightToWorkDocumentType: 'passport_uk' as const,
+  rightToWorkExpiry: '2030-06-30',
+  rightToWorkCheckedAt: new Date('2025-03-15T10:00:00Z'),
+  rightToWorkCheckedBy: null,
+  shareCode: 'ABC-DEF-GHI',
+  sponsorshipRequired: false,
+  nationality: 'British',
+  noticePeriodDays: 30,
+  gdprProcessingConsentAt: new Date('2025-01-02T09:00:00Z'),
+  gdprProcessingConsentBy: 'candidate' as const,
+}
+
+const commonProps = {
+  candidate: baseCandidate,
+  agencyName: null,
+  activeScore: null,
+  activeRole: null,
+  roleHistory: [],
+  transcriptAnalyses: [],
+  notes: [],
+  enrichment: null,
+  generatedAt: new Date('2025-05-01'),
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Extract raw text from a PDF buffer using pdf-parse v2 (class-based API). */
+async function extractPdfText(buffer: Buffer): Promise<string> {
+  const { PDFParse } = await import('pdf-parse')
+  const parser = new PDFParse({ data: buffer })
+  const result = await parser.getText()
+  // TextResult.pages is an array of PageTextResult; join all page text
+  return result.pages.map((p) => p.text).join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CandidatePDF — compliance section audience gating', () => {
+  it('customer PDF renders without throwing and produces a valid PDF buffer', async () => {
+    const buffer = await renderToBuffer(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      React.createElement(CandidatePDF, { ...commonProps, audience: 'customer' }) as any
+    )
+    expect(buffer.length).toBeGreaterThan(1000)
+    expect(buffer.subarray(0, 4).toString()).toBe('%PDF')
+  })
+
+  it('internal PDF renders without throwing and produces a valid PDF buffer', async () => {
+    const buffer = await renderToBuffer(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      React.createElement(CandidatePDF, { ...commonProps, audience: 'internal' }) as any
+    )
+    expect(buffer.length).toBeGreaterThan(1000)
+    expect(buffer.subarray(0, 4).toString()).toBe('%PDF')
+  })
+
+  it('customer PDF does NOT contain any compliance field text', async () => {
+    const buffer = await renderToBuffer(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      React.createElement(CandidatePDF, { ...commonProps, audience: 'customer' }) as any
+    )
+    const text = await extractPdfText(buffer)
+    const lower = text.toLowerCase()
+
+    // None of the compliance-section strings should appear
+    expect(lower).not.toContain('right to work')
+    expect(lower).not.toContain('share code')
+    expect(lower).not.toContain('sponsorship required')
+    expect(lower).not.toContain('nationality')
+    expect(lower).not.toContain('notice period')
+    expect(lower).not.toContain('gdpr consent')
+    expect(lower).not.toContain('compliance')
+    // The specific values should also be absent
+    expect(lower).not.toContain('abc-def-ghi')
+    expect(lower).not.toContain('british')
+    expect(lower).not.toContain('passport_uk')
+  })
+
+  it('internal PDF contains the Compliance & Eligibility section heading', async () => {
+    const buffer = await renderToBuffer(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      React.createElement(CandidatePDF, { ...commonProps, audience: 'internal' }) as any
+    )
+    const text = await extractPdfText(buffer)
+    const lower = text.toLowerCase()
+
+    expect(lower).toContain('compliance')
+  })
+
+  it('internal PDF contains the right to work status', async () => {
+    const buffer = await renderToBuffer(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      React.createElement(CandidatePDF, { ...commonProps, audience: 'internal' }) as any
+    )
+    const text = await extractPdfText(buffer)
+    const lower = text.toLowerCase()
+
+    // "Right to Work Status" label and "Checked" value
+    expect(lower).toContain('right to work')
+    expect(lower).toContain('checked')
+  })
+
+  it('internal PDF contains nationality and notice period', async () => {
+    const buffer = await renderToBuffer(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      React.createElement(CandidatePDF, { ...commonProps, audience: 'internal' }) as any
+    )
+    const text = await extractPdfText(buffer)
+    const lower = text.toLowerCase()
+
+    expect(lower).toContain('british')
+    expect(lower).toContain('30 day')
+  })
+
+  it('compliance section is absent when no compliance fields are set', async () => {
+    const candidateNoCompliance = {
+      ...baseCandidate,
+      rightToWorkStatus: null,
+      rightToWorkDocumentType: null,
+      rightToWorkExpiry: null,
+      rightToWorkCheckedAt: null,
+      shareCode: null,
+      sponsorshipRequired: false,
+      nationality: null,
+      noticePeriodDays: null,
+      gdprProcessingConsentAt: null,
+      gdprProcessingConsentBy: null,
+    }
+
+    const buffer = await renderToBuffer(
+      React.createElement(CandidatePDF, {
+        ...commonProps,
+        candidate: candidateNoCompliance,
+        audience: 'internal',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }) as any
+    )
+    const text = await extractPdfText(buffer)
+    const lower = text.toLowerCase()
+
+    // Section should not appear at all when no data
+    expect(lower).not.toContain('compliance & eligibility')
+  })
+})


### PR DESCRIPTION
## Summary

- Adds a "Compliance & Eligibility" section to the internal recruiter candidate PDF with all EU/UK compliance fields: right-to-work status (colour-coded badge), document type, expiry, check date, share code, sponsorship required, nationality, notice period, and GDPR consent
- Audience gate: section rendered only for `audience='internal'` (recruiter dossier) — customer and manager PDFs are untouched, following the same `!isCustomer` pattern used by Notes, Margin, and Agency logo
- DSAR (GDPR Article 15) export automatically includes all 9 new columns via the existing full-row `appendJson('candidate.json', candidate)` — no builder changes required
- Schema pre-req commit included (drops cleanly on rebase once #191 merges)

## Audience matrix

| Audience | Compliance section |
|---|---|
| recruiter (`internal`) | rendered |
| manager | hidden (audience is `internal`/`customer` at PDF layer; no separate manager PDF) |
| customer | hidden |

## Regression test description

**`tests/unit/pdf/candidate-pdf.test.ts`** (7 new tests):
- Renders without throwing for both `audience='customer'` and `audience='internal'`
- Customer PDF: asserts none of `"right to work"`, `"share code"`, `"sponsorship required"`, `"nationality"`, `"notice period"`, `"gdpr"`, `"compliance"`, `"abc-def-ghi"`, `"british"` appear in extracted PDF text
- Internal PDF: asserts `"compliance"`, `"right to work"`, `"checked"`, `"british"`, `"30 day"` all present
- Section absent when no compliance fields are set (empty-state guard)

**`tests/unit/lib/gdpr/dsar-builder.test.ts`** (1 new test):
- Decompresses the DSAR ZIP via JSZip, parses `candidate.json`, and asserts all 9 compliance columns are present with correct values

Full suite: **813 tests pass, 4 skipped** (pre-existing skips unchanged).

## Commits

1. `deps(schema): pre-req from #191 — drops on rebase after #191 merges` — adds 3 pg enums + 11 nullable compliance columns to the candidates schema for type-checking
2. `feat(export): audience-gated compliance section in PDF + DSAR (closes #193)` — PDF section, DSAR coverage, tests

closes #193
Part of #190; depends on #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)