### PR TITLE
feat(candidates): Compliance & Eligibility form section [#192]

### DIFF
--- a/src/actions/candidates.ts
+++ b/src/actions/candidates.ts
@@ -320,6 +320,23 @@ const UpdateCandidateSchema = z.object({
   rateCurrency: z.string().max(3).toUpperCase().optional().or(z.literal('')),
   availabilityStatus: z.enum(['available', 'on_project', 'unavailable']).optional(),
   availableFrom: z.string().optional().or(z.literal('')),
+  // ── Compliance fields — accepted here, persistence added by #194 ──
+  rightToWorkStatus: z
+    .enum(['checked', 'pending', 'fail', 'exempted', 'not_required', ''])
+    .optional(),
+  rightToWorkDocumentType: z
+    .enum([
+      'passport_uk', 'passport_eu', 'passport_other', 'brp', 'share_code',
+      'visa', 'settled_status', 'presettled_status', 'other', '',
+    ])
+    .optional(),
+  rightToWorkExpiry: z.string().optional().or(z.literal('')),
+  shareCode: z.string().max(20).optional().or(z.literal('')),
+  sponsorshipRequired: z.enum(['true', 'false', '']).optional(),
+  nationality: z.string().max(100).optional().or(z.literal('')),
+  noticePeriodDays: z.coerce.number().int().min(0).max(365).optional().or(z.literal('')),
+  gdprProcessingConsentAt: z.string().optional().or(z.literal('')),
+  gdprProcessingConsentBy: z.enum(['candidate', 'recruiter', 'agency', '']).optional(),
 })
 
 export type UpdateCandidateState = {
@@ -359,6 +376,16 @@ export async function updateCandidateDetails(
     rateCurrency: formData.get('rateCurrency') || undefined,
     availabilityStatus: formData.get('availabilityStatus') || undefined,
     availableFrom: formData.get('availableFrom') || undefined,
+    // Compliance fields (parsed + validated; persistence added by #194)
+    rightToWorkStatus: formData.get('rightToWorkStatus') || undefined,
+    rightToWorkDocumentType: formData.get('rightToWorkDocumentType') || undefined,
+    rightToWorkExpiry: formData.get('rightToWorkExpiry') || undefined,
+    shareCode: formData.get('shareCode') || undefined,
+    sponsorshipRequired: formData.get('sponsorshipRequired') || undefined,
+    nationality: formData.get('nationality') || undefined,
+    noticePeriodDays: formData.get('noticePeriodDays') || undefined,
+    gdprProcessingConsentAt: formData.get('gdprProcessingConsentAt') || undefined,
+    gdprProcessingConsentBy: formData.get('gdprProcessingConsentBy') || undefined,
   })
 
   if (!parsed.success) {

--- a/src/components/candidates/candidate-upload-form.tsx
+++ b/src/components/candidates/candidate-upload-form.tsx
@@ -7,9 +7,11 @@ import { Loader2, Sparkles } from 'lucide-react'
 import { CvDropzone } from '@/components/upload/cv-dropzone'
 import { createCandidate } from '@/actions/candidates'
 import type { CreateCandidateState } from '@/actions/candidates'
+import { ComplianceSection, DEFAULT_COMPLIANCE_FIELDS } from './compliance-section'
+import type { ComplianceFields } from './compliance-section'
 
 type Agency = { id: string; name: string }
-type Props = { roleId: string; agencies: Agency[] }
+type Props = { roleId: string; agencies: Agency[]; audience?: 'recruiter' | 'customer' | 'manager' }
 
 interface ExtractedCandidate {
   firstName?: string
@@ -21,7 +23,7 @@ interface ExtractedCandidate {
   summary?: string
 }
 
-export function CandidateUploadForm({ roleId, agencies }: Props) {
+export function CandidateUploadForm({ roleId, agencies, audience = 'recruiter' }: Props) {
   const router = useRouter()
   const [selectedFile, setSelectedFile] = useState<File | null>(null)
   const [submitting, setSubmitting] = useState(false)
@@ -43,6 +45,9 @@ export function CandidateUploadForm({ roleId, agencies }: Props) {
     customerRate: '',
     rateCurrency: 'GBP',
   })
+
+  // Compliance fields — recruiter audience only
+  const [complianceFields, setComplianceFields] = useState<ComplianceFields>(DEFAULT_COMPLIANCE_FIELDS)
 
   const [state, action, pending] = useActionState<CreateCandidateState | null, FormData>(
     createCandidate,
@@ -98,6 +103,18 @@ export function CandidateUploadForm({ roleId, agencies }: Props) {
     <form
       action={(formData) => {
         if (selectedFile) formData.set('cvFile', selectedFile)
+        // Forward compliance fields — recruiter audience only
+        if (audience === 'recruiter') {
+          formData.set('rightToWorkStatus', complianceFields.rightToWorkStatus)
+          formData.set('rightToWorkDocumentType', complianceFields.rightToWorkDocumentType)
+          formData.set('rightToWorkExpiry', complianceFields.rightToWorkExpiry)
+          formData.set('shareCode', complianceFields.shareCode)
+          formData.set('sponsorshipRequired', String(complianceFields.sponsorshipRequired))
+          formData.set('nationality', complianceFields.nationality)
+          formData.set('noticePeriodDays', complianceFields.noticePeriodDays)
+          formData.set('gdprProcessingConsentAt', complianceFields.gdprProcessingConsentAt)
+          formData.set('gdprProcessingConsentBy', complianceFields.gdprProcessingConsentBy)
+        }
         setSubmitting(true)
         action(formData)
       }}
@@ -363,6 +380,14 @@ export function CandidateUploadForm({ roleId, agencies }: Props) {
           </div>
         </div>
       </div>
+
+      {/* Compliance & Eligibility — recruiter-only collapsible section */}
+      <ComplianceSection
+        audience={audience}
+        disabled={pending || extracting}
+        fields={complianceFields}
+        onChange={setComplianceFields}
+      />
 
       <button
         type="submit"

--- a/src/components/candidates/compliance-section.tsx
+++ b/src/components/candidates/compliance-section.tsx
@@ -1,0 +1,376 @@
+'use client'
+
+/**
+ * ComplianceSection — Compliance & Eligibility collapsible form section.
+ *
+ * Recruiter-only: returns null for any other audience.
+ * Used by both CandidateUploadForm (create) and EditDetailsForm (edit).
+ *
+ * Usage:
+ *   <ComplianceSection
+ *     audience="recruiter"
+ *     disabled={pending}
+ *     fields={complianceFields}
+ *     onChange={setComplianceFields}
+ *   />
+ */
+
+import { useState } from 'react'
+import { ChevronDownIcon, ShieldCheckIcon } from 'lucide-react'
+import type { RightToWorkStatus, RightToWorkDocumentType, GdprProcessingConsentBy } from '@/db/schema/candidates'
+
+export interface ComplianceFields {
+  rightToWorkStatus: RightToWorkStatus | ''
+  rightToWorkDocumentType: RightToWorkDocumentType | ''
+  rightToWorkExpiry: string
+  shareCode: string
+  sponsorshipRequired: boolean
+  nationality: string
+  noticePeriodDays: string
+  gdprProcessingConsentAt: string
+  gdprProcessingConsentBy: GdprProcessingConsentBy | ''
+}
+
+export const DEFAULT_COMPLIANCE_FIELDS: ComplianceFields = {
+  rightToWorkStatus: '',
+  rightToWorkDocumentType: '',
+  rightToWorkExpiry: '',
+  shareCode: '',
+  sponsorshipRequired: false,
+  nationality: '',
+  noticePeriodDays: '',
+  gdprProcessingConsentAt: '',
+  gdprProcessingConsentBy: '',
+}
+
+interface ComplianceSectionProps {
+  audience?: 'recruiter' | 'customer' | 'manager'
+  disabled?: boolean
+  fields: ComplianceFields
+  onChange: (fields: ComplianceFields) => void
+}
+
+// Input className shared across all text/select/date inputs in this section
+const inputCls =
+  'w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] ' +
+  'text-[var(--color-fg)] px-3 py-2 text-sm placeholder:text-[var(--color-fg-subtle)] ' +
+  'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent ' +
+  'disabled:opacity-50'
+
+const labelCls = 'block text-xs font-medium text-[var(--color-fg-muted)] mb-1'
+const helpCls = 'mt-1 text-xs text-[var(--color-fg-subtle)]'
+
+export function ComplianceSection({ audience, disabled = false, fields, onChange }: ComplianceSectionProps) {
+  // Gate: only recruiter sees compliance data
+  if (audience !== 'recruiter') return null
+
+  const [open, setOpen] = useState(false)
+
+  function set<K extends keyof ComplianceFields>(key: K, value: ComplianceFields[K]) {
+    onChange({ ...fields, [key]: value })
+  }
+
+  return (
+    <div className="border-t border-[var(--color-bg-input)] pt-4 mt-2">
+      {/* Collapsible header */}
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls="compliance-section-body"
+        className="flex items-center justify-between w-full text-left group"
+      >
+        <div className="flex items-center gap-2">
+          <ShieldCheckIcon className="h-4 w-4 text-[var(--color-fg-subtle)]" />
+          <span className="text-sm font-medium text-[var(--color-fg-muted)]">
+            Compliance &amp; Eligibility
+          </span>
+          <span className="text-xs text-[var(--color-fg-subtle)]">(optional)</span>
+        </div>
+        <ChevronDownIcon
+          className={`h-4 w-4 text-[var(--color-fg-subtle)] transition-transform duration-150 ${open ? 'rotate-180' : ''}`}
+        />
+      </button>
+
+      {open && (
+        <div id="compliance-section-body" className="mt-4 space-y-5">
+
+          {/* ── Right to Work ─────────────────────────────────────── */}
+          <div className="rounded-lg bg-[var(--color-bg-elevated)] border border-[var(--color-border)] p-4 space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--color-fg-subtle)]">
+              Right to Work
+            </p>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {/* Status */}
+              <div>
+                <label htmlFor="rtw-status" className={labelCls}>
+                  Status
+                </label>
+                <select
+                  id="rtw-status"
+                  name="rightToWorkStatus"
+                  disabled={disabled}
+                  value={fields.rightToWorkStatus}
+                  onChange={(e) => set('rightToWorkStatus', e.target.value as RightToWorkStatus | '')}
+                  className={inputCls}
+                >
+                  <option value="">— Not checked —</option>
+                  <option value="checked">Checked — verified</option>
+                  <option value="pending">Pending — awaiting documents</option>
+                  <option value="fail">Fail — no right to work</option>
+                  <option value="exempted">
+                    Exempted — e.g. UK/EEA pre-settled, settled status
+                  </option>
+                  <option value="not_required">Not required — internal / EEA citizen</option>
+                </select>
+                {fields.rightToWorkStatus === 'exempted' && (
+                  <p className={helpCls}>
+                    Exempted applies to candidates with UK Settled Status, Pre-Settled Status, or
+                    EEA citizenship where no active check is required under current guidance.
+                  </p>
+                )}
+              </div>
+
+              {/* Document type */}
+              <div>
+                <label htmlFor="rtw-doc-type" className={labelCls}>
+                  Document type
+                </label>
+                <select
+                  id="rtw-doc-type"
+                  name="rightToWorkDocumentType"
+                  disabled={disabled}
+                  value={fields.rightToWorkDocumentType}
+                  onChange={(e) =>
+                    set('rightToWorkDocumentType', e.target.value as RightToWorkDocumentType | '')
+                  }
+                  className={inputCls}
+                >
+                  <option value="">— None selected —</option>
+                  <option value="passport_uk">UK Passport</option>
+                  <option value="passport_eu">EU Passport</option>
+                  <option value="passport_other">Other Passport</option>
+                  <option value="brp">Biometric Residence Permit (BRP)</option>
+                  <option value="share_code">Online Share Code</option>
+                  <option value="visa">Visa / Entry clearance</option>
+                  <option value="settled_status">UK Settled Status (EUSS)</option>
+                  <option value="presettled_status">UK Pre-Settled Status (EUSS)</option>
+                  <option value="other">Other document</option>
+                </select>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {/* Expiry date */}
+              <div>
+                <label htmlFor="rtw-expiry" className={labelCls}>
+                  Document / visa expiry
+                  <span className="ml-1 text-[var(--color-fg-subtle)] font-normal">(if time-limited)</span>
+                </label>
+                <input
+                  id="rtw-expiry"
+                  name="rightToWorkExpiry"
+                  type="date"
+                  disabled={disabled}
+                  value={fields.rightToWorkExpiry}
+                  onChange={(e) => set('rightToWorkExpiry', e.target.value)}
+                  className={inputCls}
+                />
+                <p className={helpCls}>
+                  Leave blank for indefinite leave to remain, settled status, or UK/EU passports.
+                </p>
+              </div>
+
+              {/* Share code */}
+              <div>
+                <label htmlFor="rtw-share-code" className={labelCls}>
+                  UK Online Right-to-Work Share Code
+                </label>
+                <input
+                  id="rtw-share-code"
+                  name="shareCode"
+                  type="text"
+                  disabled={disabled}
+                  value={fields.shareCode}
+                  onChange={(e) => set('shareCode', e.target.value.toUpperCase())}
+                  placeholder="W12-3AB-C45"
+                  maxLength={20}
+                  aria-describedby="share-code-help"
+                  className={inputCls}
+                />
+                <p id="share-code-help" className={helpCls}>
+                  9-character code issued by the Home Office: format{' '}
+                  <code className="font-mono">WWW-WWW-WWW</code> (letters &amp; digits, no spaces).
+                  Obtained from{' '}
+                  <span className="underline decoration-dotted">
+                    view.right-to-work.service.gov.uk
+                  </span>
+                  .
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* ── Eligibility Signals ────────────────────────────────── */}
+          <div className="rounded-lg bg-[var(--color-bg-elevated)] border border-[var(--color-border)] p-4 space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--color-fg-subtle)]">
+              Eligibility Signals
+            </p>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {/* Nationality */}
+              <div>
+                <label htmlFor="compliance-nationality" className={labelCls}>
+                  Nationality
+                </label>
+                <input
+                  id="compliance-nationality"
+                  name="nationality"
+                  type="text"
+                  disabled={disabled}
+                  value={fields.nationality}
+                  onChange={(e) => set('nationality', e.target.value)}
+                  placeholder="British"
+                  maxLength={100}
+                  className={inputCls}
+                />
+              </div>
+
+              {/* Notice period */}
+              <div>
+                <label htmlFor="notice-period-days" className={labelCls}>
+                  Notice period (days)
+                </label>
+                <input
+                  id="notice-period-days"
+                  name="noticePeriodDays"
+                  type="number"
+                  min={0}
+                  max={365}
+                  disabled={disabled}
+                  value={fields.noticePeriodDays}
+                  onChange={(e) => set('noticePeriodDays', e.target.value)}
+                  placeholder="30"
+                  className={inputCls}
+                />
+                <p className={helpCls}>
+                  Calendar days from acceptance to start date. Leave blank if unknown.
+                </p>
+              </div>
+            </div>
+
+            {/* Sponsorship required toggle */}
+            <div className="flex items-start gap-3 pt-1">
+              <button
+                type="button"
+                role="switch"
+                id="sponsorship-required"
+                aria-checked={fields.sponsorshipRequired}
+                disabled={disabled}
+                onClick={() => set('sponsorshipRequired', !fields.sponsorshipRequired)}
+                className={[
+                  'relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent',
+                  'transition-colors duration-200 ease-in-out',
+                  'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2',
+                  'focus:ring-offset-[var(--color-bg-app)]',
+                  'disabled:opacity-50 disabled:cursor-not-allowed',
+                  fields.sponsorshipRequired ? 'bg-blue-600' : 'bg-[var(--color-border)]',
+                ].join(' ')}
+              >
+                <span
+                  aria-hidden="true"
+                  className={[
+                    'pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0',
+                    'transition duration-200 ease-in-out',
+                    fields.sponsorshipRequired ? 'translate-x-4' : 'translate-x-0',
+                  ].join(' ')}
+                />
+              </button>
+              {/* Hidden field so the value is submitted in FormData */}
+              <input
+                type="hidden"
+                name="sponsorshipRequired"
+                value={fields.sponsorshipRequired ? 'true' : 'false'}
+              />
+              <div>
+                <label
+                  htmlFor="sponsorship-required"
+                  className="text-sm font-medium text-[var(--color-fg)] cursor-pointer"
+                >
+                  Visa sponsorship required
+                </label>
+                <p className="text-xs text-[var(--color-fg-subtle)] mt-0.5">
+                  Candidate would need a Skilled Worker / Tier 2 sponsorship to take this role.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* ── GDPR Consent ───────────────────────────────────────── */}
+          <div className="rounded-lg bg-[var(--color-bg-elevated)] border border-[var(--color-border)] p-4 space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--color-fg-subtle)]">
+              GDPR Processing Consent
+            </p>
+            <p className="text-xs text-[var(--color-fg-subtle)]">
+              Record when and how consent to process this candidate&apos;s personal data was obtained,
+              per GDPR Article 6(1)(a). Required for any candidate whose data was not received via a
+              legitimate-interest route (e.g. direct application).
+            </p>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {/* Consent date */}
+              <div>
+                <label htmlFor="gdpr-consent-at" className={labelCls}>
+                  Consent recorded on
+                </label>
+                <input
+                  id="gdpr-consent-at"
+                  name="gdprProcessingConsentAt"
+                  type="date"
+                  disabled={disabled}
+                  value={fields.gdprProcessingConsentAt}
+                  onChange={(e) => set('gdprProcessingConsentAt', e.target.value)}
+                  className={inputCls}
+                />
+              </div>
+
+              {/* Consent by — radio group */}
+              <div>
+                <p className={`${labelCls} mb-2`}>Consent provided by</p>
+                <div className="flex flex-col gap-2">
+                  {(
+                    [
+                      { value: 'candidate', label: 'Candidate (self-consent)' },
+                      { value: 'recruiter', label: 'Recruiter (verbal / email)' },
+                      { value: 'agency', label: 'Agency (contract clause)' },
+                    ] as { value: GdprProcessingConsentBy; label: string }[]
+                  ).map(({ value, label }) => (
+                    <label
+                      key={value}
+                      className="flex items-center gap-2 cursor-pointer text-sm text-[var(--color-fg)]"
+                    >
+                      <input
+                        type="radio"
+                        name="gdprProcessingConsentBy"
+                        value={value}
+                        disabled={disabled}
+                        checked={fields.gdprProcessingConsentBy === value}
+                        onChange={() => set('gdprProcessingConsentBy', value)}
+                        className="h-4 w-4 border-[var(--color-border)] text-blue-600
+                                   focus:ring-2 focus:ring-blue-500
+                                   focus:ring-offset-[var(--color-bg-elevated)]
+                                   disabled:opacity-50"
+                      />
+                      {label}
+                    </label>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/candidates/edit-details-form.tsx
+++ b/src/components/candidates/edit-details-form.tsx
@@ -4,6 +4,9 @@ import { useState, useActionState } from 'react'
 import { Loader2, PencilIcon, ChevronDownIcon } from 'lucide-react'
 import { updateCandidateDetails } from '@/actions/candidates'
 import type { UpdateCandidateState } from '@/actions/candidates'
+import { ComplianceSection, DEFAULT_COMPLIANCE_FIELDS } from './compliance-section'
+import type { ComplianceFields } from './compliance-section'
+import type { RightToWorkStatus, RightToWorkDocumentType, GdprProcessingConsentBy } from '@/db/schema/candidates'
 
 interface CandidateDetails {
   id: string
@@ -21,6 +24,16 @@ interface CandidateDetails {
   rateCurrency: string | null
   availabilityStatus?: 'available' | 'on_project' | 'unavailable' | null
   availableFrom?: string | null
+  // Compliance fields — optional; populated when #191 migration is applied
+  rightToWorkStatus?: RightToWorkStatus | null
+  rightToWorkDocumentType?: RightToWorkDocumentType | null
+  rightToWorkExpiry?: string | null
+  shareCode?: string | null
+  sponsorshipRequired?: boolean | null
+  nationality?: string | null
+  noticePeriodDays?: number | null
+  gdprProcessingConsentAt?: string | null
+  gdprProcessingConsentBy?: GdprProcessingConsentBy | null
 }
 
 interface Agency {
@@ -61,6 +74,20 @@ export function EditDetailsForm({ candidate, agencies, audience = 'recruiter' }:
     availableFrom: candidate.availableFrom ?? '',
   })
 
+  // Compliance fields — recruiter audience only
+  const [complianceFields, setComplianceFields] = useState<ComplianceFields>({
+    ...DEFAULT_COMPLIANCE_FIELDS,
+    rightToWorkStatus: (candidate.rightToWorkStatus ?? '') as ComplianceFields['rightToWorkStatus'],
+    rightToWorkDocumentType: (candidate.rightToWorkDocumentType ?? '') as ComplianceFields['rightToWorkDocumentType'],
+    rightToWorkExpiry: candidate.rightToWorkExpiry ?? '',
+    shareCode: candidate.shareCode ?? '',
+    sponsorshipRequired: candidate.sponsorshipRequired ?? false,
+    nationality: candidate.nationality ?? '',
+    noticePeriodDays: candidate.noticePeriodDays != null ? String(candidate.noticePeriodDays) : '',
+    gdprProcessingConsentAt: candidate.gdprProcessingConsentAt ?? '',
+    gdprProcessingConsentBy: (candidate.gdprProcessingConsentBy ?? '') as ComplianceFields['gdprProcessingConsentBy'],
+  })
+
   const fieldErrors = state && !state.success ? state.fieldErrors : {}
 
   return (
@@ -87,6 +114,18 @@ export function EditDetailsForm({ candidate, agencies, audience = 'recruiter' }:
             fd.set('email', fields.email)
             fd.set('phone', fields.phone)
             fd.set('agencyId', fields.agencyId)
+            // Forward compliance fields — recruiter audience only
+            if (audience === 'recruiter') {
+              fd.set('rightToWorkStatus', complianceFields.rightToWorkStatus)
+              fd.set('rightToWorkDocumentType', complianceFields.rightToWorkDocumentType)
+              fd.set('rightToWorkExpiry', complianceFields.rightToWorkExpiry)
+              fd.set('shareCode', complianceFields.shareCode)
+              fd.set('sponsorshipRequired', String(complianceFields.sponsorshipRequired))
+              fd.set('nationality', complianceFields.nationality)
+              fd.set('noticePeriodDays', complianceFields.noticePeriodDays)
+              fd.set('gdprProcessingConsentAt', complianceFields.gdprProcessingConsentAt)
+              fd.set('gdprProcessingConsentBy', complianceFields.gdprProcessingConsentBy)
+            }
             action(fd)
           }}
           className="mt-5 space-y-4"
@@ -374,6 +413,14 @@ export function EditDetailsForm({ candidate, agencies, audience = 'recruiter' }:
               </div>
             </div>
           </div>
+
+          {/* Compliance & Eligibility — recruiter-only collapsible section */}
+          <ComplianceSection
+            audience={audience}
+            disabled={pending}
+            fields={complianceFields}
+            onChange={setComplianceFields}
+          />
 
           <div className="flex items-center gap-3 pt-1">
             <button

--- a/src/db/schema/candidates.ts
+++ b/src/db/schema/candidates.ts
@@ -8,6 +8,7 @@ import {
   boolean,
   timestamp,
   numeric,
+  integer,
   index,
   date,
   jsonb,
@@ -40,6 +41,41 @@ export const availabilityStatusEnum = pgEnum('availability_status', [
 ])
 
 export type AvailabilityStatus = (typeof availabilityStatusEnum.enumValues)[number]
+
+// EU/UK right-to-work check status
+export const rightToWorkStatusEnum = pgEnum('right_to_work_status', [
+  'checked',
+  'pending',
+  'fail',
+  'exempted',
+  'not_required',
+])
+
+export type RightToWorkStatus = (typeof rightToWorkStatusEnum.enumValues)[number]
+
+// Acceptable right-to-work document types
+export const rightToWorkDocumentTypeEnum = pgEnum('right_to_work_document_type', [
+  'passport_uk',
+  'passport_eu',
+  'passport_other',
+  'brp',
+  'share_code',
+  'visa',
+  'settled_status',
+  'presettled_status',
+  'other',
+])
+
+export type RightToWorkDocumentType = (typeof rightToWorkDocumentTypeEnum.enumValues)[number]
+
+// Who provided GDPR processing consent
+export const gdprProcessingConsentByEnum = pgEnum('gdpr_processing_consent_by', [
+  'candidate',
+  'recruiter',
+  'agency',
+])
+
+export type GdprProcessingConsentBy = (typeof gdprProcessingConsentByEnum.enumValues)[number]
 
 export const candidates = pgTable(
   'candidates',
@@ -78,6 +114,19 @@ export const candidates = pgTable(
     synechronCvData: jsonb('synechron_cv_data'),
     synechronCandidateId: varchar('synechron_candidate_id', { length: 64 }),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+
+    // EU/UK right-to-work + compliance fields (all nullable — non-destructive addition)
+    rightToWorkStatus: rightToWorkStatusEnum('right_to_work_status'),
+    rightToWorkDocumentType: rightToWorkDocumentTypeEnum('right_to_work_document_type'),
+    rightToWorkExpiry: date('right_to_work_expiry'),
+    rightToWorkCheckedAt: timestamp('right_to_work_checked_at', { withTimezone: true }),
+    rightToWorkCheckedBy: uuid('right_to_work_checked_by').references(() => users.id),
+    shareCode: varchar('share_code', { length: 20 }),
+    sponsorshipRequired: boolean('sponsorship_required').notNull().default(false),
+    nationality: varchar('nationality', { length: 100 }),
+    noticePeriodDays: integer('notice_period_days'),
+    gdprProcessingConsentAt: timestamp('gdpr_processing_consent_at', { withTimezone: true }),
+    gdprProcessingConsentBy: gdprProcessingConsentByEnum('gdpr_processing_consent_by'),
   },
   (t) => [
     index('idx_candidates_tenant').on(t.tenantId),


### PR DESCRIPTION
## Summary

- Adds a collapsible **Compliance & Eligibility** section to both the candidate upload form (create) and `EditDetailsForm` (edit), gated exclusively to the `recruiter` audience — customer and manager audiences receive `null` render.
- New shared component `compliance-section.tsx` with three card subgroups: **Right to Work**, **Eligibility Signals**, and **GDPR Consent** — all 9 fields from issue #192.
- Extends `UpdateCandidateSchema` in `src/actions/candidates.ts` to parse and validate compliance fields (no DB write — persistence is #194's scope).
- Uses CSS-var theme tokens throughout; zero hardcoded zinc/gray surface colors.

## Dependency note

**Commit `HEAD~1`** (`deps(schema): pre-req from #191`) is a temporary pre-req that adds the schema columns so type-checking passes on this branch. It will be **dropped on rebase once #191 lands on `core-mvp-foundation` first**. That commit must not be merged on its own.

## CI verification

All checks verified against committed code only (untracked in-progress work in the working tree is not part of this PR):

- `npm test` — 65 test files, 850 tests, all green
- `tsc --noEmit` — 0 errors in changed files
- `npm run build` — compiled successfully

## Audience gate behaviour

| Audience | Section renders? |
|---|---|
| `recruiter` (default) | Yes — collapsible, collapsed by default |
| `manager` | No — `return null` |
| `customer` | No — `return null` |

## Test plan

- [ ] Open candidate upload form as recruiter — confirm "Compliance & Eligibility" chevron section appears below Commercial Details
- [ ] Expand section — confirm three subgroups (Right to Work / Eligibility Signals / GDPR Consent) render
- [ ] Set status to "Exempted" — confirm contextual help text appears
- [ ] Enter share code — confirm uppercase auto-formatting and format guidance `WWW-WWW-WWW`
- [ ] Toggle sponsorship required — confirm accessible toggle flips
- [ ] Open candidate edit form as recruiter — confirm section appears and pre-populates from existing compliance fields (null fields render as blank)
- [ ] Set `audience="customer"` in Storybook/mock — confirm section does not render
- [ ] Set `audience="manager"` — confirm section does not render
- [ ] Verify light and dark mode tokens render correctly (no hardcoded zinc surfaces)

## Related issues

closes #192
Part of #190; depends on #191 + #194

The schema commit at `HEAD~1` is a temporary pre-req that drops when #191 lands first.