### PR TITLE
feat(ai): inject HR skill into scoring + interview + transcript-analysis (#197)

### DIFF
--- a/src/content/skills/hr/recruiter-eu-uk.md
+++ b/src/content/skills/hr/recruiter-eu-uk.md
@@ -1,0 +1,61 @@
+---
+profile: recruiter-eu-uk
+title: HR Policy — EU & UK Recruiter Guardrails
+version: 0.1.0
+audience: claude-system-block
+---
+
+# HR Policy: EU & UK Recruiter Guardrails
+
+> Placeholder content shipped as a pre-req stub from issue #195 (vendored skill files).
+> The full version is being authored under Epic #190 and will replace this file
+> before the gating toggle is enabled for any tenant.
+
+## Scope
+
+These guardrails apply when SkillAi's AI surfaces (CV scoring, interview pack
+generation, transcript analysis) are operated against candidates being considered
+for roles in the European Union or the United Kingdom.
+
+## Hard rules
+
+1. **Do not invent right-to-work status.** If the CV does not explicitly state
+   the candidate's right to work in the EU / UK, do not claim they do or do
+   not have it. Flag it as "right-to-work status not stated" in your summary
+   so a recruiter can ask.
+2. **Do not infer protected characteristics.** Age, religion, gender identity,
+   sexual orientation, disability status, marital status, race, and ethnicity
+   must not influence scores or appear in reasoning text — even if they can be
+   inferred from CV cues (graduation year, photo, name, club memberships).
+3. **Do not use career-gap presence as a negative signal.** Gaps can have
+   protected-class causes (parental leave, illness, caring responsibilities).
+   Score on demonstrated skills and experience, not gap presence.
+4. **Salary expectations and current salary are sensitive.** Do not anchor
+   recommendations on a candidate's current or expected salary unless the
+   recruiter has explicitly added that as a role requirement.
+5. **Language requirements must be role-relevant.** If a role does not list
+   a specific language as a requirement, do not penalise a candidate for
+   working in a different language than the job's primary location.
+
+## Soft signals
+
+- Prefer phrasing that ties scores to **evidence in the CV** ("five years of
+  Postgres at scale" rather than "experienced engineer").
+- When summarising, lead with **role-relevant strengths** and end with
+  **specific gaps to probe in interview** — not with subjective fit judgements.
+- For interview questions, prefer **competency-based and behavioural** framings
+  over hypotheticals that depend on personal background.
+
+## Transcript analysis
+
+- Score communication on **clarity and structure**, not accent, fluency, or
+  speech tempo.
+- Do not infer the candidate's mood, personality, or "culture fit" from
+  filler-word frequency or pause length.
+- Quote the transcript directly when justifying a red-flag finding — do not
+  paraphrase in a way that could be contested later.
+
+---
+
+*This is a stub. The production version will be authored in a separate PR
+before tenant rollout.*

--- a/src/db/migrations/0030_hr_skill_toggle_settings.sql
+++ b/src/db/migrations/0030_hr_skill_toggle_settings.sql
@@ -1,0 +1,31 @@
+-- Migration: HR skill toggle settings (issue #198, part of Epic #190)
+--
+-- The HR skill toggle re-uses the existing `tenant_settings` K/V table
+-- (no schema change required) with two new keys:
+--
+--   key = 'hr_skill_enabled'  value = 'true' | 'false'   default 'false'
+--   key = 'hr_skill_profile'  value = 'recruiter-eu-uk'  default 'recruiter-eu-uk'
+--
+-- This file is intentionally a NO-OP at SQL level — it exists only to
+-- reserve the migration sequence number and document the new keys for
+-- reviewers. The data rows are created on-demand by the #198 server
+-- action when a tenant admin first enables the toggle on /settings.
+--
+-- DO NOT remove this file even though it is empty: drizzle-kit tracks
+-- the migration journal and renumbering migrations after they have
+-- shipped causes drift on production tenant DBs.
+--
+-- The real #198 PR will replace this comment-only file with either:
+--   (a) a backfill INSERT for the default values, OR
+--   (b) a more substantive guard (e.g. a CHECK constraint on the
+--       allowed `hr_skill_profile` values).
+--
+-- This stub is committed via #197 because the per-tenant toggle
+-- reader (`src/lib/skills/tenant-toggle.ts`) is part of the gating
+-- contract that the three AI call-site edits in #197 depend on.
+
+-- No-op marker statement (some migration runners reject empty files).
+DO $$ BEGIN
+  -- Reserved for #198: default-value backfill / CHECK constraint goes here.
+  PERFORM 1;
+END $$;

--- a/src/lib/ai/claude.ts
+++ b/src/lib/ai/claude.ts
@@ -11,6 +11,8 @@ import { resolveAnthropicKey } from './keys'
 import { CandidateScoreSchema, type CandidateScore } from './schema'
 import { formatManagerPriorities } from './priorities'
 import { logAiUsage, anthropicUsageToInput } from './usage-logger'
+import { loadHrSkill } from '@/lib/skills'
+import { getHrSkillSettings } from '@/lib/skills/tenant-toggle'
 
 const SCORING_TOOL: Anthropic.Tool = {
   name: 'submit_candidate_score',
@@ -86,17 +88,37 @@ type ScoringInput = {
 export async function scoreCandidateWithClaude(input: ScoringInput): Promise<CandidateScore> {
   const apiKey = await resolveAnthropicKey(input.tenantId)
   const anthropic = new Anthropic({ apiKey, timeout: 120_000, maxRetries: 3 })
+
+  // HR skill block — gated by per-tenant `hr_skill_enabled` (issue #198).
+  // When OFF, this resolves to `null` and the system array is byte-identical
+  // to pre-#197 behaviour (single existing block). When ON, the skill is
+  // appended AFTER the existing teaching block so the prompt prefix stays
+  // stable across candidates and the ephemeral prompt cache remains hot.
+  const hrSettings = await getHrSkillSettings(input.tenantId)
+  const hrSkill = hrSettings.enabled ? loadHrSkill(hrSettings.profile) : null
+
+  const systemBlocks: Anthropic.TextBlockParam[] = [
+    {
+      type: 'text',
+      text: 'You are an expert recruiter scoring candidates against job roles. Evaluate candidates objectively on technical skills, experience level, cultural fit, and communication. Provide specific reasoning tied to CV evidence.',
+      cache_control: { type: 'ephemeral' },
+    },
+    ...(hrSkill
+      ? [
+          {
+            type: 'text' as const,
+            text: `HR_POLICY:\n${hrSkill.content}`,
+            cache_control: { type: 'ephemeral' as const },
+          },
+        ]
+      : []),
+  ]
+
   const startedAt = Date.now()
   const response = await anthropic.messages.create({
     model: 'claude-sonnet-4-6',
     max_tokens: 2048,
-    system: [
-      {
-        type: 'text',
-        text: 'You are an expert recruiter scoring candidates against job roles. Evaluate candidates objectively on technical skills, experience level, cultural fit, and communication. Provide specific reasoning tied to CV evidence.',
-        cache_control: { type: 'ephemeral' },
-      },
-    ],
+    system: systemBlocks,
     tools: [SCORING_TOOL],
     tool_choice: { type: 'any' },
     messages: [

--- a/src/lib/ai/interview.ts
+++ b/src/lib/ai/interview.ts
@@ -18,6 +18,8 @@ import { formatManagerPriorities } from './priorities'
 import { formatLanguageDirective, TOOL_LANGUAGE_REINFORCEMENT, type SupportedLanguage } from './language'
 import { resolveAnthropicKey } from './keys'
 import { logAiUsage, anthropicUsageToInput } from './usage-logger'
+import { loadHrSkill } from '@/lib/skills'
+import { getHrSkillSettings } from '@/lib/skills/tenant-toggle'
 
 export { inferExperienceLevel, inferLanguage }
 
@@ -183,17 +185,38 @@ export async function generateQuestions(
 
   const apiKey = await resolveAnthropicKey(tenantId ?? '')
   const anthropic = new Anthropic({ apiKey, timeout: 240_000, maxRetries: 3 })
+
+  // HR skill block — gated by per-tenant `hr_skill_enabled` (issue #198).
+  // Empty tenantId (legacy call sites that don't pass one) gets defaults,
+  // i.e. fail-closed → no block. When the toggle is ON the skill is
+  // appended AFTER the existing teaching block so the prompt prefix stays
+  // stable across candidates within a role and the ephemeral prompt cache
+  // remains hot. See `claude.ts` for the same pattern.
+  const hrSettings = await getHrSkillSettings(tenantId ?? '')
+  const hrSkill = hrSettings.enabled ? loadHrSkill(hrSettings.profile) : null
+
+  const systemBlocks: Anthropic.TextBlockParam[] = [
+    {
+      type: 'text',
+      text: 'You are an expert technical interviewer creating personalised interview packs. Generate structured interview questions that are directly tied to the candidate\'s CV and the role requirements. Every question must reference specific CV details.',
+      cache_control: { type: 'ephemeral' },
+    },
+    ...(hrSkill
+      ? [
+          {
+            type: 'text' as const,
+            text: `HR_POLICY:\n${hrSkill.content}`,
+            cache_control: { type: 'ephemeral' as const },
+          },
+        ]
+      : []),
+  ]
+
   const startedAt = Date.now()
   const response = await anthropic.messages.create({
     model: 'claude-sonnet-4-6',
     max_tokens: 12000,
-    system: [
-      {
-        type: 'text',
-        text: 'You are an expert technical interviewer creating personalised interview packs. Generate structured interview questions that are directly tied to the candidate\'s CV and the role requirements. Every question must reference specific CV details.',
-        cache_control: { type: 'ephemeral' },
-      },
-    ],
+    system: systemBlocks,
     tools: [QUESTION_TOOL],
     tool_choice: { type: 'any' },
     messages: [

--- a/src/lib/ai/transcript-analysis.ts
+++ b/src/lib/ai/transcript-analysis.ts
@@ -26,6 +26,8 @@ import {
 } from './language'
 import { logAiUsage, anthropicUsageToInput } from './usage-logger'
 import { resolveAnthropicKey } from './keys'
+import { loadHrSkill } from '@/lib/skills'
+import { getHrSkillSettings } from '@/lib/skills/tenant-toggle'
 
 // Soft cap on transcript size sent to Claude. claude-sonnet-4-6 supports
 // 200K tokens (~800K chars) but very large requests are unreliable and
@@ -151,12 +153,34 @@ Numeric scores are language-agnostic. Reasoning text and the summary must be in 
   )
   const languageDirective = formatLanguageDirective(detectedLanguage)
 
+  // HR skill block — gated by per-tenant `hr_skill_enabled` (issue #198).
+  // Unlike `claude.ts` / `interview.ts`, this call site historically has
+  // no top-level `system` field — the "teaching" block lives inline as
+  // the first cached user-content text. To preserve byte-identical
+  // behaviour when the toggle is OFF we ONLY add `system: [...]` to the
+  // request shape when the skill is ON. The skill block goes BEFORE the
+  // existing role-context user block so it inherits the cache prefix
+  // (system blocks are always processed before user content).
+  const hrSettings = await getHrSkillSettings(input.tenantId ?? '')
+  const hrSkill = hrSettings.enabled ? loadHrSkill(hrSettings.profile) : null
+
   const startedAt = Date.now()
   const response = await anthropic.messages.create({
     model: 'claude-sonnet-4-6',
     max_tokens: 4096,
     tools: [TRANSCRIPT_ANALYSIS_TOOL],
     tool_choice: { type: 'any' },
+    ...(hrSkill
+      ? {
+          system: [
+            {
+              type: 'text' as const,
+              text: `HR_POLICY:\n${hrSkill.content}`,
+              cache_control: { type: 'ephemeral' as const },
+            },
+          ],
+        }
+      : {}),
     messages: [
       {
         role: 'user',

--- a/src/lib/skills/index.ts
+++ b/src/lib/skills/index.ts
@@ -1,0 +1,66 @@
+/**
+ * HR Skill loader — pre-req stub for issue #196.
+ *
+ * Loads vendored skill markdown from `src/content/skills/hr/{profile}.md`
+ * and returns it as a plain `{ profile, content }` shape suitable for
+ * injection into a Claude `system` array as a cached text block.
+ *
+ * The full implementation in #196 will:
+ *   - YAML-front-matter parse with `gray-matter`
+ *   - Zod-validate the front-matter shape
+ *   - Strip front-matter from the body before returning
+ *   - Cache the read on the module scope
+ *
+ * For now (this stub) the helper does the smallest amount of work needed
+ * to satisfy the call-site contract from #197: reading the file synchronously
+ * via `fs.readFileSync`, stripping the YAML block, and returning the body.
+ *
+ * Wiring contract (do not change without updating #197 call sites):
+ *   loadHrSkill(profile?: string): { profile: string; content: string } | null
+ */
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+export type HrSkillProfile = 'recruiter-eu-uk'
+
+export type HrSkill = {
+  profile: HrSkillProfile
+  content: string
+}
+
+const SKILLS_DIR = join(process.cwd(), 'src', 'content', 'skills', 'hr')
+
+/**
+ * Load an HR skill profile by name. Returns `null` if the file cannot be
+ * read for any reason — callers (`scoreCandidateWithClaude`,
+ * `generateQuestions`, `analyzeTranscriptWithClaude`) must treat a missing
+ * skill as equivalent to the toggle being off (no system block injected).
+ */
+export function loadHrSkill(profile: HrSkillProfile = 'recruiter-eu-uk'): HrSkill | null {
+  try {
+    const raw = readFileSync(join(SKILLS_DIR, `${profile}.md`), 'utf-8')
+    return {
+      profile,
+      content: stripFrontMatter(raw).trim(),
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Strip a leading YAML front-matter block (`---\n…\n---\n`) if present.
+ * The full #196 implementation will use `gray-matter` and surface the
+ * parsed metadata; the stub only needs the body.
+ */
+function stripFrontMatter(raw: string): string {
+  if (!raw.startsWith('---\n') && !raw.startsWith('---\r\n')) return raw
+  const closing = raw.indexOf('\n---', 4)
+  if (closing === -1) return raw
+  // Skip past the closing `---` and the following newline (LF or CRLF).
+  let cursor = closing + 4
+  if (raw[cursor] === '\r') cursor += 1
+  if (raw[cursor] === '\n') cursor += 1
+  return raw.slice(cursor)
+}

--- a/src/lib/skills/tenant-toggle.ts
+++ b/src/lib/skills/tenant-toggle.ts
@@ -1,0 +1,82 @@
+/**
+ * HR skill tenant toggle reader — pre-req stub for issue #198.
+ *
+ * Reads two settings rows from the existing K/V `tenant_settings` table:
+ *
+ *   key = 'hr_skill_enabled'  → 'true' | 'false'  (defaults to false)
+ *   key = 'hr_skill_profile'  → 'recruiter-eu-uk' (defaults to that)
+ *
+ * The actual #198 PR will land:
+ *   - admin UI on /settings to flip the toggle + pick a profile
+ *   - server action wrapping audit + the K/V write
+ *   - help article describing the rollout policy
+ *
+ * For now this stub gives #197 the smallest possible reader so the
+ * three AI call sites can gate the skill block.
+ *
+ * IMPORTANT: returns `{ enabled: false, profile: 'recruiter-eu-uk' }`
+ * on ANY error (RLS denied, table missing in test env, decrypt failure,
+ * etc.) so the toggle is fail-closed. Existing tenants get the same
+ * byte-identical Claude prompts they had before.
+ */
+
+import { eq } from 'drizzle-orm'
+import { withTenant } from '@/db'
+import { tenantSettings } from '@/db/schema'
+import type { HrSkillProfile } from './index'
+
+export type HrSkillSettings = {
+  enabled: boolean
+  profile: HrSkillProfile
+}
+
+const DEFAULTS: HrSkillSettings = {
+  enabled: false,
+  profile: 'recruiter-eu-uk',
+}
+
+const VALID_PROFILES: readonly HrSkillProfile[] = ['recruiter-eu-uk'] as const
+
+/**
+ * Read the HR skill toggle for a tenant.
+ *
+ * Resolution: tenant_settings row → DEFAULTS. Never throws.
+ *
+ * The toggle values are stored as plain (NOT encrypted) strings —
+ * unlike API keys, the boolean has no secrecy value. The #198 PR will
+ * confirm this and document it next to the encrypted API-key rows.
+ */
+export async function getHrSkillSettings(tenantId: string): Promise<HrSkillSettings> {
+  if (!tenantId) return DEFAULTS
+
+  try {
+    // RLS scopes by tenant; an extra equality on tenant_id would be
+    // belt-and-braces. We only need the two relevant keys, but app-side
+    // filtering keeps the WHERE clause simple — the K/V table is small
+    // (a handful of rows per tenant) and indexed by (tenant_id, key).
+    const rows = await withTenant(tenantId, async (tx) =>
+      tx
+        .select({ key: tenantSettings.key, value: tenantSettings.value })
+        .from(tenantSettings)
+        .where(eq(tenantSettings.tenantId, tenantId))
+    )
+
+    let enabled = DEFAULTS.enabled
+    let profile: HrSkillProfile = DEFAULTS.profile
+
+    for (const row of rows) {
+      if (row.key === 'hr_skill_enabled') {
+        enabled = row.value === 'true'
+      } else if (row.key === 'hr_skill_profile') {
+        const candidate = row.value as HrSkillProfile
+        if (VALID_PROFILES.includes(candidate)) {
+          profile = candidate
+        }
+      }
+    }
+
+    return { enabled, profile }
+  } catch {
+    return DEFAULTS
+  }
+}

--- a/tests/unit/ai/skill-injection.test.ts
+++ b/tests/unit/ai/skill-injection.test.ts
@@ -1,0 +1,333 @@
+/**
+ * HR skill injection tests for the three AI call sites touched by #197:
+ *
+ *   - scoreCandidateWithClaude           (src/lib/ai/claude.ts)
+ *   - generateQuestions                  (src/lib/ai/interview.ts)  Stage 2
+ *   - analyzeTranscriptWithClaude        (src/lib/ai/transcript-analysis.ts)
+ *
+ * For each call site we assert:
+ *   • toggle OFF → no HR_POLICY block injected; system shape byte-identical
+ *     to pre-#197 behaviour.
+ *   • toggle ON  → exactly one HR_POLICY block injected at the correct
+ *     position, marked with cache_control: ephemeral.
+ *
+ * The Anthropic SDK is fully mocked — these tests verify the request
+ * shape we hand it, not any network behaviour.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---- module mocks (hoisted) ---------------------------------------------
+
+const mockMessagesCreate = vi.hoisted(() => vi.fn())
+
+vi.mock('@anthropic-ai/sdk', () => {
+  return {
+    default: class MockAnthropic {
+      messages = { create: mockMessagesCreate }
+    },
+  }
+})
+
+vi.mock('@/lib/ai/keys', () => ({
+  resolveAnthropicKey: vi.fn(async () => 'sk-ant-test'),
+}))
+
+const mockGetHrSkillSettings = vi.hoisted(() => vi.fn())
+const mockLoadHrSkill = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/skills/tenant-toggle', () => ({
+  getHrSkillSettings: mockGetHrSkillSettings,
+}))
+
+vi.mock('@/lib/skills', () => ({
+  loadHrSkill: mockLoadHrSkill,
+}))
+
+vi.mock('@/lib/ai/usage-logger', () => ({
+  logAiUsage: vi.fn(async () => undefined),
+  anthropicUsageToInput: vi.fn(() => ({ input_tokens: 0, output_tokens: 0 })),
+}))
+
+// transcript-analysis pulls in DB modules — stub them.
+vi.mock('@/db', () => ({ withTenant: vi.fn(async (_t: string, fn: (tx: unknown) => unknown) => fn({})) }))
+vi.mock('@/db/schema', () => ({
+  interviewTranscripts: {},
+  transcriptAnalyses: {},
+  roles: {},
+  interviewQuestions: {},
+}))
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn(),
+  and: vi.fn(),
+}))
+
+// ---- module imports under test (after mocks) -----------------------------
+
+import { scoreCandidateWithClaude } from '@/lib/ai/claude'
+import { generateQuestions } from '@/lib/ai/interview'
+import { analyzeTranscriptWithClaude } from '@/lib/ai/transcript-analysis'
+import type { CvProfile } from '@/lib/ai/interview-schemas'
+
+const TENANT = '11111111-1111-1111-1111-111111111111'
+
+const FAKE_SKILL = {
+  profile: 'recruiter-eu-uk' as const,
+  content: 'placeholder skill body for tests',
+}
+
+// Minimum-viable tool_use response the SDK would return.
+function fakeAnthropicResponse(toolInput: unknown, model = 'claude-sonnet-4-6') {
+  return {
+    id: 'msg_test',
+    model,
+    stop_reason: 'tool_use',
+    usage: { input_tokens: 100, output_tokens: 50 },
+    content: [{ type: 'tool_use', name: 'submit_tool', input: toolInput }],
+  }
+}
+
+const VALID_SCORE = {
+  overall_score: 80,
+  dimensions: {
+    technical_skills: { score: 80, reasoning: 'r' },
+    experience_level: { score: 80, reasoning: 'r' },
+    cultural_fit: { score: 80, reasoning: 'r' },
+    communication: { score: 80, reasoning: 'r' },
+  },
+  summary: 'ok',
+}
+
+const VALID_PACK = {
+  experience_level: 'mid' as const,
+  recommended_duration_minutes: 60,
+  questions: Array.from({ length: 8 }, (_, i) => ({
+    question_type: 'technical' as const,
+    difficulty: 'medium' as const,
+    // question_text must be >=10 chars per InterviewPackSchema.
+    question_text: `Question number ${i + 1} for the candidate.`,
+    rationale: 'reasonable rationale',
+    follow_ups: [],
+    strong_answer_signals: [],
+    acceptable_answer_signals: [],
+    weak_answer_signals: [],
+    cv_references: [],
+  })),
+}
+
+const VALID_TRANSCRIPT_ANALYSIS = {
+  overall_score: 75,
+  dimensions: {
+    communication: { score: 75, reasoning: 'r' },
+    technical_depth: { score: 75, reasoning: 'r' },
+    problem_solving: { score: 75, reasoning: 'r' },
+    social_fit: { score: 75, reasoning: 'r' },
+  },
+  summary: 's',
+  strengths: [],
+  red_flags: [],
+  // Enum: 'proceed' | 'consider' | 'decline' (NOT 'hire').
+  recommended_decision: 'proceed' as const,
+  question_responses: [],
+}
+
+const FAKE_CV_PROFILE: CvProfile = {
+  experience_level: 'mid',
+  summary: 'experienced developer',
+  companies: [{ name: 'Acme', role: 'Engineer', key_achievements: ['shipped'] }],
+  technical_skills: ['TypeScript', 'PostgreSQL'],
+  personalizable_moments: ['Led migration'],
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// ====== scoreCandidateWithClaude ===========================================
+
+describe('scoreCandidateWithClaude — HR skill injection', () => {
+  it('OFF: system array has exactly 1 block (no HR_POLICY)', async () => {
+    mockGetHrSkillSettings.mockResolvedValue({ enabled: false, profile: 'recruiter-eu-uk' })
+    mockLoadHrSkill.mockReturnValue(null)
+    mockMessagesCreate.mockResolvedValue(fakeAnthropicResponse(VALID_SCORE))
+
+    await scoreCandidateWithClaude({
+      roleTitle: 'Senior Engineer',
+      roleDescription: 'desc',
+      roleRequirements: 'reqs',
+      cvText: 'cv',
+      candidateName: 'Alice',
+      tenantId: TENANT,
+    })
+
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(1)
+    const arg = mockMessagesCreate.mock.calls[0][0]
+    expect(Array.isArray(arg.system)).toBe(true)
+    expect(arg.system).toHaveLength(1)
+    expect(arg.system[0].text).not.toContain('HR_POLICY:')
+    // loadHrSkill must NOT be called when toggle is off — toggle gates it.
+    expect(mockLoadHrSkill).not.toHaveBeenCalled()
+  })
+
+  it('ON: system array has 2 blocks; second starts with "HR_POLICY:"', async () => {
+    mockGetHrSkillSettings.mockResolvedValue({ enabled: true, profile: 'recruiter-eu-uk' })
+    mockLoadHrSkill.mockReturnValue(FAKE_SKILL)
+    mockMessagesCreate.mockResolvedValue(fakeAnthropicResponse(VALID_SCORE))
+
+    await scoreCandidateWithClaude({
+      roleTitle: 'Senior Engineer',
+      roleDescription: 'desc',
+      roleRequirements: 'reqs',
+      cvText: 'cv',
+      candidateName: 'Alice',
+      tenantId: TENANT,
+    })
+
+    const arg = mockMessagesCreate.mock.calls[0][0]
+    expect(arg.system).toHaveLength(2)
+    expect(arg.system[1].text.startsWith('HR_POLICY:\n')).toBe(true)
+    expect(arg.system[1].text).toContain(FAKE_SKILL.content)
+    expect(arg.system[1].cache_control).toEqual({ type: 'ephemeral' })
+    expect(mockLoadHrSkill).toHaveBeenCalledWith('recruiter-eu-uk')
+  })
+
+  it('ON but loadHrSkill returns null: no HR_POLICY block (graceful)', async () => {
+    mockGetHrSkillSettings.mockResolvedValue({ enabled: true, profile: 'recruiter-eu-uk' })
+    mockLoadHrSkill.mockReturnValue(null)
+    mockMessagesCreate.mockResolvedValue(fakeAnthropicResponse(VALID_SCORE))
+
+    await scoreCandidateWithClaude({
+      roleTitle: 'Senior Engineer',
+      roleDescription: 'desc',
+      roleRequirements: 'reqs',
+      cvText: 'cv',
+      candidateName: 'Alice',
+      tenantId: TENANT,
+    })
+
+    const arg = mockMessagesCreate.mock.calls[0][0]
+    expect(arg.system).toHaveLength(1)
+    expect(arg.system[0].text).not.toContain('HR_POLICY:')
+  })
+})
+
+// ====== generateQuestions Stage 2 =========================================
+
+describe('generateQuestions Stage 2 — HR skill injection', () => {
+  it('OFF: system array has exactly 1 block (no HR_POLICY)', async () => {
+    mockGetHrSkillSettings.mockResolvedValue({ enabled: false, profile: 'recruiter-eu-uk' })
+    mockLoadHrSkill.mockReturnValue(null)
+    mockMessagesCreate.mockResolvedValue(fakeAnthropicResponse(VALID_PACK))
+
+    await generateQuestions(
+      FAKE_CV_PROFILE,
+      { title: 'Senior Engineer', description: 'desc', requirements: 'reqs' },
+      { includeCodeChallenge: false },
+      TENANT
+    )
+
+    const arg = mockMessagesCreate.mock.calls[0][0]
+    expect(arg.system).toHaveLength(1)
+    expect(arg.system[0].text).not.toContain('HR_POLICY:')
+    expect(mockLoadHrSkill).not.toHaveBeenCalled()
+  })
+
+  it('ON: system array has 2 blocks; second is HR_POLICY with ephemeral cache', async () => {
+    mockGetHrSkillSettings.mockResolvedValue({ enabled: true, profile: 'recruiter-eu-uk' })
+    mockLoadHrSkill.mockReturnValue(FAKE_SKILL)
+    mockMessagesCreate.mockResolvedValue(fakeAnthropicResponse(VALID_PACK))
+
+    await generateQuestions(
+      FAKE_CV_PROFILE,
+      { title: 'Senior Engineer', description: 'desc', requirements: 'reqs' },
+      { includeCodeChallenge: false },
+      TENANT
+    )
+
+    const arg = mockMessagesCreate.mock.calls[0][0]
+    expect(arg.system).toHaveLength(2)
+    expect(arg.system[1].text.startsWith('HR_POLICY:\n')).toBe(true)
+    expect(arg.system[1].text).toContain(FAKE_SKILL.content)
+    expect(arg.system[1].cache_control).toEqual({ type: 'ephemeral' })
+  })
+
+  it('teaching block remains the FIRST block in both states (cache prefix stable)', async () => {
+    mockGetHrSkillSettings.mockResolvedValue({ enabled: true, profile: 'recruiter-eu-uk' })
+    mockLoadHrSkill.mockReturnValue(FAKE_SKILL)
+    mockMessagesCreate.mockResolvedValue(fakeAnthropicResponse(VALID_PACK))
+
+    await generateQuestions(
+      FAKE_CV_PROFILE,
+      { title: 'Senior Engineer', description: 'desc', requirements: 'reqs' },
+      { includeCodeChallenge: false },
+      TENANT
+    )
+
+    const arg = mockMessagesCreate.mock.calls[0][0]
+    // Teaching block must precede the HR block so cache prefix is stable.
+    expect(arg.system[0].text.toLowerCase()).toContain('interviewer')
+    expect(arg.system[1].text.startsWith('HR_POLICY:\n')).toBe(true)
+  })
+})
+
+// ====== analyzeTranscriptWithClaude =======================================
+
+describe('analyzeTranscriptWithClaude — HR skill injection', () => {
+  it('OFF: request has NO top-level `system` field (byte-identical to pre-#197)', async () => {
+    mockGetHrSkillSettings.mockResolvedValue({ enabled: false, profile: 'recruiter-eu-uk' })
+    mockLoadHrSkill.mockReturnValue(null)
+    // First mock call = language detection (Haiku) returning 'en'.
+    mockMessagesCreate.mockResolvedValueOnce({
+      id: 'msg_lang',
+      model: 'claude-haiku-4-5-20251001',
+      stop_reason: 'end_turn',
+      usage: { input_tokens: 10, output_tokens: 2 },
+      content: [{ type: 'text', text: 'en' }],
+    })
+    // Second mock call = the main analysis.
+    mockMessagesCreate.mockResolvedValueOnce(fakeAnthropicResponse(VALID_TRANSCRIPT_ANALYSIS))
+
+    await analyzeTranscriptWithClaude({
+      transcriptText: 'speaker: hello',
+      roleTitle: 'Senior Engineer',
+      roleDescription: 'desc',
+      roleRequirements: 'reqs',
+      tenantId: TENANT,
+    })
+
+    // First call is language detection — not our concern. Second is analysis.
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(2)
+    const analysisArg = mockMessagesCreate.mock.calls[1][0]
+    // Critical byte-identical guarantee: no `system` key on the request body.
+    expect('system' in analysisArg).toBe(false)
+    expect(mockLoadHrSkill).not.toHaveBeenCalled()
+  })
+
+  it('ON: request has system array with 1 HR_POLICY block', async () => {
+    mockGetHrSkillSettings.mockResolvedValue({ enabled: true, profile: 'recruiter-eu-uk' })
+    mockLoadHrSkill.mockReturnValue(FAKE_SKILL)
+    mockMessagesCreate.mockResolvedValueOnce({
+      id: 'msg_lang',
+      model: 'claude-haiku-4-5-20251001',
+      stop_reason: 'end_turn',
+      usage: { input_tokens: 10, output_tokens: 2 },
+      content: [{ type: 'text', text: 'en' }],
+    })
+    mockMessagesCreate.mockResolvedValueOnce(fakeAnthropicResponse(VALID_TRANSCRIPT_ANALYSIS))
+
+    await analyzeTranscriptWithClaude({
+      transcriptText: 'speaker: hello',
+      roleTitle: 'Senior Engineer',
+      roleDescription: 'desc',
+      roleRequirements: 'reqs',
+      tenantId: TENANT,
+    })
+
+    const analysisArg = mockMessagesCreate.mock.calls[1][0]
+    expect(Array.isArray(analysisArg.system)).toBe(true)
+    expect(analysisArg.system).toHaveLength(1)
+    expect(analysisArg.system[0].text.startsWith('HR_POLICY:\n')).toBe(true)
+    expect(analysisArg.system[0].text).toContain(FAKE_SKILL.content)
+    expect(analysisArg.system[0].cache_control).toEqual({ type: 'ephemeral' })
+  })
+})


### PR DESCRIPTION
Closes #197.
Part of #190; depends on #195, #196, #198.

## Summary

Adds a per-tenant-gated HR-policy block to the three highest-value Claude call sites — CV scoring, Stage-2 interview question generation, and transcript analysis. The block is treated as plain text in a cached system block (no Skills API beta header, no scoring-schema migration). When the per-tenant toggle is OFF, the request shape is **byte-identical** to current behaviour.

## Surfaces touched

| File | Function | When toggle OFF | When toggle ON |
|---|---|---|---|
| `src/lib/ai/claude.ts` | `scoreCandidateWithClaude` | `system.length === 1` (unchanged) | `system.length === 2`; second block is HR_POLICY, ephemeral cache |
| `src/lib/ai/interview.ts` | `generateQuestions` (Stage 2) | `system.length === 1` (unchanged) | `system.length === 2`; second block is HR_POLICY, ephemeral cache |
| `src/lib/ai/transcript-analysis.ts` | `analyzeTranscriptWithClaude` | **no `system` key at all** (matches pre-#197 shape) | `system.length === 1`; sole block is HR_POLICY, ephemeral cache |

Stage 1 (`extractCvProfile`) is **not** touched — Haiku, structured-only output, no recruiter-facing reasoning surface.

## Cache positioning rationale

The HR block is placed **AFTER the existing teaching block** but **BEFORE any per-candidate / per-transcript content**. This keeps the cached prompt prefix stable across candidates within a role and lets the ephemeral cache stay hot across the typical "score 50 CVs against the same role" batch.

Both blocks carry `cache_control: { type: 'ephemeral' }`.

## Toggle-OFF byte-identical guarantee

- `getHrSkillSettings` is **fail-closed** (returns `{ enabled: false }` on any DB / RLS / decrypt error).
- When `enabled === false`, `loadHrSkill` is never called (asserted in tests).
- `claude.ts` / `interview.ts`: `systemBlocks` spreads an empty array → produces an array literal indistinguishable from the original single-element literal.
- `transcript-analysis.ts`: the entire `system: [...]` property is added **only** when the skill is ON. The OFF test asserts `expect('system' in arg).toBe(false)`.

## Commits in this PR

1. `deps(skills): pre-req from #195 + #196 — vendored skill files + loadHrSkill() helper` — stub markdown at `src/content/skills/hr/recruiter-eu-uk.md` + `loadHrSkill()` helper at `src/lib/skills/index.ts`. Returns `null` on any read error so callers can treat missing skill as "toggle off".
2. `deps(settings): pre-req from #198 — tenant_settings hr_skill_enabled toggle + reader` — `getHrSkillSettings()` reader at `src/lib/skills/tenant-toggle.ts` + comment-only migration stub at `src/db/migrations/0030_hr_skill_toggle_settings.sql`. NOT applied to the live DB by this PR (migration journal untouched, matching the team's recent manually-applied SQL pattern). **Schema note:** SkillAi's `tenant_settings` is K/V (not wide-column), so the toggle is two new rows (`hr_skill_enabled`, `hr_skill_profile`) — no new column.
3. `feat(ai): inject HR skill into scoring + interview + transcript-analysis (closes #197)` — the actual edits to the three AI files + the new test suite.

## Tests

New file: `tests/unit/ai/skill-injection.test.ts` — **8 assertions** across the three call sites.

| Call site | OFF assertions | ON assertions |
|---|---|---|
| `scoreCandidateWithClaude` | system has 1 block, no HR_POLICY, loader not called | system has 2 blocks, HR_POLICY block w/ ephemeral cache; loader called with correct profile |
| `scoreCandidateWithClaude` (extra) | — | ON + loader returns null → graceful (1-block system) |
| `generateQuestions` Stage 2 | system has 1 block, no HR_POLICY, loader not called | system has 2 blocks, HR_POLICY block w/ ephemeral cache |
| `generateQuestions` Stage 2 (extra) | — | teaching block remains FIRST (cache prefix stable) |
| `analyzeTranscriptWithClaude` | **no `system` key** (byte-identical to pre-#197) | system array has 1 HR_POLICY block w/ ephemeral cache |

## CI gates

- `npm test` → **831 pass / 4 skip / 0 fail** (66 files; new file = 8 tests)
- `npx tsc --noEmit` → clean
- `npm run build` → green

## Why no `betas: ['skills-api-…']` header

The upstream SKILL.md is plain markdown. Treating the skill as a cached text block keeps the implementation simple and avoids coupling to a beta surface that may change shape. Switching to the Skills API is a one-line change if/when we want it.

## Test plan

- [ ] Manual: with toggle OFF on a test tenant, score a candidate and confirm prompt-cache metrics + scoring output look identical to baseline.
- [ ] Manual: enable toggle on a test tenant, score 5 candidates against the same role, eyeball the Anthropic prompt-cache metrics — expect >70% cache hit after the first call (per #197 acceptance criterion).
- [ ] Verify `extractCvProfile` (Stage 1) is unchanged — no HR block in those calls.
- [ ] Verify transcript analysis OFF still has no top-level `system` field on the request body.