### PR TITLE
feat(skills): loadHrSkill() helper + unit tests (closes #196)

### DIFF
--- a/src/lib/ai/skills/index.ts
+++ b/src/lib/ai/skills/index.ts
@@ -1,0 +1,71 @@
+/**
+ * HR skill loader — reads vendored skill markdown files from this directory
+ * and returns them as plain strings ready to be plumbed into the Claude
+ * system prompt.
+ *
+ * Three profiles:
+ *   - talent-acquisition  → talent-acquisition.md
+ *   - people-analytics    → people-analytics.md
+ *   - recruiter-eu-uk     → talent-acquisition.md + '\n\n---\n\n' + eu-uk-supplement.md
+ *
+ * `recruiter-eu-uk` is SkillAi's default; it combines the upstream talent-
+ * acquisition skill with the SkillAi-authored EU/UK right-to-work supplement.
+ *
+ * Files are read from disk on first call per profile and cached at module
+ * scope, so repeat calls are cheap (string lookup, no fs hit).
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+
+export type SkillProfile = 'talent-acquisition' | 'people-analytics' | 'recruiter-eu-uk'
+
+export type LoadedHrSkill = { name: string; content: string }
+
+// Module-level cache. Cleared automatically when the process restarts; never
+// mutated after first write.
+const cache = new Map<SkillProfile, LoadedHrSkill>()
+
+// `import.meta.dirname` is the canonical accessor under Node ≥ 20 ESM and
+// modern bundlers; `__dirname` is the CJS fallback. Vitest and Next.js both
+// resolve one or the other depending on transform.
+function dirOfThisFile(): string {
+  const importMetaDir = typeof import.meta !== 'undefined' ? import.meta.dirname : undefined
+  return importMetaDir ?? __dirname
+}
+
+function readSkillFile(filename: string): string {
+  return fs.readFileSync(path.join(dirOfThisFile(), filename), 'utf-8')
+}
+
+export function loadHrSkill(profile: SkillProfile): LoadedHrSkill {
+  const cached = cache.get(profile)
+  if (cached) return cached
+
+  let loaded: LoadedHrSkill
+  switch (profile) {
+    case 'talent-acquisition':
+      loaded = { name: 'talent-acquisition', content: readSkillFile('talent-acquisition.md') }
+      break
+    case 'people-analytics':
+      loaded = { name: 'people-analytics', content: readSkillFile('people-analytics.md') }
+      break
+    case 'recruiter-eu-uk': {
+      const ta = readSkillFile('talent-acquisition.md')
+      const supplement = readSkillFile('eu-uk-supplement.md')
+      loaded = {
+        name: 'recruiter-eu-uk',
+        content: `${ta}\n\n---\n\n${supplement}`,
+      }
+      break
+    }
+    default: {
+      // Exhaustiveness check — TS will error if a new SkillProfile member is
+      // added without updating this switch.
+      const _exhaustive: never = profile
+      throw new Error(`Unknown HR skill profile: ${String(_exhaustive)}`)
+    }
+  }
+
+  cache.set(profile, loaded)
+  return loaded
+}

--- a/tests/unit/lib/ai/skills.test.ts
+++ b/tests/unit/lib/ai/skills.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock `node:fs` so we can both (a) drive content from the test and (b)
+// observe whether the module-level cache is short-circuiting subsequent
+// reads. `vi.hoisted` is required because the factory passed to `vi.mock`
+// is lifted above any top-level `const`s.
+const { mockReadFileSync, fileContents } = vi.hoisted(() => {
+  const fileContents: Record<string, string> = {
+    'talent-acquisition.md':
+      '# Talent Acquisition\n\nMock talent-acquisition content. ' +
+      'Lorem ipsum '.repeat(80),
+    'people-analytics.md':
+      '# People Analytics\n\nMock people-analytics content. ' +
+      'Lorem ipsum '.repeat(80),
+    'eu-uk-supplement.md':
+      '# EU/UK Right-to-Work Supplement\n\nMock supplement content. ' +
+      'Lorem ipsum '.repeat(80),
+  }
+  return {
+    fileContents,
+    mockReadFileSync: vi.fn((p: string) => {
+      const name = (p.split('/').pop() ?? p) as keyof typeof fileContents
+      const body = fileContents[name]
+      if (body === undefined) {
+        throw new Error(`Unexpected file read: ${p}`)
+      }
+      return body
+    }),
+  }
+})
+
+vi.mock('node:fs', () => ({
+  default: { readFileSync: mockReadFileSync },
+  readFileSync: mockReadFileSync,
+}))
+
+// IMPORTANT: import the SUT AFTER the mock so the mocked `node:fs` is in scope.
+// We re-import inside each test via dynamic import + `vi.resetModules()` where
+// cache behaviour matters; here we get one shared import for shape assertions.
+import { loadHrSkill } from '@/lib/ai/skills'
+
+describe('loadHrSkill', () => {
+  beforeEach(() => {
+    mockReadFileSync.mockClear()
+  })
+
+  it('returns name + content for the talent-acquisition profile', () => {
+    const result = loadHrSkill('talent-acquisition')
+    expect(result.name).toBe('talent-acquisition')
+    expect(result.content.length).toBeGreaterThan(100)
+    expect(result.content).toContain('# Talent Acquisition')
+  })
+
+  it('returns name + content for the people-analytics profile', () => {
+    const result = loadHrSkill('people-analytics')
+    expect(result.name).toBe('people-analytics')
+    expect(result.content.length).toBeGreaterThan(100)
+    expect(result.content).toContain('# People Analytics')
+  })
+
+  it('combines talent-acquisition + eu-uk-supplement for recruiter-eu-uk', () => {
+    const result = loadHrSkill('recruiter-eu-uk')
+    expect(result.name).toBe('recruiter-eu-uk')
+    // Both source files' headings show up in the combined content.
+    expect(result.content).toContain('# Talent Acquisition')
+    expect(result.content).toContain('# EU/UK Right-to-Work Supplement')
+    // Separator between the two files.
+    expect(result.content).toContain('\n\n---\n\n')
+    // Reasonable combined size: >500 B (lower than concatenated mock content)
+    // and <50 KB (so we never serialise an absurd system prompt).
+    expect(result.content.length).toBeGreaterThan(500)
+    expect(result.content.length).toBeLessThan(50_000)
+  })
+
+  it('caches per-profile and does not re-read fs on a second call', async () => {
+    // Reset modules so we get a fresh module-scope cache for this test only,
+    // independent of the calls the earlier tests have already made.
+    vi.resetModules()
+    mockReadFileSync.mockClear()
+
+    const { loadHrSkill: freshLoad } = await import('@/lib/ai/skills')
+
+    // First call should hit fs for talent-acquisition.md (1 read).
+    const first = freshLoad('talent-acquisition')
+    expect(mockReadFileSync).toHaveBeenCalledTimes(1)
+
+    // Second call MUST be served from cache → call count unchanged.
+    const second = freshLoad('talent-acquisition')
+    expect(mockReadFileSync).toHaveBeenCalledTimes(1)
+
+    // Same object instance returned from cache (we use Map.get, not a copy).
+    expect(second).toBe(first)
+
+    // A different profile triggers exactly the new reads it needs.
+    freshLoad('recruiter-eu-uk')
+    // recruiter-eu-uk reads talent-acquisition.md (cached upstream? no — the
+    // helper reads via fs each composition; what's cached is the resulting
+    // LoadedSkill object per profile, not the underlying file). So the
+    // composition reads talent-acquisition.md again + eu-uk-supplement.md →
+    // +2 reads.
+    expect(mockReadFileSync).toHaveBeenCalledTimes(3)
+
+    // And a second call for recruiter-eu-uk hits cache, no further reads.
+    freshLoad('recruiter-eu-uk')
+    expect(mockReadFileSync).toHaveBeenCalledTimes(3)
+  })
+})


### PR DESCRIPTION
## Summary

Adds `loadHrSkill()` — a small synchronous helper that reads vendored HR-skill markdown files from `src/lib/ai/skills/` and returns them as `{ name, content }` ready to be plumbed into the Claude system prompt (call site lands in #197).

Closes #196. Part of #190. Depends on #195.

## API

```ts
// src/lib/ai/skills/index.ts
export type SkillProfile = 'talent-acquisition' | 'people-analytics' | 'recruiter-eu-uk'
export type LoadedHrSkill = { name: string; content: string }

export function loadHrSkill(profile: SkillProfile): LoadedHrSkill
```

## Profile mapping

| Profile | Files combined |
| --- | --- |
| `talent-acquisition` | `talent-acquisition.md` |
| `people-analytics` | `people-analytics.md` |
| `recruiter-eu-uk` | `talent-acquisition.md` + `\n\n---\n\n` + `eu-uk-supplement.md` |

`recruiter-eu-uk` is SkillAi's default — combines the upstream talent-acquisition skill with the SkillAi-authored EU/UK right-to-work supplement.

## Cache behaviour

Module-scope `Map<SkillProfile, LoadedHrSkill>`. First call per profile hits the disk; subsequent calls return the cached object (same reference). Cleared automatically on process restart; never mutated after first write.

## Path resolution

`import.meta.dirname ?? __dirname` — works under both ESM (Next.js / Node ≥ 20) and CJS (vitest transform) without relying on `process.cwd()`.

## Tests

4 new tests in `tests/unit/lib/ai/skills.test.ts`:

1. `loadHrSkill('talent-acquisition')` returns `name === 'talent-acquisition'`, `content.length > 100`, contains the file's H1
2. Same shape for `people-analytics`
3. `recruiter-eu-uk` contains both files' H1 headings, contains the `\n\n---\n\n` separator, and combined size is 500 B – 50 KB
4. Cache: second call for the same profile does **not** re-invoke `fs.readFileSync` (asserted via `vi.mock` + call-count); different profiles cache independently

Combined `recruiter-eu-uk` content against the current placeholder files is ~15.6 KB.

## Pre-req commit (drops on rebase)

The first commit (`deps(skills): pre-req from #195`) adds placeholder markdown files so the helper has something to read end-to-end. The real upstream-vendored content lands when #195 merges — at that point this branch should be rebased and the pre-req commit dropped.

## Test plan

- [x] `npm test` — 67 test files / 884 tests passing (4 new from this PR)
- [x] `tsc --noEmit` clean on changed files
- [ ] CI green (test + lint + build jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)