### PR TITLE
feat(audit): log skill_used metadata on AI-driven audit rows

### DIFF
--- a/src/app/api/interview-packs/generate/route.ts
+++ b/src/app/api/interview-packs/generate/route.ts
@@ -188,6 +188,10 @@ export async function POST(request: Request) {
         questionCount: result.questions.length,
         experienceLevel: result.experience_level,
         includesCodeChallenge: !!result.code_challenge,
+        // #199 — record which HR skill profile (if any) augmented this AI
+        // call. `null` when toggle is OFF (NOT absent) so future queries can
+        // filter via `WHERE metadata->>'skill_used' IS NOT NULL`.
+        skill_used: skill?.name ?? null,
       },
     })
 
@@ -200,7 +204,8 @@ export async function POST(request: Request) {
       action: 'interview_pack.failed',
       entityType: 'interview_pack',
       entityId: packId,
-      metadata: { error: message },
+      // #199 — same skill_used tag as on interview_pack.completed.
+      metadata: { error: message, skill_used: skill?.name ?? null },
     })
 
     console.error(`Interview pack generation failed for ${packId}:`, message)

--- a/src/app/api/interview-packs/generate/route.ts
+++ b/src/app/api/interview-packs/generate/route.ts
@@ -17,6 +17,8 @@ import { getOrExtractCvProfile } from '@/lib/ai/cv-profile'
 import { inferLanguage } from '@/lib/ai/interview-helpers'
 import { SUPPORTED_LANGUAGES, isSupportedLanguage, type SupportedLanguage } from '@/lib/ai/language'
 import { emitAudit } from '@/lib/audit-middleware'
+import { getHrSkillSettings } from '@/actions/settings'
+import { loadHrSkill } from '@/lib/ai/skills'
 
 export const maxDuration = 300
 
@@ -93,6 +95,11 @@ export async function POST(request: Request) {
       })
       .where(eq(interviewPacks.id, packId))
   )
+
+  // #199 — resolve HR skill outside the try/catch so both the completion and
+  // failure audit rows can reference `skill?.name` in their metadata.
+  const hrSkillSettings = await getHrSkillSettings(tenantId)
+  const skill = hrSkillSettings.enabled ? loadHrSkill(hrSkillSettings.profile) : null
 
   try {
     const [candidate] = await withTenant(tenantId, async (tx) =>

--- a/src/lib/ai/scoring.ts
+++ b/src/lib/ai/scoring.ts
@@ -161,6 +161,11 @@ When scoring experience_level, assess specifically whether the candidate's senio
         roleId,
         overallScore: result.overall_score,
         model: useGemini ? 'gemini' : 'claude',
+        // #199 — record which HR skill profile (if any) augmented this AI call
+        // so we can A/B compare skill-augmented vs unaugmented scoring runs.
+        // `null` (not absent) when toggle is OFF so future queries can use the
+        // simple `WHERE metadata->>'skill_used' IS NOT NULL` filter.
+        skill_used: skill?.name ?? null,
       },
     })
   } catch (err) {
@@ -176,7 +181,9 @@ When scoring experience_level, assess specifically whether the candidate's senio
       action: 'score.failed',
       entityType: 'score',
       entityId: candidateId,
-      metadata: { roleId, error: message },
+      // #199 — same skill_used tag as on score.completed so failure rows are
+      // attributable to skill-on or skill-off runs in the A/B analysis.
+      metadata: { roleId, error: message, skill_used: skill?.name ?? null },
     })
 
     console.error(`Scoring failed for candidate ${candidateId}:`, message)

--- a/tests/unit/ai/scoring-skill-audit.test.ts
+++ b/tests/unit/ai/scoring-skill-audit.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Unit tests for `skill_used` audit-metadata enrichment in
+ * `src/lib/ai/scoring.ts` (closes #199).
+ *
+ * Why a dedicated test file rather than extending `tests/unit/actions/scores.test.ts`:
+ *   - `triggerScoring` lives at `src/lib/ai/scoring.ts`, not in `src/actions`.
+ *   - The scores-action test covers `rescoreCandidate` + `removeCandidateFromRole`,
+ *     not `triggerScoring`. Co-locating these assertions in the action file
+ *     would obscure where the behaviour lives.
+ *
+ * Coverage:
+ *   1. Toggle OFF → audit metadata includes `skill_used: null` (NOT absent).
+ *   2. Toggle ON  → audit metadata includes `skill_used: 'recruiter-eu-uk'`.
+ *
+ * Mocked surface:
+ *   - `@/db`                              — withTenant + db.transaction
+ *   - `@/db/schema`                       — table stubs
+ *   - `drizzle-orm`                       — eq / and / sql pass-throughs
+ *   - `@/lib/audit-middleware`            — emitAudit spy
+ *   - `@/lib/notifications/dispatcher`    — dispatchHighScoreNotification no-op
+ *   - `./claude`                          — scoreCandidateWithClaude returns canned score
+ *   - `./gemini`                          — scoreCandidateWithGemini (unused, present for symmetry)
+ *   - `@/actions/settings`                — getHrSkillSettings (toggle off/on)
+ *   - `./skills`                          — loadHrSkill returns { name, content: '' }
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const TENANT_ID    = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const CANDIDATE_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const ROLE_ID      = '11111111-1111-4111-8111-111111111111'
+
+// ── Mocks (hoisted) ───────────────────────────────────────────────────────────
+
+const { mockEmitAudit, mockGetHrSkillSettings, mockScoreCandidateWithClaude } = vi.hoisted(() => ({
+  mockEmitAudit: vi.fn(),
+  mockGetHrSkillSettings: vi.fn(),
+  mockScoreCandidateWithClaude: vi.fn(),
+}))
+
+// withTenant: invoke the callback with a stub tx that resolves to the
+// per-query rows configured via the module-scoped `queueSelectRows` array.
+// This lets each test queue the candidate row, role row, and model-setting row
+// in arrival order without rebuilding the whole mock each time.
+let queueSelectRows: unknown[][] = []
+let _selectCallIndex = 0
+
+function makeSelectChain(rows: unknown[]) {
+  const c: Record<string, unknown> = {}
+  const resolved = Promise.resolve(rows)
+  c.then  = resolved.then.bind(resolved)
+  c.catch = resolved.catch.bind(resolved)
+  c.from  = vi.fn(() => c)
+  c.where = vi.fn(() => c)
+  c.limit = vi.fn(() => Promise.resolve(rows))
+  return c
+}
+
+vi.mock('@/db', () => ({
+  db: {
+    transaction: vi.fn().mockImplementation(async (fn: (tx: unknown) => unknown) => {
+      const tx = {
+        execute: vi.fn().mockResolvedValue(undefined),
+        select: vi.fn(() => makeSelectChain([])), // no framework rows
+      }
+      return fn(tx)
+    }),
+  },
+  withTenant: vi.fn().mockImplementation(
+    async (_tenantId: string, fn: (tx: unknown) => unknown) => {
+      // Each tx instance lazily dequeues a row-set on its first `.select()` call.
+      // This avoids incrementing the queue on update-only `withTenant` blocks
+      // (e.g. the "mark as processing" prelude).
+      const tx = {
+        select: vi.fn(() => {
+          const nextRows = queueSelectRows[_selectCallIndex] ?? []
+          _selectCallIndex++
+          return makeSelectChain(nextRows)
+        }),
+        update: vi.fn(() => ({
+          set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+        })),
+      }
+      return fn(tx)
+    }
+  ),
+}))
+
+vi.mock('@/db/schema', () => ({
+  candidates: { id: 'id' },
+  roles: { id: 'id' },
+  scores: { candidateId: 'cid', roleId: 'rid' },
+  customerFrameworks: { customerId: 'cust' },
+  tenantSettings: { tenantId: 'tid', key: 'key', value: 'value' },
+}))
+
+vi.mock('drizzle-orm', () => ({
+  eq:  vi.fn(() => ({ type: 'eq' })),
+  and: vi.fn((...args: unknown[]) => ({ type: 'and', args })),
+  sql: vi.fn((strings: TemplateStringsArray) => ({ type: 'sql', strings })),
+}))
+
+vi.mock('@/lib/audit-middleware', () => ({
+  emitAudit: (...args: unknown[]) => mockEmitAudit(...args),
+}))
+
+vi.mock('@/lib/notifications/dispatcher', () => ({
+  dispatchHighScoreNotification: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/lib/ai/claude', () => ({
+  scoreCandidateWithClaude: (...args: unknown[]) => mockScoreCandidateWithClaude(...args),
+}))
+
+vi.mock('@/lib/ai/gemini', () => ({
+  scoreCandidateWithGemini: vi.fn(),
+}))
+
+vi.mock('@/actions/settings', () => ({
+  getHrSkillSettings: (...args: unknown[]) => mockGetHrSkillSettings(...args),
+}))
+
+// Stub loader — returns a fixed shape; the test only cares about `.name`.
+vi.mock('@/lib/ai/skills', () => ({
+  loadHrSkill: (profile: string) => ({ name: profile, content: '' }),
+}))
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const FAKE_SCORE = {
+  overall_score: 87,
+  dimensions: {
+    technical_skills: { score: 90, reasoning: 'strong' },
+    experience_level: { score: 85, reasoning: 'fits' },
+    cultural_fit:     { score: 84, reasoning: 'aligned' },
+    communication:    { score: 88, reasoning: 'clear' },
+  },
+  summary: 'Strong fit.',
+}
+
+function queueRowsForHappyPath() {
+  // triggerScoring select-order:
+  //   1. candidate (select.from.where.limit)
+  //   2. role (select.from.where.limit)
+  //   3. modelSetting (select.from.where.limit)  — empty → default Claude
+  queueSelectRows = [
+    [{ id: CANDIDATE_ID, firstName: 'Ada', lastName: 'Lovelace', cvText: 'CV...', candidateRate: null, rateCurrency: null }],
+    [{ id: ROLE_ID, title: 'Engineer', description: 'desc', requirements: 'req', frameworkLevelId: null, customerId: null, customerDayRate: null, rateCurrency: null, priorityKeywords: [] }],
+    [], // no model setting → Claude path
+  ]
+  _selectCallIndex = 0
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('triggerScoring — skill_used audit metadata (#199)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queueRowsForHappyPath()
+    mockScoreCandidateWithClaude.mockResolvedValue(FAKE_SCORE)
+  })
+
+  it('emits score.completed with skill_used: null when HR skill toggle is OFF', async () => {
+    mockGetHrSkillSettings.mockResolvedValue({ enabled: false, profile: 'recruiter-eu-uk' })
+
+    const { triggerScoring } = await import('@/lib/ai/scoring')
+    await triggerScoring(CANDIDATE_ID, ROLE_ID, TENANT_ID)
+
+    expect(mockEmitAudit).toHaveBeenCalledWith(
+      TENANT_ID,
+      expect.objectContaining({
+        action: 'score.completed',
+        metadata: expect.objectContaining({ skill_used: null }),
+      })
+    )
+  })
+
+  it('emits score.completed with skill_used: profile name when HR skill toggle is ON', async () => {
+    mockGetHrSkillSettings.mockResolvedValue({ enabled: true, profile: 'recruiter-eu-uk' })
+
+    const { triggerScoring } = await import('@/lib/ai/scoring')
+    await triggerScoring(CANDIDATE_ID, ROLE_ID, TENANT_ID)
+
+    expect(mockEmitAudit).toHaveBeenCalledWith(
+      TENANT_ID,
+      expect.objectContaining({
+        action: 'score.completed',
+        metadata: expect.objectContaining({ skill_used: 'recruiter-eu-uk' }),
+      })
+    )
+  })
+
+  it('preserves the existing metadata fields alongside skill_used', async () => {
+    mockGetHrSkillSettings.mockResolvedValue({ enabled: false, profile: 'recruiter-eu-uk' })
+
+    const { triggerScoring } = await import('@/lib/ai/scoring')
+    await triggerScoring(CANDIDATE_ID, ROLE_ID, TENANT_ID)
+
+    // Confirms #199 is metadata enrichment, NOT a metadata rewrite.
+    expect(mockEmitAudit).toHaveBeenCalledWith(
+      TENANT_ID,
+      expect.objectContaining({
+        action: 'score.completed',
+        metadata: expect.objectContaining({
+          roleId: ROLE_ID,
+          overallScore: 87,
+          model: 'claude',
+          skill_used: null,
+        }),
+      })
+    )
+  })
+
+  it('emits score.failed with skill_used when Claude call throws', async () => {
+    mockGetHrSkillSettings.mockResolvedValue({ enabled: true, profile: 'talent-acquisition' })
+    mockScoreCandidateWithClaude.mockRejectedValueOnce(new Error('Claude exploded'))
+
+    const { triggerScoring } = await import('@/lib/ai/scoring')
+    await triggerScoring(CANDIDATE_ID, ROLE_ID, TENANT_ID)
+
+    expect(mockEmitAudit).toHaveBeenCalledWith(
+      TENANT_ID,
+      expect.objectContaining({
+        action: 'score.failed',
+        metadata: expect.objectContaining({
+          error: 'Claude exploded',
+          skill_used: 'talent-acquisition',
+        }),
+      })
+    )
+  })
+})


### PR DESCRIPTION
Closes #199. Part of Epic #190; depends on #197.

## Summary

- Enrich existing AI-driven audit rows with a `skill_used` metadata field for future A/B comparison of skill-augmented vs unaugmented runs.
- Two touchpoints land here (`score.completed` / `score.failed` and `interview_pack.completed` / `interview_pack.failed`). The third planned touchpoint — transcript analysis — has no audit row today; see the **Discovered gap** section.
- No new audit actions; this is metadata enrichment of EXISTING rows. Three-job CI gate (test / tsc / build) green.

## Query pattern enabled

After this PR lands, downstream analytics can pick out every skill-augmented AI call with the simple, idiomatic form

```sql
SELECT *
  FROM audit_logs
 WHERE action IN ('score.completed', 'score.failed', 'interview_pack.completed', 'interview_pack.failed')
   AND metadata->>'skill_used' IS NOT NULL;
```

The `null`-not-absent semantics (see commit message) make this filter robust against the toggle-off case and against pre-#199 rows lacking the key entirely.

## Audit rows touched

| Action | Surface | File |
| --- | --- | --- |
| `score.completed` | scoring | `src/lib/ai/scoring.ts` |
| `score.failed` | scoring (error path) | `src/lib/ai/scoring.ts` |
| `interview_pack.completed` | interview pack | `src/app/api/interview-packs/generate/route.ts` |
| `interview_pack.failed` | interview pack (error path) | `src/app/api/interview-packs/generate/route.ts` |

## Before / after — sample metadata

`score.completed` (toggle OFF):

```diff
 {
   "roleId": "11111111-…",
   "overallScore": 87,
-  "model": "claude"
+  "model": "claude",
+  "skill_used": null
 }
```

`score.completed` (toggle ON, profile `recruiter-eu-uk`):

```diff
 {
   "roleId": "11111111-…",
   "overallScore": 87,
   "model": "claude",
+  "skill_used": "recruiter-eu-uk"
 }
```

## Discovered gap — transcript analysis has no audit emit

The original issue spec (#199) names three surfaces: scoring, interview-pack generation, and transcript analysis. Investigation shows `src/lib/ai/transcript-analysis.ts` (`triggerTranscriptAnalysis`) **has no audit emit at all** — neither `transcript_analysis.completed` nor a failure variant exists.

Adding a new audit action would violate the hard constraint of #199 ("No new audit actions — this is metadata enrichment of EXISTING rows"). I therefore:

1. Added the skill-loading hook to `triggerTranscriptAnalysis` (in the pre-req commit, so #197 can finish its work) but
2. Did **not** add a `skill_used` audit field, since there's no audit row to enrich.

A small follow-up issue should: (a) add `transcript_analysis.completed` / `.failed` to the `AuditAction` union, (b) emit the audit row at the success + failure points in `triggerTranscriptAnalysis`, (c) include `skill_used` in the metadata, mirroring the pattern landed here.

## Pre-req commit on this branch

The first commit (`143646f`) is a minimal `loadHrSkill()` + `getHrSkillSettings()` scaffolding so this PR can be reviewed without waiting for #195 / #196 / #197 / #198 to merge. It drops on rebase once those land.

## Test plan

- [x] `npm test` — full suite 827 passed (4 new in `tests/unit/ai/scoring-skill-audit.test.ts`).
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run build` — clean.
- [ ] Manual spot-check: enable HR skill on a test tenant, score a candidate, query the audit row to confirm `metadata->>'skill_used' = 'recruiter-eu-uk'`. Defer until #197 + #198 merge to a shared branch so the toggle + injection both work end-to-end.

## Notes for reviewer

- The new `skill_used` field is the **profile name** (`'recruiter-eu-uk'` / `'talent-acquisition'` / `'people-analytics'`), not a boolean. This is more informative for A/B analysis — different profiles can later be compared against each other, not just on/off.
- The pre-req commit's `loadHrSkill()` returns `{ name, content: '' }` (content is empty until #195 vendors the markdown). Audit-side code only reads `.name`; #197's injection-side code is also fine with an empty string (no content → no system block when toggle is on).
- The error-path emits (`score.failed`, `interview_pack.failed`) also carry `skill_used` so attribution survives failure modes — important for "did the skill cause more failures?" questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)