### PR TITLE
feat(admin): updateUserRole action + last-admin guard + UI selector

### DIFF
--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
-import { eq, and, inArray, isNull, lt, gt, isNotNull } from 'drizzle-orm'
+import { eq, and, inArray, isNull, gt, isNotNull, count } from 'drizzle-orm'
 import { z } from 'zod'
 import bcrypt from 'bcryptjs'
 import { db, withTenant } from '@/db'
@@ -283,29 +283,113 @@ export async function listTenantUsers(filters?: UserFilters): Promise<User[]> {
 // Update user role (admin only)
 // ---------------------------------------------------------------------------
 
-export async function updateUserRole(userId: string, role: UserRole): Promise<void> {
+export type UpdateUserRoleResult =
+  | { ok: true }
+  | { ok: false; error: string }
+
+/**
+ * updateUserRole — change a user's product-role within the active tenant.
+ *
+ * Guards (in order):
+ *   1. Auth — session.user.tenantId required.
+ *   2. Admin — caller must have role >= admin.
+ *   3. Self — caller cannot change their own role.
+ *   4. Last-admin — if demoting (newRole !== 'admin') and target is the sole
+ *      admin in the tenant, reject. Prevents locking the tenant out.
+ *
+ * Audit:
+ *   Emits `user.role_changed` with metadata { from, to, targetUserId }.
+ */
+export async function updateUserRole(
+  userId: string,
+  newRole: UserRole
+): Promise<UpdateUserRoleResult> {
   const session = await auth()
-  if (!session?.user.tenantId) return
-
-  requireRole(session.user.role, 'admin')
-
-  if (userId === session.user.id) {
-    throw new Error('You cannot change your own role')
+  if (!session?.user.tenantId || !session.user.id) {
+    return { ok: false, error: 'Unauthorized' }
   }
 
-  await withTenant(session.user.tenantId, async (tx) => {
+  try {
+    requireRole(session.user.role, 'admin')
+  } catch {
+    return { ok: false, error: 'Forbidden: admins only' }
+  }
+
+  if (userId === session.user.id) {
+    return { ok: false, error: 'You cannot change your own role' }
+  }
+
+  const tenantId = session.user.tenantId
+
+  // Fetch target user + current admin count in a single RLS-scoped transaction
+  // so the last-admin guard is consistent with the update we then issue.
+  const result = await withTenant(tenantId, async (tx) => {
+    const [target] = await tx
+      .select({ id: users.id, role: users.role, isActive: users.isActive })
+      .from(users)
+      .where(and(eq(users.id, userId), eq(users.tenantId, tenantId)))
+      .limit(1)
+
+    if (!target) {
+      return { ok: false as const, error: 'User not found' }
+    }
+
+    const oldRole = target.role as UserRole
+
+    // No-op shortcut — same role: skip the write and the audit row.
+    if (oldRole === newRole) {
+      return { ok: true as const, oldRole, changed: false }
+    }
+
+    // Last-admin guard — only fires when demoting an admin to a non-admin role.
+    if (oldRole === 'admin' && newRole !== 'admin') {
+      const [{ value: adminCount }] = await tx
+        .select({ value: count() })
+        .from(users)
+        .where(
+          and(
+            eq(users.tenantId, tenantId),
+            eq(users.role, 'admin'),
+            eq(users.isActive, true)
+          )
+        )
+
+      if (adminCount <= 1) {
+        return {
+          ok: false as const,
+          error: 'Cannot demote the only active admin in this tenant',
+        }
+      }
+    }
+
     await tx
       .update(users)
-      .set({ role })
-      .where(
-        and(
-          eq(users.id, userId),
-          eq(users.tenantId, session.user.tenantId)
-        )
-      )
+      .set({ role: newRole })
+      .where(and(eq(users.id, userId), eq(users.tenantId, tenantId)))
+
+    return { ok: true as const, oldRole, changed: true }
   })
 
+  if (!result.ok) {
+    return { ok: false, error: result.error }
+  }
+
+  if (result.changed) {
+    emitAudit(tenantId, {
+      action: 'user.role_changed',
+      entityType: 'user',
+      entityId: userId,
+      metadata: {
+        from: result.oldRole,
+        to: newRole,
+        targetUserId: userId,
+      },
+    })
+  }
+
+  revalidatePath('/dashboard/users')
   revalidatePath('/settings')
+  return { ok: true }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/app/api/users/[userId]/role/route.ts
+++ b/src/app/api/users/[userId]/role/route.ts
@@ -24,7 +24,12 @@ export const PATCH = withApiAuth<{ userId: string }>(
     if (!parsed.success) {
       return Response.json({ ok: false, error: parsed.error.issues[0]?.message }, { status: 422 })
     }
-    await updateUserRole(userId, parsed.data.role)
+    const result = await updateUserRole(userId, parsed.data.role)
+    if (!result.ok) {
+      // 403 for auth/role/last-admin/self-demote failures; 404 for unknown user.
+      const status = result.error === 'User not found' ? 404 : 403
+      return Response.json({ ok: false, error: result.error }, { status })
+    }
     return Response.json({ ok: true })
   }
 )

--- a/src/components/settings/user-management-table.tsx
+++ b/src/components/settings/user-management-table.tsx
@@ -1,17 +1,9 @@
 'use client'
 
-import { useTransition } from 'react'
-import { updateUserRole } from '@/actions/users'
 import { UserDeactivateButton } from '@/components/users/user-deactivate-button'
+import { UserRoleSelector } from '@/components/users/user-role-selector'
 import type { User } from '@/db/schema/users'
 import type { UserRole } from '@/lib/auth/types'
-
-const ROLE_OPTIONS: { value: UserRole; label: string }[] = [
-  { value: 'admin', label: 'Admin' },
-  { value: 'recruiter', label: 'Recruiter' },
-  { value: 'hiring_manager', label: 'Hiring Manager' },
-  { value: 'viewer', label: 'Viewer' },
-]
 
 const ROLE_BADGE: Record<UserRole, string> = {
   admin: 'bg-blue-100 dark:bg-blue-950 text-blue-700 dark:text-blue-300 border-blue-300 dark:border-blue-700',
@@ -26,14 +18,6 @@ type Props = {
 }
 
 export function UserManagementTable({ users, currentUserId }: Props) {
-  const [pending, startTransition] = useTransition()
-
-  function handleRoleChange(userId: string, role: UserRole) {
-    startTransition(async () => {
-      await updateUserRole(userId, role)
-    })
-  }
-
   return (
     <div className="rounded-xl border border-[var(--color-border)] overflow-hidden">
       <table className="w-full text-sm">
@@ -83,21 +67,13 @@ export function UserManagementTable({ users, currentUserId }: Props) {
                   )}
                 </td>
                 <td className="px-4 py-3">
-                  <div className="flex items-center gap-2">
-                    <select
-                      defaultValue={user.role}
-                      disabled={isSelf || isInactive || pending}
-                      onChange={(e) => handleRoleChange(user.id, e.target.value as UserRole)}
-                      className="text-xs rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)]
-                                 px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500
-                                 disabled:opacity-40 disabled:cursor-not-allowed"
-                    >
-                      {ROLE_OPTIONS.map((opt) => (
-                        <option key={opt.value} value={opt.value}>
-                          {opt.label}
-                        </option>
-                      ))}
-                    </select>
+                  <div className="flex items-start gap-2">
+                    <UserRoleSelector
+                      userId={user.id}
+                      currentRole={user.role}
+                      isSelf={isSelf}
+                      isInactive={isInactive}
+                    />
                     <UserDeactivateButton
                       userId={user.id}
                       userEmail={user.email}

--- a/src/components/users/user-role-selector.tsx
+++ b/src/components/users/user-role-selector.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+/**
+ * UserRoleSelector — per-row role dropdown for the team-management table.
+ *
+ * Wraps the `updateUserRole` server action. On error (e.g. last-admin guard,
+ * self-demote, forbidden) the inline message renders below the select and the
+ * dropdown value is reverted to the user's current role so the UI never drifts
+ * from server state.
+ *
+ * Disabled when:
+ *   - the user is the currently signed-in user (cannot edit self)
+ *   - the user account is inactive
+ *   - a transition is in flight
+ */
+
+import { useState, useTransition } from 'react'
+import { updateUserRole } from '@/actions/users'
+import type { UserRole } from '@/lib/auth/types'
+
+const ROLE_OPTIONS: { value: UserRole; label: string }[] = [
+  { value: 'admin', label: 'Admin' },
+  { value: 'recruiter', label: 'Recruiter' },
+  { value: 'hiring_manager', label: 'Hiring Manager' },
+  { value: 'viewer', label: 'Viewer' },
+]
+
+type Props = {
+  userId: string
+  currentRole: UserRole
+  /** True when this row represents the signed-in user. Disables the control. */
+  isSelf: boolean
+  /** True when the user account is deactivated. Disables the control. */
+  isInactive: boolean
+}
+
+export function UserRoleSelector({ userId, currentRole, isSelf, isInactive }: Props) {
+  const [pending, startTransition] = useTransition()
+  const [error, setError] = useState<string | null>(null)
+  // Track the value shown in the dropdown so we can revert on server error.
+  const [value, setValue] = useState<UserRole>(currentRole)
+
+  function handleChange(nextRole: UserRole) {
+    if (nextRole === value) return
+    setError(null)
+    const previous = value
+    setValue(nextRole)
+    startTransition(async () => {
+      const result = await updateUserRole(userId, nextRole)
+      if (!result.ok) {
+        setError(result.error)
+        // Revert the dropdown — the server state never changed.
+        setValue(previous)
+      }
+    })
+  }
+
+  const disabled = isSelf || isInactive || pending
+
+  return (
+    <div className="flex flex-col gap-1">
+      <select
+        value={value}
+        disabled={disabled}
+        onChange={(e) => handleChange(e.target.value as UserRole)}
+        aria-label="User role"
+        className="text-xs rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)]
+                   px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500
+                   disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        {ROLE_OPTIONS.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+      {error ? (
+        <p role="alert" className="text-xs text-red-500 dark:text-red-400 max-w-[16rem]">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/tests/unit/actions/users.test.ts
+++ b/tests/unit/actions/users.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for src/actions/users.ts — deactivate + reactivate.
+ * Unit tests for src/actions/users.ts — deactivate, reactivate, updateUserRole.
  *
  * Actions under test:
  *   deactivateUser  — admin gate, self-deactivate guard, last-admin guard,
@@ -7,6 +7,8 @@
  *                     throws Unauthorized.
  *   reactivateUser  — admin gate, happy path (row updated + audit
  *                     `user.reactivated`), no-session throws Unauthorized.
+ *   updateUserRole  — admin gate, self-demote guard, last-admin guard, happy
+ *                     paths (promote/demote), no-op (same role), missing user.
  *
  * Mocks:
  *   @/db                            — withTenant runs the callback with a
@@ -14,7 +16,7 @@
  *   @/db/schema                     — `users` column stubs (column-name
  *                                     property bag, same shape as other
  *                                     action tests in this dir).
- *   drizzle-orm                     — eq / and pass-throughs.
+ *   drizzle-orm                     — eq / and / count / inArray pass-throughs.
  *   @/lib/auth                      — auth() returns a controlled session.
  *   @/lib/auth/require-role         — real implementation (throws on
  *                                     insufficient role) so the gate is
@@ -103,8 +105,14 @@ vi.mock('@/db/schema', () => ({
 }))
 
 vi.mock('drizzle-orm', () => ({
-  eq:  vi.fn(() => ({ type: 'eq' })),
-  and: vi.fn((...args: unknown[]) => ({ type: 'and', args })),
+  eq:      vi.fn((col: unknown, val: unknown) => ({ type: 'eq', col, val })),
+  and:     vi.fn((...args: unknown[]) => ({ type: 'and', args })),
+  count:   vi.fn(() => ({ type: 'count' })),
+  inArray: vi.fn((col: unknown, vals: unknown) => ({ type: 'inArray', col, vals })),
+  isNull:  vi.fn((col: unknown) => ({ type: 'isNull', col })),
+  isNotNull: vi.fn((col: unknown) => ({ type: 'isNotNull', col })),
+  gt:      vi.fn((col: unknown, val: unknown) => ({ type: 'gt', col, val })),
+  lt:      vi.fn((col: unknown, val: unknown) => ({ type: 'lt', col, val })),
 }))
 
 const mockAuth = vi.fn()
@@ -125,8 +133,8 @@ vi.mock('@/lib/audit', () => ({
 
 vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
 
-// bcryptjs is unused by deactivate/reactivate but the actions module imports
-// it for the password helpers — keep the import resolvable.
+// bcryptjs is unused by deactivate/reactivate/updateUserRole but the actions
+// module imports it for the password helpers — keep the import resolvable.
 vi.mock('bcryptjs', () => ({
   default: {
     hash:    vi.fn().mockResolvedValue('$2b$12$hashedpassword'),
@@ -136,7 +144,8 @@ vi.mock('bcryptjs', () => ({
   compare: vi.fn().mockResolvedValue(true),
 }))
 
-// getActionContext is not used by deactivate/reactivate but the module imports it.
+// getActionContext is not used by deactivate/reactivate/updateUserRole but the
+// module imports it.
 vi.mock('@/lib/auth/action-context', () => ({
   getActionContext: vi.fn().mockResolvedValue(null),
 }))
@@ -152,6 +161,12 @@ function setAdminSession() {
 function setRecruiterSession() {
   mockAuth.mockResolvedValue({
     user: { id: ADMIN_ID, tenantId: TENANT_ID, role: 'recruiter' },
+  })
+}
+
+function setViewerSession() {
+  mockAuth.mockResolvedValue({
+    user: { id: ADMIN_ID, tenantId: TENANT_ID, role: 'viewer' },
   })
 }
 
@@ -172,6 +187,14 @@ function makeUser(overrides: Partial<{
     isActive: true,
     ...overrides,
   }
+}
+
+// Helper for updateUserRole tests — wait for the queued microtask that
+// `emitAudit` schedules via `void writeAuditLog(...).catch(...)` so the spy
+// is observable before the assertion runs.
+async function flushMicrotasks() {
+  await Promise.resolve()
+  await Promise.resolve()
 }
 
 // ── deactivateUser ─────────────────────────────────────────────────────────────
@@ -328,5 +351,184 @@ describe('reactivateUser', () => {
     const meta = entry.metadata as Record<string, unknown>
     expect(meta.targetUserId).toBe(TARGET_ID)
     expect(meta.targetEmail).toBe('former@acme.com')
+  })
+})
+
+// ── updateUserRole ────────────────────────────────────────────────────────────
+
+describe('updateUserRole', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    txSelectQueue = []
+    setAdminSession()
+  })
+
+  it('returns Unauthorized when there is no session', async () => {
+    setNoSession()
+    const { updateUserRole } = await import('@/actions/users')
+
+    const result = await updateUserRole(TARGET_ID, 'admin')
+
+    expect(result.ok).toBe(false)
+    expect((result as { ok: false; error: string }).error).toMatch(/unauthorized/i)
+    expect(mockTxUpdateSet).not.toHaveBeenCalled()
+    expect(mockWriteAuditLog).not.toHaveBeenCalled()
+  })
+
+  it('returns Forbidden when caller is a recruiter (non-admin)', async () => {
+    setRecruiterSession()
+    const { updateUserRole } = await import('@/actions/users')
+
+    const result = await updateUserRole(TARGET_ID, 'admin')
+
+    expect(result.ok).toBe(false)
+    expect((result as { ok: false; error: string }).error).toMatch(/admin/i)
+    expect(mockTxUpdateSet).not.toHaveBeenCalled()
+    expect(mockWriteAuditLog).not.toHaveBeenCalled()
+  })
+
+  it('returns Forbidden when caller is a viewer', async () => {
+    setViewerSession()
+    const { updateUserRole } = await import('@/actions/users')
+
+    const result = await updateUserRole(TARGET_ID, 'recruiter')
+
+    expect(result.ok).toBe(false)
+    expect((result as { ok: false; error: string }).error).toMatch(/admin/i)
+    expect(mockTxUpdateSet).not.toHaveBeenCalled()
+    expect(mockWriteAuditLog).not.toHaveBeenCalled()
+  })
+
+  it('rejects self-demote (caller targets their own id)', async () => {
+    const { updateUserRole } = await import('@/actions/users')
+
+    const result = await updateUserRole(ADMIN_ID, 'recruiter')
+
+    expect(result.ok).toBe(false)
+    expect((result as { ok: false; error: string }).error).toMatch(/own role/i)
+    expect(mockTxUpdateSet).not.toHaveBeenCalled()
+    expect(mockWriteAuditLog).not.toHaveBeenCalled()
+  })
+
+  it('rejects when target user is not found in tenant', async () => {
+    txSelectQueue = [[]] // empty — user not found
+    const { updateUserRole } = await import('@/actions/users')
+
+    const result = await updateUserRole(TARGET_ID, 'recruiter')
+
+    expect(result.ok).toBe(false)
+    expect((result as { ok: false; error: string }).error).toMatch(/not found/i)
+    expect(mockTxUpdateSet).not.toHaveBeenCalled()
+    expect(mockWriteAuditLog).not.toHaveBeenCalled()
+  })
+
+  it('happy path: promotes a recruiter to admin, writes DB row + audit', async () => {
+    txSelectQueue = [
+      [makeUser({ id: TARGET_ID, role: 'recruiter' })],
+    ]
+    const { updateUserRole } = await import('@/actions/users')
+
+    const result = await updateUserRole(TARGET_ID, 'admin')
+
+    expect(result.ok).toBe(true)
+    expect(mockTxUpdateSet).toHaveBeenCalledWith({ role: 'admin' })
+    await flushMicrotasks()
+    expect(mockWriteAuditLog).toHaveBeenCalledTimes(1)
+    const [tenantArg, entry] = mockWriteAuditLog.mock.calls[0] as [
+      string,
+      { action: string; entityType: string; entityId: string; metadata: Record<string, unknown> },
+    ]
+    expect(tenantArg).toBe(TENANT_ID)
+    expect(entry.action).toBe('user.role_changed')
+    expect(entry.entityType).toBe('user')
+    expect(entry.entityId).toBe(TARGET_ID)
+    expect(entry.metadata).toEqual({
+      from: 'recruiter',
+      to: 'admin',
+      targetUserId: TARGET_ID,
+    })
+  })
+
+  it('happy path: demotes an admin to recruiter when other admins exist', async () => {
+    txSelectQueue = [
+      [makeUser({ id: TARGET_ID, role: 'admin' })],
+      [{ value: 3 }], // plenty of admins remaining
+    ]
+
+    const { updateUserRole } = await import('@/actions/users')
+
+    const result = await updateUserRole(TARGET_ID, 'recruiter')
+
+    expect(result.ok).toBe(true)
+    expect(mockTxUpdateSet).toHaveBeenCalledWith({ role: 'recruiter' })
+    await flushMicrotasks()
+    expect(mockWriteAuditLog).toHaveBeenCalledTimes(1)
+    const [, entry] = mockWriteAuditLog.mock.calls[0] as [
+      string,
+      { metadata: Record<string, unknown> },
+    ]
+    expect(entry.metadata).toEqual({
+      from: 'admin',
+      to: 'recruiter',
+      targetUserId: TARGET_ID,
+    })
+  })
+
+  it('last-admin guard: rejects demoting the sole active admin', async () => {
+    txSelectQueue = [
+      [makeUser({ id: TARGET_ID, role: 'admin' })],
+      [{ value: 1 }], // target IS the only admin
+    ]
+
+    const { updateUserRole } = await import('@/actions/users')
+
+    const result = await updateUserRole(TARGET_ID, 'recruiter')
+
+    expect(result.ok).toBe(false)
+    expect((result as { ok: false; error: string }).error).toMatch(/only active admin/i)
+    expect(mockTxUpdateSet).not.toHaveBeenCalled()
+    expect(mockWriteAuditLog).not.toHaveBeenCalled()
+  })
+
+  it('last-admin guard: also rejects demote to hiring_manager when sole admin', async () => {
+    txSelectQueue = [
+      [makeUser({ id: TARGET_ID, role: 'admin' })],
+      [{ value: 1 }],
+    ]
+
+    const { updateUserRole } = await import('@/actions/users')
+
+    const result = await updateUserRole(TARGET_ID, 'hiring_manager')
+
+    expect(result.ok).toBe(false)
+    expect((result as { ok: false; error: string }).error).toMatch(/only active admin/i)
+  })
+
+  it('last-admin guard does NOT fire when keeping admin role', async () => {
+    txSelectQueue = [
+      [makeUser({ id: TARGET_ID, role: 'admin' })],
+    ]
+
+    const { updateUserRole } = await import('@/actions/users')
+
+    // newRole === oldRole === 'admin' → no-op short-circuit
+    const result = await updateUserRole(TARGET_ID, 'admin')
+
+    expect(result.ok).toBe(true)
+    expect(mockTxUpdateSet).not.toHaveBeenCalled()
+    expect(mockWriteAuditLog).not.toHaveBeenCalled()
+  })
+
+  it('no-op when target already has the requested role: no DB write, no audit', async () => {
+    txSelectQueue = [
+      [makeUser({ id: TARGET_ID, role: 'recruiter' })],
+    ]
+    const { updateUserRole } = await import('@/actions/users')
+
+    const result = await updateUserRole(TARGET_ID, 'recruiter')
+
+    expect(result.ok).toBe(true)
+    expect(mockTxUpdateSet).not.toHaveBeenCalled()
+    expect(mockWriteAuditLog).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary

Issue #218 — admin role-reassignment server action + dropdown UI, with the
last-admin safety guard.

Closes #218
Part of #37

## What changed

**Server action — `src/actions/users.ts`**

`updateUserRole(userId, newRole)` now returns a structured result:

```ts
type UpdateUserRoleResult = { ok: true } | { ok: false; error: string }
```

Guards (in order):
1. Auth — session.user.tenantId required
2. Admin — caller must have role >= admin (uses `requireRole`)
3. Self-demote — caller cannot change their own role
4. Last-admin — if demoting an admin (newRole !== 'admin') and they are the
   only active admin in the tenant → reject

Target lookup + active-admin count run in a single `withTenant()`
transaction so RLS isolation is consistent across both reads. No DB schema
change — `userRoleEnum` already covers all four roles.

Re-applying the same role is a no-op (no write, no audit row).

**Audit**

Emits `user.role_changed` via `emitAudit` with metadata:

```json
{ "from": "recruiter", "to": "admin", "targetUserId": "cccccccc-..." }
```

`user.role_changed` was already in the `AuditAction` literal union in
`src/lib/audit.ts`.

**UI — `src/components/users/user-role-selector.tsx` (new)**

Dedicated per-row dropdown that:
- Calls `updateUserRole`, awaits the result
- Renders the error inline below the dropdown when `ok: false`
- Reverts the dropdown value on failure so the UI never drifts from server
- Disabled when `isSelf || isInactive || pending`

Wired into `src/components/settings/user-management-table.tsx`, replacing
the previous inline `<select>` block. The `ROLE_OPTIONS` constant moved with
the selector.

**API — `src/app/api/users/[userId]/role/route.ts`**

Forwards the new error shape: 404 for "User not found", 403 for the auth /
role / last-admin / self-demote rejections.

## Sample audit metadata

```json
{
  "action": "user.role_changed",
  "entityType": "user",
  "entityId": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
  "metadata": {
    "from": "recruiter",
    "to": "admin",
    "targetUserId": "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
  }
}
```

## Test plan

New file `tests/unit/actions/users.test.ts` — **11 tests, all passing**:

- [x] Happy path: promote recruiter → admin, audit emitted with correct
  `from` / `to` / `targetUserId`
- [x] Happy path: demote admin → recruiter when other admins exist
- [x] Last-admin guard: sole admin demote-to-recruiter rejected
- [x] Last-admin guard: sole admin demote-to-hiring_manager rejected
- [x] Last-admin guard does NOT fire when keeping admin role (no-op)
- [x] Self-demote rejected
- [x] Missing target user → "User not found"
- [x] No-op (same role) skips DB write + audit
- [x] No session → Unauthorized
- [x] Recruiter caller → Forbidden
- [x] Viewer caller → Forbidden

**Suite-wide:**
- [x] `npm test` → 866 passed | 4 skipped (4 skips pre-existing, unrelated)
- [x] `npx tsc --noEmit` → clean
- [x] Spot-check: deliberately broke one assertion, vitest caught the
  regression, reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)