### PR TITLE
feat(admin): admin-scoped audit log filters + CSV export

### DIFF
--- a/src/app/(dashboard)/dashboard/audit/page.tsx
+++ b/src/app/(dashboard)/dashboard/audit/page.tsx
@@ -1,13 +1,32 @@
-import { ShieldCheckIcon } from 'lucide-react'
+import { ShieldCheckIcon, DownloadIcon } from 'lucide-react'
 import { auth } from '@/lib/auth'
 import { withTenant } from '@/db'
-import { auditLogs } from '@/db/schema'
-import { desc } from 'drizzle-orm'
+import { auditLogs, users } from '@/db/schema'
+import { and, eq, gte, lte, like, desc, type SQL } from 'drizzle-orm'
 import type { AuditLog } from '@/db/schema/audit-logs'
 
+export const dynamic = 'force-dynamic'
 export const metadata = { title: 'Audit Log — SkillAI' }
 
-// Color badge per action prefix
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/**
+ * Well-known action-class prefixes exposed in the filter UI.
+ * Each maps to a LIKE pattern: "candidate.*" → "candidate.%"
+ */
+const ACTION_CLASSES = [
+  { value: 'user.*',               label: 'User' },
+  { value: 'candidate.*',          label: 'Candidate' },
+  { value: 'settings.*',           label: 'Settings' },
+  { value: 'score.*',              label: 'Score' },
+  { value: 'interview_pack.*',     label: 'Interview Pack' },
+  { value: 'transcript_analysis.*', label: 'Transcript Analysis' },
+  { value: 'tenant.*',             label: 'Tenant' },
+] as const
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Color badge per action prefix — matches original logic */
 function actionBadgeClass(action: string): string {
   if (action.endsWith('.created') || action.endsWith('.invited')) {
     return 'bg-blue-950 text-blue-400 border border-blue-700'
@@ -33,7 +52,40 @@ function formatMetadata(metadata: AuditLog['metadata']): string {
     .join(', ')
 }
 
-export default async function AuditLogPage() {
+/** Build a query-string from non-empty filter values */
+function buildFilterQs(params: Record<string, string | undefined>): string {
+  const qs = new URLSearchParams()
+  for (const [k, v] of Object.entries(params)) {
+    if (v) qs.set(k, v)
+  }
+  const s = qs.toString()
+  return s ? `?${s}` : ''
+}
+
+// ── Default date helpers ──────────────────────────────────────────────────────
+
+function defaultFromDate(): string {
+  const d = new Date()
+  d.setDate(d.getDate() - 7)
+  return d.toISOString().slice(0, 10) // YYYY-MM-DD
+}
+
+function todayDate(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+// ── Page component ────────────────────────────────────────────────────────────
+
+interface PageProps {
+  searchParams: Promise<{
+    user?: string
+    action?: string
+    from?: string
+    to?: string
+  }>
+}
+
+export default async function AuditLogPage({ searchParams }: PageProps) {
   const session = await auth()
   const isAdmin = session?.user.role === 'admin'
 
@@ -52,30 +104,228 @@ export default async function AuditLogPage() {
 
   const tenantId = session!.user.tenantId
 
-  const logs = await withTenant(tenantId, async (tx) =>
+  // ── Resolve filter params ─────────────────────────────────────────────────
+
+  const params = await searchParams
+  const userParam   = params.user   ?? undefined
+  const actionParam = params.action ?? undefined
+  // Default: last 7 days
+  const fromParam   = params.from   ?? defaultFromDate()
+  const toParam     = params.to     ?? todayDate()
+
+  // ── Fetch users list for the dropdown ─────────────────────────────────────
+
+  const tenantUsers = await withTenant(tenantId, async (tx) =>
     tx
+      .select({ id: users.id, email: users.email, name: users.name })
+      .from(users)
+      .where(eq(users.tenantId, tenantId))
+      .orderBy(users.email)
+  )
+
+  // ── Build DB filter conditions ─────────────────────────────────────────────
+
+  const conditions: SQL[] = []
+
+  if (userParam) {
+    conditions.push(eq(auditLogs.userId, userParam))
+  }
+
+  if (actionParam) {
+    const likePattern = actionParam.endsWith('*')
+      ? actionParam.slice(0, -1) + '%'
+      : actionParam
+    conditions.push(like(auditLogs.action, likePattern))
+  }
+
+  if (fromParam) {
+    const fromDate = new Date(fromParam)
+    if (!isNaN(fromDate.getTime())) {
+      fromDate.setUTCHours(0, 0, 0, 0)
+      conditions.push(gte(auditLogs.createdAt, fromDate))
+    }
+  }
+
+  if (toParam) {
+    const toDate = new Date(toParam)
+    if (!isNaN(toDate.getTime())) {
+      toDate.setUTCHours(23, 59, 59, 999)
+      conditions.push(lte(auditLogs.createdAt, toDate))
+    }
+  }
+
+  // ── Query audit logs ───────────────────────────────────────────────────────
+
+  const logs = await withTenant(tenantId, async (tx) => {
+    const q = tx
       .select()
       .from(auditLogs)
       .orderBy(desc(auditLogs.createdAt))
-      .limit(100)
-  )
+      .limit(500)
+    return conditions.length > 0 ? q.where(and(...conditions)) : q
+  })
+
+  // ── Build CSV export URL ───────────────────────────────────────────────────
+
+  const csvQs = buildFilterQs({ user: userParam, action: actionParam, from: fromParam, to: toParam })
+  const csvHref = `/api/export/audit${csvQs}`
 
   return (
     <div className="max-w-6xl">
       {/* Page header */}
-      <div className="flex items-center gap-3 mb-8">
-        <div className="p-2 bg-[var(--color-bg-elevated)] rounded-lg">
-          <ShieldCheckIcon className="h-5 w-5 text-[var(--color-fg-muted)]" />
+      <div className="flex items-center justify-between gap-3 mb-6">
+        <div className="flex items-center gap-3">
+          <div className="p-2 bg-[var(--color-bg-elevated)] rounded-lg">
+            <ShieldCheckIcon className="h-5 w-5 text-[var(--color-fg-muted)]" />
+          </div>
+          <div>
+            <h1 className="text-xl font-bold text-[var(--color-fg)]">Audit Log</h1>
+            <p className="text-sm text-[var(--color-fg-subtle)]">
+              {logs.length} event{logs.length !== 1 ? 's' : ''} matching current filters
+            </p>
+          </div>
         </div>
-        <div>
-          <h1 className="text-xl font-bold text-[var(--color-fg)]">Audit Log</h1>
-          <p className="text-sm text-[var(--color-fg-subtle)]">Last 100 events for your tenant</p>
-        </div>
+
+        {/* CSV export button */}
+        <a
+          href={csvHref}
+          className="inline-flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-medium
+                     bg-[var(--color-bg-elevated)] border border-[var(--color-border)]
+                     text-[var(--color-fg-muted)] hover:text-[var(--color-fg)]
+                     hover:bg-[var(--color-bg-input)] transition-colors"
+        >
+          <DownloadIcon className="h-3.5 w-3.5" />
+          Export CSV
+        </a>
       </div>
 
+      {/* Filter bar — submits via GET to update URL search params */}
+      <form
+        method="GET"
+        action="/dashboard/audit"
+        className="flex flex-wrap items-end gap-3 mb-6 p-4 rounded-xl
+                   bg-[var(--color-bg-elevated)] border border-[var(--color-border)]"
+      >
+        {/* User dropdown */}
+        <div className="flex flex-col gap-1 min-w-[180px]">
+          <label
+            htmlFor="audit-filter-user"
+            className="text-xs font-medium text-[var(--color-fg-muted)]"
+          >
+            User
+          </label>
+          <select
+            id="audit-filter-user"
+            name="user"
+            defaultValue={userParam ?? ''}
+            className="px-2 py-1.5 rounded-md text-xs
+                       bg-[var(--color-bg-input)] border border-[var(--color-border)]
+                       text-[var(--color-fg)] focus:outline-none focus:ring-1
+                       focus:ring-blue-600"
+          >
+            <option value="">All users</option>
+            {tenantUsers.map((u) => (
+              <option key={u.id} value={u.id}>
+                {u.email}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Action class dropdown */}
+        <div className="flex flex-col gap-1 min-w-[180px]">
+          <label
+            htmlFor="audit-filter-action"
+            className="text-xs font-medium text-[var(--color-fg-muted)]"
+          >
+            Action class
+          </label>
+          <select
+            id="audit-filter-action"
+            name="action"
+            defaultValue={actionParam ?? ''}
+            className="px-2 py-1.5 rounded-md text-xs
+                       bg-[var(--color-bg-input)] border border-[var(--color-border)]
+                       text-[var(--color-fg)] focus:outline-none focus:ring-1
+                       focus:ring-blue-600"
+          >
+            <option value="">All actions</option>
+            {ACTION_CLASSES.map((cls) => (
+              <option key={cls.value} value={cls.value}>
+                {cls.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* From date */}
+        <div className="flex flex-col gap-1">
+          <label
+            htmlFor="audit-filter-from"
+            className="text-xs font-medium text-[var(--color-fg-muted)]"
+          >
+            From
+          </label>
+          <input
+            id="audit-filter-from"
+            type="date"
+            name="from"
+            defaultValue={fromParam}
+            className="px-2 py-1.5 rounded-md text-xs
+                       bg-[var(--color-bg-input)] border border-[var(--color-border)]
+                       text-[var(--color-fg)] focus:outline-none focus:ring-1
+                       focus:ring-blue-600"
+          />
+        </div>
+
+        {/* To date */}
+        <div className="flex flex-col gap-1">
+          <label
+            htmlFor="audit-filter-to"
+            className="text-xs font-medium text-[var(--color-fg-muted)]"
+          >
+            To
+          </label>
+          <input
+            id="audit-filter-to"
+            type="date"
+            name="to"
+            defaultValue={toParam}
+            className="px-2 py-1.5 rounded-md text-xs
+                       bg-[var(--color-bg-input)] border border-[var(--color-border)]
+                       text-[var(--color-fg)] focus:outline-none focus:ring-1
+                       focus:ring-blue-600"
+          />
+        </div>
+
+        {/* Submit */}
+        <button
+          type="submit"
+          className="px-3 py-1.5 rounded-md text-xs font-medium
+                     bg-blue-600 text-white hover:bg-blue-500
+                     focus:outline-none focus:ring-1 focus:ring-blue-400
+                     transition-colors"
+        >
+          Apply
+        </button>
+
+        {/* Clear link — strips all params */}
+        <a
+          href="/dashboard/audit"
+          className="px-3 py-1.5 rounded-md text-xs font-medium
+                     text-[var(--color-fg-muted)] hover:text-[var(--color-fg)]
+                     transition-colors"
+        >
+          Clear
+        </a>
+      </form>
+
+      {/* Results table */}
       {logs.length === 0 ? (
         <div className="rounded-xl bg-[var(--color-bg-elevated)] border border-[var(--color-border)] px-5 py-4">
-          <p className="text-sm text-[var(--color-fg-subtle)]">No audit events recorded yet.</p>
+          <p className="text-sm text-[var(--color-fg-subtle)]">
+            No audit events match the current filters.
+          </p>
         </div>
       ) : (
         <div className="rounded-xl border border-[var(--color-border)] overflow-hidden">
@@ -101,7 +351,10 @@ export default async function AuditLogPage() {
             </thead>
             <tbody className="divide-y divide-[var(--color-bg-elevated)]">
               {logs.map((log) => (
-                <tr key={log.id} className="bg-[var(--color-bg-app)] hover:bg-[var(--color-bg-input)] transition-colors">
+                <tr
+                  key={log.id}
+                  className="bg-[var(--color-bg-app)] hover:bg-[var(--color-bg-input)] transition-colors"
+                >
                   <td className="px-4 py-3 text-[var(--color-fg-subtle)] text-xs whitespace-nowrap">
                     {new Date(log.createdAt).toLocaleString('en-GB', {
                       day: '2-digit',

--- a/src/app/api/export/audit/route.ts
+++ b/src/app/api/export/audit/route.ts
@@ -1,0 +1,152 @@
+/**
+ * GET /api/export/audit
+ *
+ * Admin-only CSV export of audit log rows, scoped to the authenticated user's
+ * tenant.  Supports the same filter params as the audit log page so the
+ * download always mirrors what the admin currently sees.
+ *
+ * Query params (all optional):
+ *   user        UUID of a specific user to filter on
+ *   action      Action-class prefix, e.g. "user.*" or "candidate.*"
+ *   from        ISO date string — start of range (inclusive, UTC midnight)
+ *   to          ISO date string — end of range (inclusive, UTC end-of-day)
+ *
+ * Response columns: created_at, actor_email, action, entity_type, entity_id,
+ *   entity_label, metadata_json
+ *
+ * Auth:  session required + admin role
+ * Audit: fires audit.exported_csv with { filters, rowCount }
+ */
+
+import { auth } from '@/lib/auth'
+import { emitAudit } from '@/lib/audit-middleware'
+import { withTenant } from '@/db'
+import { auditLogs } from '@/db/schema'
+import { and, eq, gte, lte, like, desc, type SQL } from 'drizzle-orm'
+import { toCsv } from '@/lib/reports/to-csv'
+
+// ── Response helpers ───────────────────────────────────────────────────────────
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function csvResponse(csv: string, filename: string): Response {
+  return new Response(csv, {
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': `attachment; filename="${filename}"`,
+    },
+  })
+}
+
+function utcDateString(): string {
+  const now = new Date()
+  const yyyy = now.getUTCFullYear()
+  const mm = String(now.getUTCMonth() + 1).padStart(2, '0')
+  const dd = String(now.getUTCDate()).padStart(2, '0')
+  return `${yyyy}-${mm}-${dd}`
+}
+
+// ── CSV column spec ────────────────────────────────────────────────────────────
+
+const AUDIT_CSV_HEADERS = [
+  { key: 'created_at',    label: 'created_at'    },
+  { key: 'actor_email',   label: 'actor_email'   },
+  { key: 'action',        label: 'action'        },
+  { key: 'entity_type',   label: 'entity_type'   },
+  { key: 'entity_id',     label: 'entity_id'     },
+  { key: 'entity_label',  label: 'entity_label'  },
+  { key: 'metadata_json', label: 'metadata_json' },
+]
+
+// ── Route handler ──────────────────────────────────────────────────────────────
+
+export async function GET(req: Request): Promise<Response> {
+  // 1. Auth — require a session with a tenantId
+  const session = await auth()
+  if (!session?.user?.tenantId) return json({ error: 'Unauthorized' }, 401)
+
+  // 2. Admin gate
+  if (session.user.role !== 'admin') return json({ error: 'Forbidden' }, 403)
+
+  const tenantId = session.user.tenantId
+
+  // 3. Parse filter params
+  const url = new URL(req.url)
+  const userParam   = url.searchParams.get('user')   ?? undefined
+  const actionParam = url.searchParams.get('action') ?? undefined
+  const fromParam   = url.searchParams.get('from')   ?? undefined
+  const toParam     = url.searchParams.get('to')     ?? undefined
+
+  // 4. Build where conditions
+  const conditions: SQL[] = []
+
+  if (userParam) {
+    conditions.push(eq(auditLogs.userId, userParam))
+  }
+
+  if (actionParam) {
+    // e.g. "user.*" → LIKE 'user.%'
+    const likePattern = actionParam.endsWith('*')
+      ? actionParam.slice(0, -1) + '%'
+      : actionParam
+    conditions.push(like(auditLogs.action, likePattern))
+  }
+
+  if (fromParam) {
+    const fromDate = new Date(fromParam)
+    if (!isNaN(fromDate.getTime())) {
+      fromDate.setUTCHours(0, 0, 0, 0)
+      conditions.push(gte(auditLogs.createdAt, fromDate))
+    }
+  }
+
+  if (toParam) {
+    const toDate = new Date(toParam)
+    if (!isNaN(toDate.getTime())) {
+      toDate.setUTCHours(23, 59, 59, 999)
+      conditions.push(lte(auditLogs.createdAt, toDate))
+    }
+  }
+
+  // 5. Query DB
+  const rows = await withTenant(tenantId, async (tx) => {
+    const q = tx.select().from(auditLogs).orderBy(desc(auditLogs.createdAt))
+    return conditions.length > 0 ? q.where(and(...conditions)) : q
+  })
+
+  // 6. Map rows to CSV-ready flat records
+  const csvRows = rows.map((row) => ({
+    created_at:    row.createdAt,
+    actor_email:   row.userEmail ?? row.userId ?? '',
+    action:        row.action,
+    entity_type:   row.entityType,
+    entity_id:     row.entityId ?? '',
+    entity_label:  row.entityLabel ?? '',
+    metadata_json: row.metadata !== null && row.metadata !== undefined
+      ? JSON.stringify(row.metadata)
+      : '',
+  }))
+
+  const csv = toCsv(csvRows, AUDIT_CSV_HEADERS)
+
+  // 7. Fire-and-forget audit row (new action)
+  emitAudit(tenantId, {
+    action: 'audit.exported_csv',
+    entityType: 'audit',
+    entityId: tenantId,
+    metadata: {
+      filters: { user: userParam, action: actionParam, from: fromParam, to: toParam },
+      rowCount: rows.length,
+    },
+  })
+
+  // 8. Filename: skillai-audit-{tenantId}-{YYYY-MM-DD}.csv
+  const filename = `skillai-audit-${tenantId}-${utcDateString()}.csv`
+
+  return csvResponse(csv, filename)
+}

--- a/tests/unit/api/audit-export-route.test.ts
+++ b/tests/unit/api/audit-export-route.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Unit tests for GET /api/export/audit
+ *
+ * Tests: admin gate, filter parsing, audit emission, CSV response shape.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Mocks — must be declared before any imports that transitively load them ───
+
+vi.mock('@/lib/auth', () => ({ auth: vi.fn() }))
+vi.mock('@/lib/audit-middleware', () => ({ emitAudit: vi.fn() }))
+vi.mock('@/db', () => ({ withTenant: vi.fn() }))
+
+// ── Import subjects after mocks ───────────────────────────────────────────────
+
+import { GET } from '@/app/api/export/audit/route'
+import { auth } from '@/lib/auth'
+import { emitAudit } from '@/lib/audit-middleware'
+import { withTenant } from '@/db'
+
+const mockAuth     = vi.mocked(auth)
+const mockEmit     = vi.mocked(emitAudit)
+const mockWithTenant = vi.mocked(withTenant)
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const ADMIN_SESSION = {
+  user: { tenantId: 'tenant-abc', role: 'admin' as const },
+  expires: '2099-01-01',
+}
+
+const RECRUITER_SESSION = {
+  user: { tenantId: 'tenant-abc', role: 'recruiter' as const },
+  expires: '2099-01-01',
+}
+
+const SAMPLE_LOGS = [
+  {
+    id: 'log-1',
+    tenantId: 'tenant-abc',
+    userId: 'user-1',
+    userEmail: 'recruiter@acme.com',
+    action: 'candidate.created',
+    entityType: 'candidate',
+    entityId: 'cand-1',
+    entityLabel: 'Jane Smith',
+    metadata: { agencyId: 'ag-1' },
+    createdAt: new Date('2026-05-20T10:00:00.000Z'),
+  },
+]
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeReq(url: string): Request {
+  return new Request(url)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('GET /api/export/audit', () => {
+  // ── Auth / authorisation ──────────────────────────────────────────────────
+
+  it('returns 401 when there is no session', async () => {
+    mockAuth.mockResolvedValue(null as never)
+    const res = await GET(makeReq('http://localhost/api/export/audit'))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 when session has no tenantId', async () => {
+    mockAuth.mockResolvedValue({ user: { role: 'admin' }, expires: '2099-01-01' } as never)
+    const res = await GET(makeReq('http://localhost/api/export/audit'))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 when the session role is recruiter', async () => {
+    mockAuth.mockResolvedValue(RECRUITER_SESSION as never)
+    const res = await GET(makeReq('http://localhost/api/export/audit'))
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 403 when the session role is viewer', async () => {
+    mockAuth.mockResolvedValue({
+      user: { tenantId: 'tenant-abc', role: 'viewer' },
+      expires: '2099-01-01',
+    } as never)
+    const res = await GET(makeReq('http://localhost/api/export/audit'))
+    expect(res.status).toBe(403)
+  })
+
+  // ── Happy path — no filters ───────────────────────────────────────────────
+
+  it('returns 200 with text/csv content-type for a valid admin session', async () => {
+    mockAuth.mockResolvedValue(ADMIN_SESSION as never)
+    mockWithTenant.mockResolvedValue(SAMPLE_LOGS as never)
+
+    const res = await GET(makeReq('http://localhost/api/export/audit'))
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('text/csv; charset=utf-8')
+  })
+
+  it('returns Content-Disposition attachment with a .csv filename', async () => {
+    mockAuth.mockResolvedValue(ADMIN_SESSION as never)
+    mockWithTenant.mockResolvedValue(SAMPLE_LOGS as never)
+
+    const res = await GET(makeReq('http://localhost/api/export/audit'))
+
+    const cd = res.headers.get('Content-Disposition') ?? ''
+    expect(cd).toContain('attachment')
+    expect(cd).toContain('skillai-audit-tenant-abc-')
+    expect(cd).toMatch(/\.csv"$/)
+  })
+
+  it('includes the correct header row in the CSV body', async () => {
+    mockAuth.mockResolvedValue(ADMIN_SESSION as never)
+    mockWithTenant.mockResolvedValue(SAMPLE_LOGS as never)
+
+    const res = await GET(makeReq('http://localhost/api/export/audit'))
+    const body = await res.text()
+
+    expect(body.startsWith(
+      'created_at,actor_email,action,entity_type,entity_id,entity_label,metadata_json\r\n',
+    )).toBe(true)
+  })
+
+  it('includes the data row with expected values', async () => {
+    mockAuth.mockResolvedValue(ADMIN_SESSION as never)
+    mockWithTenant.mockResolvedValue(SAMPLE_LOGS as never)
+
+    const res = await GET(makeReq('http://localhost/api/export/audit'))
+    const body = await res.text()
+
+    expect(body).toContain('recruiter@acme.com')
+    expect(body).toContain('candidate.created')
+    expect(body).toContain('Jane Smith')
+  })
+
+  it('emits audit.exported_csv with rowCount metadata', async () => {
+    mockAuth.mockResolvedValue(ADMIN_SESSION as never)
+    mockWithTenant.mockResolvedValue(SAMPLE_LOGS as never)
+
+    await GET(makeReq('http://localhost/api/export/audit'))
+
+    expect(mockEmit).toHaveBeenCalledOnce()
+    const [tenantId, entry] = mockEmit.mock.calls[0]
+    expect(tenantId).toBe('tenant-abc')
+    expect(entry.action).toBe('audit.exported_csv')
+    expect((entry.metadata as Record<string, unknown>)?.rowCount).toBe(1)
+  })
+
+  // ── Filter parsing ────────────────────────────────────────────────────────
+
+  it('passes filter params through to the audit metadata', async () => {
+    mockAuth.mockResolvedValue(ADMIN_SESSION as never)
+    mockWithTenant.mockResolvedValue([] as never)
+
+    const url = 'http://localhost/api/export/audit?user=user-1&action=candidate.*&from=2026-05-01&to=2026-05-20'
+    await GET(makeReq(url))
+
+    expect(mockEmit).toHaveBeenCalledOnce()
+    const [, entry] = mockEmit.mock.calls[0]
+    const filters = (entry.metadata as Record<string, unknown>)?.filters as Record<string, string>
+    expect(filters.user).toBe('user-1')
+    expect(filters.action).toBe('candidate.*')
+    expect(filters.from).toBe('2026-05-01')
+    expect(filters.to).toBe('2026-05-20')
+  })
+
+  it('emits rowCount=0 when the DB returns no rows', async () => {
+    mockAuth.mockResolvedValue(ADMIN_SESSION as never)
+    mockWithTenant.mockResolvedValue([] as never)
+
+    await GET(makeReq('http://localhost/api/export/audit'))
+
+    const [, entry] = mockEmit.mock.calls[0]
+    expect((entry.metadata as Record<string, unknown>)?.rowCount).toBe(0)
+  })
+
+  it('produces only the header line when there are no log rows', async () => {
+    mockAuth.mockResolvedValue(ADMIN_SESSION as never)
+    mockWithTenant.mockResolvedValue([] as never)
+
+    const res = await GET(makeReq('http://localhost/api/export/audit'))
+    const body = await res.text()
+
+    // Only the header + trailing CRLF = two CRLF-delimited tokens, second empty
+    const lines = body.split('\r\n')
+    expect(lines[0]).toMatch(/^created_at,/)
+    expect(lines[1]).toBe('')
+  })
+
+  it('emits filters.user undefined when no user param supplied', async () => {
+    mockAuth.mockResolvedValue(ADMIN_SESSION as never)
+    mockWithTenant.mockResolvedValue([] as never)
+
+    await GET(makeReq('http://localhost/api/export/audit'))
+
+    const [, entry] = mockEmit.mock.calls[0]
+    const filters = (entry.metadata as Record<string, unknown>)?.filters as Record<string, unknown>
+    expect(filters.user).toBeUndefined()
+    expect(filters.action).toBeUndefined()
+  })
+})

--- a/tests/unit/lib/reports/audit-csv.test.ts
+++ b/tests/unit/lib/reports/audit-csv.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for the CSV row shape produced by the audit export route.
+ *
+ * We exercise the CSV serialisation layer in isolation by importing the
+ * RFC 4180 helpers directly — no DB, no auth.
+ */
+import { describe, it, expect } from 'vitest'
+import { toCsv, escapeCsvField } from '@/lib/reports/to-csv'
+
+// ── Shared column spec (mirrors route.ts) ─────────────────────────────────────
+
+const AUDIT_CSV_HEADERS = [
+  { key: 'created_at',    label: 'created_at'    },
+  { key: 'actor_email',   label: 'actor_email'   },
+  { key: 'action',        label: 'action'        },
+  { key: 'entity_type',   label: 'entity_type'   },
+  { key: 'entity_id',     label: 'entity_id'     },
+  { key: 'entity_label',  label: 'entity_label'  },
+  { key: 'metadata_json', label: 'metadata_json' },
+]
+
+// ── Fixture ───────────────────────────────────────────────────────────────────
+
+const AUDIT_ROW = {
+  created_at:    new Date('2026-05-20T10:00:00.000Z'),
+  actor_email:   'recruiter@acme.com',
+  action:        'candidate.created',
+  entity_type:   'candidate',
+  entity_id:     'cand-uuid-1234',
+  entity_label:  'Jane Smith',
+  metadata_json: JSON.stringify({ source: 'manual', agencyId: 'ag-1' }),
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('audit CSV row shape', () => {
+  it('produces the expected header row', () => {
+    const csv = toCsv([], AUDIT_CSV_HEADERS)
+    const headerLine = csv.split('\r\n')[0]
+    expect(headerLine).toBe(
+      'created_at,actor_email,action,entity_type,entity_id,entity_label,metadata_json',
+    )
+  })
+
+  it('serialises all seven columns in the correct order', () => {
+    const csv = toCsv([AUDIT_ROW], AUDIT_CSV_HEADERS)
+    const lines = csv.split('\r\n')
+    // lines[0] = header, lines[1] = first data row, lines[2] = trailing CRLF
+    expect(lines.length).toBe(3)
+    expect(lines[2]).toBe('')
+
+    const dataLine = lines[1]
+    // created_at is a Date → ISO string
+    expect(dataLine).toContain('2026-05-20T10:00:00.000Z')
+    expect(dataLine).toContain('recruiter@acme.com')
+    expect(dataLine).toContain('candidate.created')
+    expect(dataLine).toContain('candidate')
+    expect(dataLine).toContain('cand-uuid-1234')
+    expect(dataLine).toContain('Jane Smith')
+  })
+
+  it('serialises metadata_json as a JSON string wrapped in quotes (contains braces)', () => {
+    const csv = toCsv([AUDIT_ROW], AUDIT_CSV_HEADERS)
+    const dataLine = csv.split('\r\n')[1]
+    // JSON strings contain commas and double-quotes — RFC 4180 wraps in
+    // outer double-quotes and escapes inner double-quotes by doubling them.
+    // e.g. {"source":"manual"} → "{""source"":""manual"",...}"
+    expect(dataLine).toContain('"{""source"":""manual""')
+    expect(dataLine).toContain('""agencyId"":""ag-1""}"')
+  })
+
+  it('emits empty string for null entity_id', () => {
+    const row = { ...AUDIT_ROW, entity_id: '' }
+    const csv = toCsv([row], AUDIT_CSV_HEADERS)
+    const fields = csv.split('\r\n')[1].split(',')
+    // entity_id is the 5th column (index 4)
+    expect(fields[4]).toBe('')
+  })
+
+  it('emits empty string for null entity_label', () => {
+    const row = { ...AUDIT_ROW, entity_label: '' }
+    const csv = toCsv([row], AUDIT_CSV_HEADERS)
+    const fields = csv.split('\r\n')[1].split(',')
+    // entity_label is the 6th column (index 5)
+    expect(fields[5]).toBe('')
+  })
+
+  it('emits empty string for null metadata_json', () => {
+    const row = { ...AUDIT_ROW, metadata_json: '' }
+    const csv = toCsv([row], AUDIT_CSV_HEADERS)
+    const fields = csv.split('\r\n')[1].split(',')
+    // metadata_json is the 7th column (index 6)
+    expect(fields[6]).toBe('')
+  })
+
+  it('handles entity_label containing a comma by wrapping in quotes', () => {
+    const row = { ...AUDIT_ROW, entity_label: 'Smith, Jane' }
+    const csv = toCsv([row], AUDIT_CSV_HEADERS)
+    expect(csv).toContain('"Smith, Jane"')
+  })
+
+  it('produces only the header row when given an empty rows array', () => {
+    const csv = toCsv([], AUDIT_CSV_HEADERS)
+    expect(csv).toBe(
+      'created_at,actor_email,action,entity_type,entity_id,entity_label,metadata_json\r\n',
+    )
+  })
+
+  it('escapeCsvField coerces a Date to ISO string', () => {
+    const d = new Date('2026-05-20T10:00:00.000Z')
+    expect(escapeCsvField(d)).toBe('2026-05-20T10:00:00.000Z')
+  })
+})


### PR DESCRIPTION
## Summary

- Adds filter bar to `/dashboard/audit` — user dropdown (all tenant users), action-class select (7 prefixes), from/to date pickers defaulting to last 7 days. Filters update via GET form submission so URLs are shareable.
- New `GET /api/export/audit` endpoint — admin-only, honours the same `?user&action&from&to` params, streams RFC 4180 CSV using the existing `toCsv` helper from `src/lib/reports/to-csv.ts`.
- New `audit.exported_csv` audit action emitted on every export with `{ filters, rowCount }` metadata.
- Page limit raised from 100 → 500; `export const dynamic = 'force-dynamic'` added per the prerender constraint documented in CLAUDE.md.

**CSV columns:** `created_at`, `actor_email`, `action`, `entity_type`, `entity_id`, `entity_label`, `metadata_json`

**Filter param schema:**
| Param | Type | Example | Notes |
|---|---|---|---|
| `user` | UUID string | `?user=<uuid>` | Exact match on `userId` |
| `action` | string | `?action=candidate.*` | Trailing `*` becomes SQL `LIKE 'candidate.%'` |
| `from` | YYYY-MM-DD | `?from=2026-05-01` | UTC midnight start |
| `to` | YYYY-MM-DD | `?to=2026-05-20` | UTC end-of-day |

## Test plan

- [x] `npm test` — 877 passed, 0 failed (22 new tests added)
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: visit `/dashboard/audit` as admin → filter bar renders with user list populated
- [ ] Manual: apply user filter → table narrows; URL updates with `?user=<uuid>`
- [ ] Manual: apply action class `candidate.*` → only candidate actions shown
- [ ] Manual: click "Export CSV" → file downloads with correct 7-column header
- [ ] Manual: change date range → CSV reflects filtered rows; `audit.exported_csv` appears in the log

closes #222
Part of #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)