### PR TITLE
fix(skills): use process.cwd() path + fail-safe loader (scoring break)

### DIFF
--- a/src/lib/ai/skills/index.ts
+++ b/src/lib/ai/skills/index.ts
@@ -25,45 +25,57 @@ export type LoadedHrSkill = { name: string; content: string }
 // mutated after first write.
 const cache = new Map<SkillProfile, LoadedHrSkill>()
 
-// `import.meta.dirname` is the canonical accessor under Node ≥ 20 ESM and
-// modern bundlers; `__dirname` is the CJS fallback. Vitest and Next.js both
-// resolve one or the other depending on transform.
-function dirOfThisFile(): string {
-  const importMetaDir = typeof import.meta !== 'undefined' ? import.meta.dirname : undefined
-  return importMetaDir ?? __dirname
-}
+// Anchor reads to `process.cwd()` rather than `import.meta.dirname` / `__dirname`.
+// Next.js + turbopack rewrite both to opaque tokens like `/ROOT/...` for compiled
+// server bundles, which then ENOENT at runtime. This is the same pattern used by
+// the help-article loader at src/lib/help/loader.ts:61 — `process.cwd()` resolves
+// to the project root in dev (the bind-mount root in Docker) and to the
+// standalone server root in production.
+const SKILLS_DIR = path.join(process.cwd(), 'src', 'lib', 'ai', 'skills')
 
 function readSkillFile(filename: string): string {
-  return fs.readFileSync(path.join(dirOfThisFile(), filename), 'utf-8')
+  return fs.readFileSync(path.join(SKILLS_DIR, filename), 'utf-8')
 }
 
-export function loadHrSkill(profile: SkillProfile): LoadedHrSkill {
+export function loadHrSkill(profile: SkillProfile): LoadedHrSkill | null {
   const cached = cache.get(profile)
   if (cached) return cached
 
   let loaded: LoadedHrSkill
-  switch (profile) {
-    case 'talent-acquisition':
-      loaded = { name: 'talent-acquisition', content: readSkillFile('talent-acquisition.md') }
-      break
-    case 'people-analytics':
-      loaded = { name: 'people-analytics', content: readSkillFile('people-analytics.md') }
-      break
-    case 'recruiter-eu-uk': {
-      const ta = readSkillFile('talent-acquisition.md')
-      const supplement = readSkillFile('eu-uk-supplement.md')
-      loaded = {
-        name: 'recruiter-eu-uk',
-        content: `${ta}\n\n---\n\n${supplement}`,
+  try {
+    switch (profile) {
+      case 'talent-acquisition':
+        loaded = { name: 'talent-acquisition', content: readSkillFile('talent-acquisition.md') }
+        break
+      case 'people-analytics':
+        loaded = { name: 'people-analytics', content: readSkillFile('people-analytics.md') }
+        break
+      case 'recruiter-eu-uk': {
+        const ta = readSkillFile('talent-acquisition.md')
+        const supplement = readSkillFile('eu-uk-supplement.md')
+        loaded = {
+          name: 'recruiter-eu-uk',
+          content: `${ta}\n\n---\n\n${supplement}`,
+        }
+        break
       }
-      break
+      default: {
+        // Exhaustiveness check — TS will error if a new SkillProfile member is
+        // added without updating this switch.
+        const _exhaustive: never = profile
+        throw new Error(`Unknown HR skill profile: ${String(_exhaustive)}`)
+      }
     }
-    default: {
-      // Exhaustiveness check — TS will error if a new SkillProfile member is
-      // added without updating this switch.
-      const _exhaustive: never = profile
-      throw new Error(`Unknown HR skill profile: ${String(_exhaustive)}`)
-    }
+  } catch (err) {
+    // Fail-safe: a missing skill file or unexpected error must NEVER kill a
+    // scoring / interview / transcript-analysis call. Log it and degrade
+    // gracefully — the system array shape becomes byte-identical to the
+    // toggle-OFF path, which is the expected fallback per Phase 2 design.
+    console.warn(
+      `[hr-skill] loadHrSkill(${profile}) failed; degrading to toggle-OFF behaviour:`,
+      err instanceof Error ? err.message : err
+    )
+    return null
   }
 
   cache.set(profile, loaded)

--- a/tests/unit/lib/ai/skills.test.ts
+++ b/tests/unit/lib/ai/skills.test.ts
@@ -46,30 +46,30 @@ describe('loadHrSkill', () => {
 
   it('returns name + content for the talent-acquisition profile', () => {
     const result = loadHrSkill('talent-acquisition')
-    expect(result.name).toBe('talent-acquisition')
-    expect(result.content.length).toBeGreaterThan(100)
-    expect(result.content).toContain('# Talent Acquisition')
+    expect(result!.name).toBe('talent-acquisition')
+    expect(result!.content.length).toBeGreaterThan(100)
+    expect(result!.content).toContain('# Talent Acquisition')
   })
 
   it('returns name + content for the people-analytics profile', () => {
     const result = loadHrSkill('people-analytics')
-    expect(result.name).toBe('people-analytics')
-    expect(result.content.length).toBeGreaterThan(100)
-    expect(result.content).toContain('# People Analytics')
+    expect(result!.name).toBe('people-analytics')
+    expect(result!.content.length).toBeGreaterThan(100)
+    expect(result!.content).toContain('# People Analytics')
   })
 
   it('combines talent-acquisition + eu-uk-supplement for recruiter-eu-uk', () => {
     const result = loadHrSkill('recruiter-eu-uk')
-    expect(result.name).toBe('recruiter-eu-uk')
+    expect(result!.name).toBe('recruiter-eu-uk')
     // Both source files' headings show up in the combined content.
-    expect(result.content).toContain('# Talent Acquisition')
-    expect(result.content).toContain('# EU/UK Right-to-Work Supplement')
+    expect(result!.content).toContain('# Talent Acquisition')
+    expect(result!.content).toContain('# EU/UK Right-to-Work Supplement')
     // Separator between the two files.
-    expect(result.content).toContain('\n\n---\n\n')
+    expect(result!.content).toContain('\n\n---\n\n')
     // Reasonable combined size: >500 B (lower than concatenated mock content)
     // and <50 KB (so we never serialise an absurd system prompt).
-    expect(result.content.length).toBeGreaterThan(500)
-    expect(result.content.length).toBeLessThan(50_000)
+    expect(result!.content.length).toBeGreaterThan(500)
+    expect(result!.content.length).toBeLessThan(50_000)
   })
 
   it('caches per-profile and does not re-read fs on a second call', async () => {


### PR DESCRIPTION
## Symptom

Scoring kicked off via the candidate-detail page but never completed — score-status polled forever. Container logs:

\`\`\`
Error: ENOENT: no such file or directory, open '/ROOT/src/lib/ai/skills/talent-acquisition.md'
    at readSkillFile (src/lib/ai/skills/index.ts:37)
    at loadHrSkill (src/lib/ai/skills/index.ts:53)
    at triggerScoring (src/lib/ai/scoring.ts:45)
\`\`\`

## Root cause (two issues)

**1. Wrong path resolution.** \`dirOfThisFile()\` used \`import.meta.dirname || __dirname\` — both resolve to opaque \`/ROOT/...\` tokens in Next.js turbopack server bundles. The .md files exist on disk at \`src/lib/ai/skills/*.md\` but the helper couldn't find them via that path.

**2. Throw kills scoring silently.** The exception propagated up through \`triggerScoring\` and was eaten by the fire-and-forget \`after()\` handler, leaving \`scores\` rows stuck in 'pending' forever while the frontend polled.

## Fix

- **Anchor to \`process.cwd()\`** (same pattern as \`src/lib/help/loader.ts:61\` for help articles)
- **Wrap in try/catch** — on error, log a warn and return \`null\`. Call sites already handle nullable returns via \`hrSettings.enabled ? loadHrSkill(...) : null\`, so degraded behaviour is byte-identical to toggle-OFF. AI calls succeed, scoring completes, audit metadata records \`skill_used: null\` for the failed-load case.

Function return type changes from \`LoadedHrSkill\` to \`LoadedHrSkill | null\`.

## Workaround until merge

Tenant admins can disable the HR skill toggle at \`/settings → AI Behaviour\` — that returns scoring to the pre-Phase-2 path.

## Verification

- 4/4 existing tests in \`tests/unit/lib/ai/skills.test.ts\` still pass
- CI gate (test + typecheck + build) handles the rest
- Bind-mount picks up the fix immediately in dev; new scoring attempts use the new code

## Stuck score rows

Existing 'pending' \`scores\` rows from before this fix won't auto-resolve — they were never marked as failed. Operator can either:
- Trigger a re-score on those candidates (cheapest)
- Or update DB directly: \`UPDATE scores SET score_status = 'failed' WHERE score_status = 'pending' AND created_at < NOW() - INTERVAL '5 minutes'\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)