### PR TITLE
fix(pdf): structured CV section with heuristic + markdown formatting

### DIFF
--- a/src/lib/pdf/candidate-pdf.tsx
+++ b/src/lib/pdf/candidate-pdf.tsx
@@ -8,6 +8,7 @@ import {
   StyleSheet,
 } from '@react-pdf/renderer'
 import { base, colors } from './styles'
+import { parseCvBlocks } from './cv-formatter'
 import type { candidates, scores, roles } from '@/db/schema'
 import type { QuestionResponse } from '@/db/schema/transcript-analyses'
 import type { WebHit, GitHubProfile } from '@/db/schema/candidate-enrichments'
@@ -301,6 +302,29 @@ const s = StyleSheet.create({
     fontSize: 8.5,
     color: colors.slate700,
     lineHeight: 1.6,
+  },
+  cvSectionHeading: {
+    fontSize: 10,
+    fontWeight: 'bold',
+    color: colors.slate900,
+    marginTop: 10,
+    marginBottom: 4,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  cvSubHeading: {
+    fontSize: 9,
+    fontWeight: 'bold',
+    color: colors.slate700,
+    marginTop: 6,
+    marginBottom: 2,
+  },
+  cvBullet: {
+    fontSize: 8.5,
+    color: colors.slate700,
+    lineHeight: 1.5,
+    marginLeft: 10,
+    marginBottom: 2,
   },
 
   // Section header row (h2 + optional badge on the same line)
@@ -1135,21 +1159,36 @@ function ComplianceSection({ candidate }: { candidate: Candidate }) {
 // Section: CV Text
 // ---------------------------------------------------------------------------
 function CvTextSection({ cvText, cvTextFormatted }: { cvText: string; cvTextFormatted?: string | null }) {
-  // Prefer AI-formatted version when present — split by blank lines into
-  // paragraphs for proper PDF spacing. Falls back to raw cvText.
-  const text = cvTextFormatted ?? cvText
-  const paragraphs = text.split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean)
+  // Prefer AI-formatted (markdown) version when present; fall back to raw
+  // cv_text. The parser handles both — it auto-detects markdown markers and
+  // otherwise injects section breaks before known CV headings.
+  const blocks = parseCvBlocks(cvTextFormatted ?? cvText)
+
+  if (blocks.length === 0) {
+    return (
+      <View>
+        <Text style={base.h2}>Curriculum Vitae</Text>
+        <Text style={s.cvText}>(no CV text available)</Text>
+      </View>
+    )
+  }
 
   return (
     <View>
       <Text style={base.h2}>Curriculum Vitae</Text>
-      {paragraphs.length > 0 ? (
-        paragraphs.map((para, i) => (
-          <Text key={i} style={[s.cvText, { marginBottom: 6 }]}>{para}</Text>
-        ))
-      ) : (
-        <Text style={s.cvText}>{text}</Text>
-      )}
+      {blocks.map((block, i) => {
+        switch (block.type) {
+          case 'heading':
+            return <Text key={i} style={s.cvSectionHeading}>{block.text}</Text>
+          case 'subheading':
+            return <Text key={i} style={s.cvSubHeading}>{block.text}</Text>
+          case 'bullet':
+            return <Text key={i} style={s.cvBullet}>• {block.text}</Text>
+          case 'paragraph':
+          default:
+            return <Text key={i} style={[s.cvText, { marginBottom: 6 }]}>{block.text}</Text>
+        }
+      })}
     </View>
   )
 }

--- a/src/lib/pdf/cv-formatter.ts
+++ b/src/lib/pdf/cv-formatter.ts
@@ -1,0 +1,150 @@
+/**
+ * CV text formatter — turns the raw `candidates.cv_text` blob (often a
+ * single-line dump from `pdf-parse`) into a structured list of blocks
+ * for the candidate PDF renderer.
+ *
+ * Block types:
+ *   - heading:  a top-level CV section (TECHNICAL SKILLS, EMPLOYMENT HISTORY, …)
+ *   - subheading: a "Label : value" pattern within a section
+ *   - paragraph: body text
+ *   - bullet:   a list item (line starting with •, -, *, or numbered)
+ *
+ * Also handles the case where `cv_text_formatted` (AI-cleaned markdown) is
+ * available — strips simple markdown markers (`# `, `## `, `- `) and emits
+ * the corresponding block types.
+ */
+
+export type CvBlock =
+  | { type: 'heading'; text: string }
+  | { type: 'subheading'; text: string }
+  | { type: 'paragraph'; text: string }
+  | { type: 'bullet'; text: string }
+
+/** Common CV section headings — match case-insensitively, anchored to a word boundary. */
+const SECTION_HEADINGS = [
+  'OVERALL EXPERIENCE',
+  'RELEVANT EXPERIENCE',
+  'PROFESSIONAL EXPERIENCE',
+  'EMPLOYMENT HISTORY',
+  'WORK HISTORY',
+  'WORK EXPERIENCE',
+  'CAREER HISTORY',
+  'TECHNICAL SKILLS',
+  'CORE SKILLS',
+  'KEY SKILLS',
+  'TECHNICAL EXPERTISE',
+  'SKILLS',
+  'EDUCATION',
+  'ACADEMIC BACKGROUND',
+  'CERTIFICATIONS',
+  'CERTIFICATES',
+  'TRAINING',
+  'COURSES',
+  'PROJECTS',
+  'KEY PROJECTS',
+  'NOTABLE PROJECTS',
+  'ACHIEVEMENTS',
+  'KEY ACHIEVEMENTS',
+  'ACCOMPLISHMENTS',
+  'PUBLICATIONS',
+  'PATENTS',
+  'AWARDS',
+  'HONORS',
+  'PROFESSIONAL SUMMARY',
+  'EXECUTIVE SUMMARY',
+  'SUMMARY',
+  'PROFILE',
+  'OBJECTIVE',
+  'CAREER OBJECTIVE',
+  'LANGUAGES',
+  'LANGUAGE SKILLS',
+  'REFERENCES',
+  'INTERESTS',
+  'VOLUNTEER EXPERIENCE',
+  'VOLUNTEERING',
+  'CONTACT',
+  'CONTACT DETAILS',
+  'PERSONAL DETAILS',
+]
+
+/**
+ * Inject newlines before known section headings in a single-line CV blob.
+ * Case-insensitive match. Adds a marker `\n§SECTION§ HEADING\n` so the parser
+ * can pick them out unambiguously even when the raw text already had spaces.
+ */
+function injectSectionBreaks(raw: string): string {
+  // Sort by length DESC so longer phrases match before their prefixes.
+  // Single alternated regex with global flag — JavaScript's alternation
+  // tries options left-to-right, so DESC-sorted longer headings win over
+  // their shorter prefixes ("PROFESSIONAL EXPERIENCE" before "EXPERIENCE").
+  // A single pass avoids the bug where a second iteration re-matches the
+  // shorter prefix INSIDE an already-wrapped longer match.
+  const sorted = [...SECTION_HEADINGS].sort((a, b) => b.length - a.length)
+  const pattern = sorted.map((h) => h.replace(/ /g, '\\s+')).join('|')
+  const re = new RegExp(`\\b(${pattern})\\b\\s*:?`, 'gi')
+
+  return raw.replace(re, (match) => `\n§SECTION§ ${match.replace(/\s*:$/, '').trim()}\n`)
+}
+
+/** Strip simple markdown into normalised line-per-block form. */
+function normaliseMarkdown(text: string): string {
+  return text
+    .replace(/^#{1,2}\s+(.+)$/gm, '\n§SECTION§ $1\n')
+    .replace(/^#{3,6}\s+(.+)$/gm, '\n§SUBHEAD§ $1\n')
+    .replace(/^\s*[-*]\s+(.+)$/gm, '§BULLET§ $1')
+    .replace(/\*\*(.+?)\*\*/g, '$1') // drop bold markers; react-pdf doesn't render inline styles cheaply
+    .replace(/[_*]([^_*\n]+?)[_*]/g, '$1') // drop italic markers
+}
+
+/**
+ * Parse a CV blob (raw text OR cv_text_formatted markdown) into ordered blocks.
+ *
+ * Algorithm:
+ * 1. If the input looks like markdown (contains `# `, `## `, or `- ` at line starts),
+ *    normalise the markdown markers into `§SECTION§` / `§SUBHEAD§` / `§BULLET§`.
+ * 2. Otherwise, inject `§SECTION§` markers before known CV section headings.
+ * 3. Split on `\n`, dispatch each line to a block by marker / leading-char heuristic.
+ *
+ * Lines without markers become paragraphs. Empty lines split paragraphs but don't
+ * emit a block themselves.
+ */
+export function parseCvBlocks(input: string): CvBlock[] {
+  if (!input || !input.trim()) return []
+
+  const isMarkdown = /^#{1,6}\s|^\s*[-*]\s/m.test(input)
+  const normalised = isMarkdown ? normaliseMarkdown(input) : injectSectionBreaks(input)
+
+  const lines = normalised.split(/\n+/).map((l) => l.trim()).filter(Boolean)
+
+  const blocks: CvBlock[] = []
+
+  for (const line of lines) {
+    if (line.startsWith('§SECTION§ ')) {
+      blocks.push({ type: 'heading', text: line.slice('§SECTION§ '.length).trim() })
+      continue
+    }
+    if (line.startsWith('§SUBHEAD§ ')) {
+      blocks.push({ type: 'subheading', text: line.slice('§SUBHEAD§ '.length).trim() })
+      continue
+    }
+    if (line.startsWith('§BULLET§ ')) {
+      blocks.push({ type: 'bullet', text: line.slice('§BULLET§ '.length).trim() })
+      continue
+    }
+    // Heuristic: a leading "•" or "- " on a line = bullet
+    const bulletMatch = line.match(/^[•\-*]\s*(.+)$/)
+    if (bulletMatch) {
+      blocks.push({ type: 'bullet', text: bulletMatch[1].trim() })
+      continue
+    }
+    // Heuristic: numbered list "1. text" or "1) text"
+    const numberedMatch = line.match(/^\d+[.)]\s+(.+)$/)
+    if (numberedMatch) {
+      blocks.push({ type: 'bullet', text: numberedMatch[1].trim() })
+      continue
+    }
+    blocks.push({ type: 'paragraph', text: line })
+  }
+
+  return blocks
+}

--- a/tests/unit/lib/pdf/cv-formatter.test.ts
+++ b/tests/unit/lib/pdf/cv-formatter.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest'
+import { parseCvBlocks } from '@/lib/pdf/cv-formatter'
+
+describe('parseCvBlocks — raw CV text (no newlines)', () => {
+  it('injects section breaks before known CV headings (Alex Dolia case)', () => {
+    // Real case from production: pdf-parse extracted the CV as a single line.
+    const raw =
+      'OVERALL EXPERIENCE : 15+ Years RELEVANT EXPERIENCE : 10 Years ' +
+      'TECHNICAL SKILLS Information Retrieval & Ranking : Ranking ' +
+      'EMPLOYMENT HISTORY Senior Data Scientist | Nov 2025 - Present Severn Trent ' +
+      'EDUCATION MSc Computer Science'
+
+    const blocks = parseCvBlocks(raw)
+    const headings = blocks.filter((b) => b.type === 'heading').map((b) => b.text)
+
+    expect(headings).toContain('OVERALL EXPERIENCE')
+    expect(headings).toContain('RELEVANT EXPERIENCE')
+    expect(headings).toContain('TECHNICAL SKILLS')
+    expect(headings).toContain('EMPLOYMENT HISTORY')
+    expect(headings).toContain('EDUCATION')
+  })
+
+  it('returns paragraphs when no known headings are present', () => {
+    const raw = 'Just a plain paragraph of free-form text with no obvious structure.'
+    const blocks = parseCvBlocks(raw)
+    expect(blocks).toEqual([{ type: 'paragraph', text: raw }])
+  })
+
+  it('returns empty array for empty input', () => {
+    expect(parseCvBlocks('')).toEqual([])
+    expect(parseCvBlocks('   ')).toEqual([])
+  })
+
+  it('matches the longer of two overlapping headings first', () => {
+    // "PROFESSIONAL EXPERIENCE" should match as a unit, not split into
+    // "EXPERIENCE" alone (which would also be a valid match).
+    const raw = 'X X X PROFESSIONAL EXPERIENCE Senior Engineer at FooCorp ...'
+    const blocks = parseCvBlocks(raw)
+    const headings = blocks.filter((b) => b.type === 'heading').map((b) => b.text)
+    expect(headings).toEqual(['PROFESSIONAL EXPERIENCE'])
+  })
+
+  it('handles trailing colon after section heading', () => {
+    const raw = 'X X SKILLS: Python, TypeScript EDUCATION: BSc CS'
+    const blocks = parseCvBlocks(raw)
+    const headings = blocks.filter((b) => b.type === 'heading').map((b) => b.text)
+    expect(headings).toContain('SKILLS')
+    expect(headings).toContain('EDUCATION')
+  })
+})
+
+describe('parseCvBlocks — markdown input', () => {
+  it('renders # / ## headings as heading and subheading blocks', () => {
+    const md = '# Profile\nSenior engineer.\n## Experience\nWorked at FooCorp.'
+    const blocks = parseCvBlocks(md)
+    expect(blocks).toEqual([
+      { type: 'heading', text: 'Profile' },
+      { type: 'paragraph', text: 'Senior engineer.' },
+      { type: 'heading', text: 'Experience' },
+      { type: 'paragraph', text: 'Worked at FooCorp.' },
+    ])
+  })
+
+  it('renders ### as subheading', () => {
+    const md = '### Job Title\nDescription here.'
+    const blocks = parseCvBlocks(md)
+    expect(blocks).toEqual([
+      { type: 'subheading', text: 'Job Title' },
+      { type: 'paragraph', text: 'Description here.' },
+    ])
+  })
+
+  it('renders - and * lines as bullets', () => {
+    const md = '## Skills\n- Python\n- TypeScript\n* Rust'
+    const blocks = parseCvBlocks(md)
+    expect(blocks).toEqual([
+      { type: 'heading', text: 'Skills' },
+      { type: 'bullet', text: 'Python' },
+      { type: 'bullet', text: 'TypeScript' },
+      { type: 'bullet', text: 'Rust' },
+    ])
+  })
+
+  it('strips bold/italic markers from paragraph text', () => {
+    const md = '## Section\nThis is **bold** and *italic* and _emphasised_.'
+    const blocks = parseCvBlocks(md)
+    expect(blocks[1]).toEqual({
+      type: 'paragraph',
+      text: 'This is bold and italic and emphasised.',
+    })
+  })
+})
+
+describe('parseCvBlocks — bullet detection in raw text', () => {
+  it('detects • marker', () => {
+    const raw = '• First item\n• Second item'
+    const blocks = parseCvBlocks(raw)
+    expect(blocks).toEqual([
+      { type: 'bullet', text: 'First item' },
+      { type: 'bullet', text: 'Second item' },
+    ])
+  })
+
+  it('detects numbered lists', () => {
+    const raw = '1. First\n2. Second\n3) Third'
+    const blocks = parseCvBlocks(raw)
+    expect(blocks).toEqual([
+      { type: 'bullet', text: 'First' },
+      { type: 'bullet', text: 'Second' },
+      { type: 'bullet', text: 'Third' },
+    ])
+  })
+})


### PR DESCRIPTION
## Reported

The internal candidate PDF rendered the CV as a wall of unformatted prose. Sections like TECHNICAL SKILLS, EMPLOYMENT HISTORY, EDUCATION all collapsed into one giant paragraph with no headings, bullets, or visual structure. Screenshot showed continuous prose like:

> OVERALL EXPERIENCE : 15+ Years RELEVANT EXPERIENCE : 10 Years TECHNICAL SKILLS Information Retrieval & Ranking : Ranking ...

## Root cause

\`pdf-parse\` extracts many CVs as a **single line with zero newlines**. Verified in production: \`SELECT LENGTH(cv_text) - LENGTH(REPLACE(cv_text, E'\\n', '')) AS newlines\` returned 0 for a 21,008-char CV. The old renderer split on blank lines only, so the whole CV rendered as one paragraph.

## Fix

New helper \`src/lib/pdf/cv-formatter.ts\` with \`parseCvBlocks(text)\`:

**For markdown input** (\`cv_text_formatted\` after AI reformat):
- Parses \`# / ## / ###\` as heading / heading / subheading
- Parses \`- / * / 1.\` lines as bullets
- Strips inline \`**bold**\` / \`*italic*\` markers (react-pdf doesn't render inline styles cheaply)

**For raw text input** (\`cv_text\` direct from parser):
- Single-pass regex with alternation matches 40+ known CV section headings (TECHNICAL SKILLS, EMPLOYMENT HISTORY, PROFESSIONAL EXPERIENCE, EDUCATION, CERTIFICATIONS, PROJECTS, etc.)
- Headings sorted DESC by length so longer phrases match before their prefixes ("PROFESSIONAL EXPERIENCE" wins over "EXPERIENCE")
- Injects \`§SECTION§\` markers to split the blob into ordered blocks

Returns ordered \`CvBlock[]\` of \`heading\` / \`subheading\` / \`paragraph\` / \`bullet\`. \`CvTextSection\` in \`candidate-pdf.tsx\` renders each with appropriate react-pdf styles (3 new entries in StyleSheet: \`cvSectionHeading\`, \`cvSubHeading\`, \`cvBullet\`).

## Tests

11 unit tests in \`tests/unit/lib/pdf/cv-formatter.test.ts\` — all passing locally:
- Raw single-line CV (the production case) → expected 5 section headings detected
- Markdown input → expected heading + paragraph + bullet sequence
- Edge cases: empty input, no-heading input, overlapping headings (PROFESSIONAL EXPERIENCE vs EXPERIENCE), trailing colon
- Bullet detection: \`•\`, \`-\`, \`*\`, numbered \`1.\` / \`1)\`

## Test plan

- [x] \`npm test\` green (11 new tests + full suite)
- [x] \`npx tsc --noEmit\` clean
- [ ] CI green
- [ ] Manual: re-download the internal PDF for the candidate that triggered the bug report; verify sections render as bold uppercase headings with spacing between them

## Out of scope (follow-ups)

- Auto-running cv-reformat AI on candidate upload so \`cv_text_formatted\` is always populated. Right now the AI reformat is opt-in via a button on the candidate page; with that auto-applied, the markdown-rendering path of this fix becomes the primary one and the raw heuristic stays as fallback.
- Detecting job-entry patterns ("Title | Company | Date") for richer rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)