### PR TITLE
ci: establish ESLint baseline + add lint to CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,15 @@
 #
 # Continuous integration gate for pull requests targeting core-mvp-foundation.
 #
-# Runs three jobs in parallel where possible:
-#   1. test      — vitest unit + integration tests (excludes DB integration tests
+# Runs four jobs in parallel where possible:
+#   1. lint      — ESLint with --max-warnings=99999 (errors block, warnings allowed)
+#                  Baseline established in PR #178 ci/eslint-baseline:
+#                    • 0 errors required; warnings are non-blocking for v1
+#                    • Re-evaluate warning gate once warning count is <50
+#   2. test      — vitest unit + integration tests (excludes DB integration tests
 #                  that require RUN_DB_INTEGRATION_TESTS=true and a live Postgres)
-#   2. typecheck — tsc --noEmit across the whole project (src + tests)
-#   3. build     — next build with stub env vars to catch compile-time errors
+#   3. typecheck — tsc --noEmit across the whole project (src + tests)
+#   4. build     — next build with stub env vars to catch compile-time errors
 #                  (depends on test + typecheck so we don't waste build minutes
 #                  on a branch that's already red)
 #
@@ -17,11 +21,6 @@
 #   no TCP connection is attempted until a query executes. AUTH_SECRET and
 #   ENCRYPTION_KEY are only validated at request time, not build time.
 #   Therefore a syntactically-valid placeholder is sufficient for `next build`.
-#
-# Why not lint:
-#   ESLint is currently not enforced in the project's CI (no eslint config
-#   produces zero warnings on the codebase today). Lint is deferred to a
-#   follow-up PR that establishes a clean baseline before gating it.
 #
 # Why not e2e:
 #   Playwright e2e tests (test:e2e) require a running Postgres + Next.js server
@@ -46,7 +45,39 @@ concurrency:
 
 jobs:
   # ---------------------------------------------------------------------------
-  # 1. test — vitest run (NODE_ENV=test is set in the npm script)
+  # 1. lint — ESLint (errors block CI; warnings are non-blocking)
+  #
+  # --max-warnings=99999 allows any number of warnings through while still
+  # exiting non-zero on any error.  The warning count will be reduced in
+  # follow-up cleanup PRs; keeping this generous cap avoids churn in the
+  # short term.
+  # ---------------------------------------------------------------------------
+  lint:
+    name: Lint (ESLint)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Setup Node 22
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        env:
+          NODE_ENV: test
+        run: npm ci
+
+      - name: Lint
+        # Exit non-zero on any error; warnings are allowed (--max-warnings=99999).
+        # ESLint exits 1 when there are errors regardless of --max-warnings.
+        run: npx eslint . --max-warnings=99999
+
+  # ---------------------------------------------------------------------------
+  # 2. test — vitest run (NODE_ENV=test is set in the npm script)
   # ---------------------------------------------------------------------------
   test:
     name: Tests (vitest)
@@ -111,6 +142,7 @@ jobs:
     name: Build (next build)
     runs-on: ubuntu-latest
     needs:
+      - lint
       - test
       - typecheck
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,27 @@ const eslintConfig = defineConfig([
     "build/**",
     "next-env.d.ts",
   ]),
+  {
+    // eslint-plugin-react-hooks v7 introduced two new experimental rules that
+    // fire on intentional, canonical patterns in this codebase:
+    //
+    //  • react-hooks/set-state-in-effect — fires on `useEffect(() => { setState(true) }, [])`
+    //    which is the documented next-themes hydration pattern (ThemeToggle) and other
+    //    sync init effects.  These are not cascading-render bugs; they are one-time
+    //    mount-time initialisations.
+    //
+    //  • react-hooks/purity — fires on Date.now() inside async Server Components
+    //    (dashboard/page.tsx) and .map() callbacks in Client Components.  Server
+    //    Components are never re-rendered by React; the rule is a false positive there.
+    //
+    // Both rules are kept at "warn" so violations are still visible in development
+    // and IDEs, but they must not block CI.  Re-evaluate when the rules graduate
+    // from experimental in a future react-hooks release.
+    rules: {
+      "react-hooks/set-state-in-effect": "warn",
+      "react-hooks/purity": "warn",
+    },
+  },
 ]);
 
 export default eslintConfig;

--- a/src/actions/candidates.ts
+++ b/src/actions/candidates.ts
@@ -466,7 +466,7 @@ export async function updateCandidateDetails(
     gdprProcessingConsentBy: 'candidate' | 'recruiter' | 'agency' | null
   }>
 
-  let complianceUpdate: ComplianceUpdate = {}
+  const complianceUpdate: ComplianceUpdate = {}
   let rtwTransitionedToChecked = false
   let fieldsChanged: ComplianceField[] = []
 

--- a/src/actions/enrichment/http.ts
+++ b/src/actions/enrichment/http.ts
@@ -35,7 +35,7 @@ export async function readCappedText(res: Response): Promise<string> {
   const decoder = new TextDecoder('utf-8', { fatal: false })
   let received = 0
   let out = ''
-  // eslint-disable-next-line no-constant-condition
+   
   while (true) {
     const { done, value } = await reader.read()
     if (done) break

--- a/src/app/api/export/candidate/[candidateId]/route.ts
+++ b/src/app/api/export/candidate/[candidateId]/route.ts
@@ -249,6 +249,7 @@ export async function GET(
           }
         : null,
       generatedAt: new Date(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- react-pdf renderToBuffer expects any-typed element
     }) as any
   )
 

--- a/src/app/api/export/interview-pack/[packId]/route.ts
+++ b/src/app/api/export/interview-pack/[packId]/route.ts
@@ -59,6 +59,7 @@ export async function GET(
       codeChallenge: codeChallenge ?? null,
       candidateName,
       roleTitle,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- react-pdf renderToBuffer expects any-typed element
     }) as any
   )
 

--- a/src/app/api/export/role/[roleId]/route.ts
+++ b/src/app/api/export/role/[roleId]/route.ts
@@ -50,6 +50,7 @@ export async function GET(
       customerName,
       customerRoleId: role.customerRoleId,
       customerRoleIdLabel,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- react-pdf renderToBuffer expects any-typed element
     }) as any
   )
 

--- a/src/app/api/export/shortlist/[roleId]/route.ts
+++ b/src/app/api/export/shortlist/[roleId]/route.ts
@@ -92,6 +92,7 @@ export async function GET(
       customerName,
       customerRoleId: role.customerRoleId,
       customerRoleIdLabel,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- react-pdf renderToBuffer expects any-typed element
     }) as any
   )
 

--- a/src/components/candidates/compliance-section.tsx
+++ b/src/components/candidates/compliance-section.tsx
@@ -61,10 +61,11 @@ const labelCls = 'block text-xs font-medium text-[var(--color-fg-muted)] mb-1'
 const helpCls = 'mt-1 text-xs text-[var(--color-fg-subtle)]'
 
 export function ComplianceSection({ audience, disabled = false, fields, onChange }: ComplianceSectionProps) {
+  // Hooks must be called unconditionally before any early return (Rules of Hooks)
+  const [open, setOpen] = useState(false)
+
   // Gate: only recruiter sees compliance data
   if (audience !== 'recruiter') return null
-
-  const [open, setOpen] = useState(false)
 
   function set<K extends keyof ComplianceFields>(key: K, value: ComplianceFields[K]) {
     onChange({ ...fields, [key]: value })

--- a/src/components/candidates/edit-details-form.tsx
+++ b/src/components/candidates/edit-details-form.tsx
@@ -48,7 +48,7 @@ interface EditDetailsFormProps {
 }
 
 export function EditDetailsForm({ candidate, agencies, audience = 'recruiter' }: EditDetailsFormProps) {
-  if (audience === 'manager') return null
+  // Hooks must be called unconditionally before any early return (Rules of Hooks)
   const [isOpen, setIsOpen] = useState(false)
 
   const boundAction = updateCandidateDetails.bind(null, candidate.id)
@@ -87,6 +87,8 @@ export function EditDetailsForm({ candidate, agencies, audience = 'recruiter' }:
     gdprProcessingConsentAt: candidate.gdprProcessingConsentAt ?? '',
     gdprProcessingConsentBy: (candidate.gdprProcessingConsentBy ?? '') as ComplianceFields['gdprProcessingConsentBy'],
   })
+
+  if (audience === 'manager') return null
 
   const fieldErrors = state && !state.success ? state.fieldErrors : {}
 

--- a/src/components/roles/role-form.tsx
+++ b/src/components/roles/role-form.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useActionState, useRef } from 'react'
 import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 import { useEffect } from 'react'
 import { Loader2, Sparkles, UploadCloud, X } from 'lucide-react'
 import { createRole } from '@/actions/roles'
@@ -574,9 +575,9 @@ export function RoleForm({ customers = [], frameworks = {}, customerRoleIdLabels
             {pending && <Loader2 className="h-4 w-4 animate-spin" />}
             {pending ? 'Creating…' : 'Create role'}
           </button>
-          <a href="/dashboard/roles" className="text-sm text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)]">
+          <Link href="/dashboard/roles" className="text-sm text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)]">
             Cancel
-          </a>
+          </Link>
         </div>
       </form>
     </div>

--- a/src/components/settings/ai-behaviour-panel.tsx
+++ b/src/components/settings/ai-behaviour-panel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useTransition } from 'react'
+import Link from 'next/link'
 import { BrainCircuitIcon } from 'lucide-react'
 import { updateHrSkillSettings } from '@/actions/settings'
 import type { HrSkillSettingsRecord } from '@/actions/settings'
@@ -56,12 +57,12 @@ export function AiBehaviourPanel({ initial }: AiBehaviourPanelProps) {
         When enabled, Claude scoring, interview generation, and transcript analysis use
         HR-policy-aware reasoning. The skill profile determines which guidance pack is
         loaded.{' '}
-        <a
+        <Link
           href="/dashboard/help/ai-behaviour"
           className="text-blue-400 hover:text-blue-300 underline underline-offset-2"
         >
           Learn more →
-        </a>
+        </Link>
       </p>
 
       <div className="space-y-5">

--- a/src/components/settings/backups-panel.tsx
+++ b/src/components/settings/backups-panel.tsx
@@ -12,6 +12,7 @@
  */
 
 import { useState } from 'react'
+import Link from 'next/link'
 
 interface BackupsPanelProps {
   lastExportAt: Date | null
@@ -58,12 +59,12 @@ export function BackupsPanel({ lastExportAt }: BackupsPanelProps) {
       <p className="text-sm text-[var(--color-fg-muted)] mb-4">
         Download a snapshot of all data for your tenant. Includes JSON for every
         table. Optionally include binary file attachments (CVs, logos).{' '}
-        <a
+        <Link
           className="underline"
           href="/dashboard/help/settings-backups-data-export"
         >
           See the help article
-        </a>
+        </Link>
         .
       </p>
       <div className="flex flex-col gap-3">

--- a/src/components/settings/oauth-credentials-form.tsx
+++ b/src/components/settings/oauth-credentials-form.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useActionState, useState } from 'react'
+import Link from 'next/link'
 import { CheckCircleIcon, EyeIcon, EyeOffIcon, KeyIcon, Loader2Icon, TrashIcon } from 'lucide-react'
 import { saveApiKey, removeApiKey } from '@/actions/settings'
 import type { SettingsState } from '@/actions/settings'
@@ -178,12 +179,12 @@ export function OAuthCredentialsForm({ configuredKeys }: Props) {
         <p className="text-xs text-[var(--color-fg-subtle)]">
           Per-tenant OAuth credentials override the deployment-level env vars. Leave blank to use the
           env-var fallback (if configured).{' '}
-          <a
+          <Link
             href="/dashboard/help/settings-oauth-credentials"
             className="text-blue-400 hover:text-blue-300 underline underline-offset-2"
           >
             See setup guide →
-          </a>
+          </Link>
         </p>
       </div>
 

--- a/src/lib/api-tokens/format.ts
+++ b/src/lib/api-tokens/format.ts
@@ -1,4 +1,5 @@
 import { hash } from '@node-rs/argon2'
+import { randomFillSync } from 'crypto'
 
 /**
  * Token format: skl_<env>_<24-char-base62>
@@ -17,8 +18,6 @@ const SECRET_LENGTH = 24
 function generateBase62(length: number): string {
   const bytes = new Uint8Array(length)
   // Use Node.js crypto for server-side secure random
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { randomFillSync } = require('crypto') as typeof import('crypto')
   randomFillSync(bytes)
   return Array.from(bytes)
     .map((b) => BASE62_CHARS[b % 62])

--- a/src/lib/parsers/transcript.ts
+++ b/src/lib/parsers/transcript.ts
@@ -244,7 +244,7 @@ function buildRawText(cues: TranscriptCue[]): string {
  */
 export function sanitizeText(text: string): string {
   // Remove NULL bytes and other non-printable control chars except \t, \n, \r
-  // eslint-disable-next-line no-control-regex
+   
   return text.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F]/g, '')
 }
 

--- a/src/lib/pdf/candidate-pdf.tsx
+++ b/src/lib/pdf/candidate-pdf.tsx
@@ -873,7 +873,7 @@ function TranscriptAnalysesSection({
                         </View>
                       </View>
                       {qr.transcriptExcerpt && (
-                        <Text style={s.qExcerpt}>"{qr.transcriptExcerpt}"</Text>
+                        <Text style={s.qExcerpt}>&ldquo;{qr.transcriptExcerpt}&rdquo;</Text>
                       )}
                       {qr.notes && (
                         <Text style={s.qNotes}>{qr.notes}</Text>
@@ -976,67 +976,69 @@ function EnrichmentSection({ enrichment }: { enrichment: EnrichmentData }) {
 // Section: Compliance & Eligibility (internal / recruiter only)
 // Never rendered for customer audience — gated at the call-site.
 // ---------------------------------------------------------------------------
+
+// Helper functions hoisted to module scope to avoid react-hooks/static-components
+// (components defined inside render bodies are re-created on every render)
+function complianceRtwStatusLabel(v: string | null): string {
+  if (!v) return '—'
+  const map: Record<string, string> = {
+    checked: 'Checked',
+    pending: 'Pending',
+    fail: 'Fail',
+    exempted: 'Exempted',
+    not_required: 'Not Required',
+  }
+  return map[v] ?? v
+}
+
+function complianceRtwDocLabel(v: string | null): string {
+  if (!v) return '—'
+  const map: Record<string, string> = {
+    passport_uk: 'UK Passport',
+    passport_eu: 'EU Passport',
+    passport_other: 'Other Passport',
+    brp: 'BRP',
+    share_code: 'Share Code',
+    visa: 'Visa',
+    settled_status: 'Settled Status',
+    presettled_status: 'Pre-Settled Status',
+    other: 'Other',
+  }
+  return map[v] ?? v
+}
+
+function complianceConsentByLabel(v: string | null): string {
+  if (!v) return '—'
+  const map: Record<string, string> = {
+    candidate: 'Candidate',
+    recruiter: 'Recruiter',
+    agency: 'Agency',
+  }
+  return map[v] ?? v
+}
+
+// Reusable label+value row for the compliance section
+function ComplianceFieldRow({ label, value }: { label: string; value: string }) {
+  return (
+    <View style={{ flexDirection: 'row', marginBottom: 4 }}>
+      <Text
+        style={{
+          fontSize: 8,
+          fontFamily: 'Helvetica-Bold',
+          color: colors.slate500,
+          width: 160,
+        }}
+      >
+        {label}
+      </Text>
+      <Text style={{ fontSize: 9, color: colors.slate700, flex: 1 }}>{value}</Text>
+    </View>
+  )
+}
+
 function ComplianceSection({ candidate }: { candidate: Candidate }) {
   // Only render when at least one compliance field is populated
   if (!hasComplianceData(candidate)) return null
-
-  // Human-readable labels for enum values
-  function rtwStatusLabel(v: string | null): string {
-    if (!v) return '—'
-    const map: Record<string, string> = {
-      checked: 'Checked',
-      pending: 'Pending',
-      fail: 'Fail',
-      exempted: 'Exempted',
-      not_required: 'Not Required',
-    }
-    return map[v] ?? v
-  }
-
-  function rtwDocLabel(v: string | null): string {
-    if (!v) return '—'
-    const map: Record<string, string> = {
-      passport_uk: 'UK Passport',
-      passport_eu: 'EU Passport',
-      passport_other: 'Other Passport',
-      brp: 'BRP',
-      share_code: 'Share Code',
-      visa: 'Visa',
-      settled_status: 'Settled Status',
-      presettled_status: 'Pre-Settled Status',
-      other: 'Other',
-    }
-    return map[v] ?? v
-  }
-
-  function consentByLabel(v: string | null): string {
-    if (!v) return '—'
-    const map: Record<string, string> = {
-      candidate: 'Candidate',
-      recruiter: 'Recruiter',
-      agency: 'Agency',
-    }
-    return map[v] ?? v
-  }
-
-  // Reusable row: label + value
-  function FieldRow({ label, value }: { label: string; value: string }) {
-    return (
-      <View style={{ flexDirection: 'row', marginBottom: 4 }}>
-        <Text
-          style={{
-            fontSize: 8,
-            fontFamily: 'Helvetica-Bold',
-            color: colors.slate500,
-            width: 160,
-          }}
-        >
-          {label}
-        </Text>
-        <Text style={{ fontSize: 9, color: colors.slate700, flex: 1 }}>{value}</Text>
-      </View>
-    )
-  }
 
   // Right-to-work status badge color
   function rtwStatusColors(v: string | null): { bg: string; text: string } {
@@ -1064,7 +1066,7 @@ function ComplianceSection({ candidate }: { candidate: Candidate }) {
             ]}
           >
             <Text style={{ color: rtwC.text, fontSize: 8, fontFamily: 'Helvetica-Bold' }}>
-              RIGHT TO WORK: {rtwStatusLabel(candidate.rightToWorkStatus).toUpperCase()}
+              RIGHT TO WORK: {complianceRtwStatusLabel(candidate.rightToWorkStatus).toUpperCase()}
             </Text>
           </View>
         )}
@@ -1073,33 +1075,33 @@ function ComplianceSection({ candidate }: { candidate: Candidate }) {
       <View style={[base.card, { marginTop: 6 }]}>
         {/* Right to Work */}
         {candidate.rightToWorkStatus && (
-          <FieldRow label="Right to Work Status" value={rtwStatusLabel(candidate.rightToWorkStatus)} />
+          <ComplianceFieldRow label="Right to Work Status" value={complianceRtwStatusLabel(candidate.rightToWorkStatus)} />
         )}
         {candidate.rightToWorkDocumentType && (
-          <FieldRow label="Document Type" value={rtwDocLabel(candidate.rightToWorkDocumentType)} />
+          <ComplianceFieldRow label="Document Type" value={complianceRtwDocLabel(candidate.rightToWorkDocumentType)} />
         )}
         {candidate.rightToWorkExpiry && (
-          <FieldRow label="Document Expiry" value={candidate.rightToWorkExpiry} />
+          <ComplianceFieldRow label="Document Expiry" value={candidate.rightToWorkExpiry} />
         )}
         {candidate.rightToWorkCheckedAt && (
-          <FieldRow label="Check Date" value={fmt(candidate.rightToWorkCheckedAt)} />
+          <ComplianceFieldRow label="Check Date" value={fmt(candidate.rightToWorkCheckedAt)} />
         )}
         {candidate.shareCode && (
-          <FieldRow label="Share Code" value={candidate.shareCode} />
+          <ComplianceFieldRow label="Share Code" value={candidate.shareCode} />
         )}
 
         {/* Sponsorship & Nationality */}
-        <FieldRow
+        <ComplianceFieldRow
           label="Sponsorship Required"
           value={candidate.sponsorshipRequired ? 'Yes' : 'No'}
         />
         {candidate.nationality && (
-          <FieldRow label="Nationality" value={candidate.nationality} />
+          <ComplianceFieldRow label="Nationality" value={candidate.nationality} />
         )}
 
         {/* Notice period */}
         {candidate.noticePeriodDays !== null && candidate.noticePeriodDays !== undefined && (
-          <FieldRow
+          <ComplianceFieldRow
             label="Notice Period"
             value={
               candidate.noticePeriodDays === 0
@@ -1111,12 +1113,12 @@ function ComplianceSection({ candidate }: { candidate: Candidate }) {
 
         {/* GDPR consent */}
         {candidate.gdprProcessingConsentAt && (
-          <FieldRow label="GDPR Consent Date" value={fmt(candidate.gdprProcessingConsentAt)} />
+          <ComplianceFieldRow label="GDPR Consent Date" value={fmt(candidate.gdprProcessingConsentAt)} />
         )}
         {candidate.gdprProcessingConsentBy && (
-          <FieldRow
+          <ComplianceFieldRow
             label="GDPR Consent Provided By"
-            value={consentByLabel(candidate.gdprProcessingConsentBy)}
+            value={complianceConsentByLabel(candidate.gdprProcessingConsentBy)}
           />
         )}
       </View>


### PR DESCRIPTION
## Summary

- **Before:** 39 errors, 69 warnings (third-party code review flagged 117 errors / 206 warnings on an older baseline — some had already been resolved)
- **After:** 0 errors, 78 warnings (12 errors downgraded to warnings via rule config; rest fixed in code)
- CI now has a `lint` job that blocks merges on any error; warnings remain non-blocking

## Rule-by-rule breakdown

| Rule | Count | Action |
|---|---|---|
| `react-hooks/rules-of-hooks` | 5 | Fixed in code — moved hooks above early-return guards in `compliance-section.tsx` and `edit-details-form.tsx` |
| `react-hooks/static-components` | 10 | Fixed in code — hoisted `FieldRow` component + 3 helper functions out of `ComplianceSection` body to module scope in `candidate-pdf.tsx` |
| `@next/next/no-html-link-for-pages` | 4 | Fixed in code — replaced `<a href>` with `<Link>` in 4 settings/roles components |
| `react/no-unescaped-entities` | 2 | Fixed in code — `"` → `&ldquo;` / `&rdquo;` in react-pdf Text element |
| `@typescript-eslint/no-require-imports` | 1 | Fixed in code — converted `require('crypto')` to ESM import in `format.ts` |
| `prefer-const` | 1 | Auto-fixed |
| `@typescript-eslint/no-explicit-any` | 4 | Per-line `eslint-disable-next-line` with justification — all 4 are react-pdf `renderToBuffer()` call sites where the typing is genuinely intractable |
| `react-hooks/set-state-in-effect` | 9 errors → warn | Downgraded in `eslint.config.mjs` — v7.1.1 experimental rule fires on the canonical `next-themes` hydration pattern and other intentional sync-init effects |
| `react-hooks/purity` | 3 errors → warn | Downgraded in `eslint.config.mjs` — v7.1.1 experimental rule fires on `Date.now()` in async Server Components (false positive) |

## CI changes

- New `lint` job parallel to `test` and `typecheck`; `build` now depends on all three
- `npx eslint . --max-warnings=99999` — errors block, warnings pass
- Header comment in `ci.yml` updated: removed the "Why not lint" paragraph, added policy note about warning count

## Lint policy going forward

- Error count must stay at **0** after this PR
- 78 warnings are non-blocking for v1; target is to clean them up in follow-up PRs once the gate is green
- Re-evaluate `--max-warnings` cap when warning count reaches <50

## Link to finding

This addresses the third-party code review finding that flagged 323 lint problems (117 errors, 206 warnings) with no CI enforcement.

## Test plan

- [ ] `npx eslint . --max-warnings=99999` → 0 errors
- [ ] `npx tsc --noEmit` → clean
- [ ] `npm test` → 927 tests pass
- [ ] CI workflow shows lint job as green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)