### PR TITLE
feat(candidates): add rejected_by_customer pipeline status

### DIFF
--- a/src/actions/candidates.ts
+++ b/src/actions/candidates.ts
@@ -254,7 +254,7 @@ export async function updateSynechronCandidateId(
 // ---------------------------------------------------------------------------
 
 const VALID_STATUSES: CandidateStatus[] = [
-  'new', 'shortlisted', 'interviewing', 'offered', 'hired', 'rejected',
+  'new', 'shortlisted', 'interviewing', 'offered', 'hired', 'rejected', 'rejected_by_customer',
 ]
 
 export async function bulkUpdateCandidateStatus(

--- a/src/app/(dashboard)/dashboard/candidates/page.tsx
+++ b/src/app/(dashboard)/dashboard/candidates/page.tsx
@@ -36,7 +36,7 @@ export default async function CandidatesPage({ searchParams }: PageProps) {
 
   // Validate status is a known enum value
   const validStatuses: CandidateStatus[] = [
-    'new', 'shortlisted', 'interviewing', 'offered', 'rejected', 'hired',
+    'new', 'shortlisted', 'interviewing', 'offered', 'rejected', 'rejected_by_customer', 'hired',
   ]
   const statusFilter = status && validStatuses.includes(status as CandidateStatus)
     ? (status as CandidateStatus)

--- a/src/app/api/candidates/[candidateId]/status/route.ts
+++ b/src/app/api/candidates/[candidateId]/status/route.ts
@@ -4,7 +4,7 @@ import { registerRoute } from '@/lib/api/openapi'
 import { updateCandidateStatus } from '@/actions/candidates'
 
 export const CandidateStatusBodySchema = z.object({
-  status: z.enum(['new', 'shortlisted', 'interviewing', 'offered', 'hired', 'rejected']),
+  status: z.enum(['new', 'shortlisted', 'interviewing', 'offered', 'hired', 'rejected', 'rejected_by_customer']),
 })
 
 registerRoute('POST', '/api/candidates/{candidateId}/status', {

--- a/src/components/candidates/bulk-status-bar.tsx
+++ b/src/components/candidates/bulk-status-bar.tsx
@@ -13,6 +13,7 @@ const STATUS_OPTIONS: Array<{ value: CandidateStatus; label: string }> = [
   { value: 'interviewing', label: 'Interviewing' },
   { value: 'offered', label: 'Offered' },
   { value: 'rejected', label: 'Rejected' },
+  { value: 'rejected_by_customer', label: 'Rejected by Customer' },
   { value: 'hired', label: 'Hired' },
 ]
 

--- a/src/components/candidates/status-selector.tsx
+++ b/src/components/candidates/status-selector.tsx
@@ -11,6 +11,7 @@ const STATUS_OPTIONS: Array<{ value: CandidateStatus; label: string }> = [
   { value: 'interviewing', label: 'Interviewing' },
   { value: 'offered', label: 'Offered' },
   { value: 'rejected', label: 'Rejected' },
+  { value: 'rejected_by_customer', label: 'Rejected by Customer' },
   { value: 'hired', label: 'Hired' },
 ]
 
@@ -20,6 +21,7 @@ const STATUS_BADGE: Record<CandidateStatus, string> = {
   interviewing: 'bg-amber-100 dark:bg-amber-950 text-amber-700 dark:text-amber-300 border-amber-300 dark:border-amber-700',
   offered: 'bg-violet-100 dark:bg-violet-950 text-violet-700 dark:text-violet-300 border-violet-300 dark:border-violet-700',
   rejected: 'bg-red-100 dark:bg-red-950 text-red-700 dark:text-red-300 border-red-300 dark:border-red-800',
+  rejected_by_customer: 'bg-orange-100 dark:bg-orange-950 text-orange-700 dark:text-orange-300 border-orange-300 dark:border-orange-800',
   hired: 'bg-emerald-100 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-300 border-emerald-300 dark:border-emerald-700',
 }
 

--- a/src/db/migrations/0032_candidate_status_rejected_by_customer.sql
+++ b/src/db/migrations/0032_candidate_status_rejected_by_customer.sql
@@ -1,0 +1,8 @@
+-- Migration: 0032_candidate_status_rejected_by_customer
+-- Adds 'rejected_by_customer' to the candidate_status enum.
+-- Additive-only: ALTER TYPE ... ADD VALUE is safe on live data.
+-- Operator apply command (post-merge):
+--   docker exec -i skillai-db-1 psql -U skillai -d skillai \
+--     < src/db/migrations/0032_candidate_status_rejected_by_customer.sql
+
+ALTER TYPE candidate_status ADD VALUE IF NOT EXISTS 'rejected_by_customer';

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1779580800000,
       "tag": "0031_password_reset_token",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1747699200000,
+      "tag": "0032_candidate_status_rejected_by_customer",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/candidates.ts
+++ b/src/db/schema/candidates.ts
@@ -28,6 +28,7 @@ export const candidateStatusEnum = pgEnum('candidate_status', [
   'interviewing',
   'offered',
   'rejected',
+  'rejected_by_customer',
   'hired',
 ])
 

--- a/src/lib/mcp/tools/candidates.ts
+++ b/src/lib/mcp/tools/candidates.ts
@@ -27,7 +27,7 @@ import type { CandidateStatus, AvailabilityStatus } from '@/db/schema/candidates
 export const ListCandidatesInput = {
   search: z.string().optional().describe('Optional case-insensitive substring match on first or last name'),
   agencyId: z.string().uuid().optional(),
-  status: z.enum(['new', 'shortlisted', 'interviewing', 'offered', 'rejected', 'hired']).optional(),
+  status: z.enum(['new', 'shortlisted', 'interviewing', 'offered', 'rejected', 'rejected_by_customer', 'hired']).optional(),
   availabilityStatus: z.enum(['available', 'on_project', 'unavailable']).optional(),
   limit: z.number().int().min(1).max(200).optional().default(50),
   offset: z.number().int().min(0).optional().default(0),
@@ -43,7 +43,7 @@ export const FindByEmailInput = {
 
 export const UpdateStatusInput = {
   candidateId: z.string().uuid(),
-  status: z.enum(['new', 'shortlisted', 'interviewing', 'offered', 'rejected', 'hired']),
+  status: z.enum(['new', 'shortlisted', 'interviewing', 'offered', 'rejected', 'rejected_by_customer', 'hired']),
   confirmed: z.literal(true).describe('Must be true. Write tools require explicit confirmation.'),
 }
 
@@ -233,7 +233,7 @@ export function registerCandidateTools(server: McpServer, ctx: McpContext): void
       title: 'Update candidate pipeline status',
       description:
         'Move a candidate to a new pipeline stage (new / shortlisted / interviewing / offered / ' +
-        'hired / rejected). Requires write scope and confirmed: true.',
+        'hired / rejected / rejected_by_customer). Requires write scope and confirmed: true.',
       inputSchema: UpdateStatusInput,
     },
     async (args) =>

--- a/src/lib/pdf/candidate-pdf.tsx
+++ b/src/lib/pdf/candidate-pdf.tsx
@@ -410,6 +410,8 @@ function statusColors(status: Candidate['status']): { bg: string; text: string }
     case 'interviewing': return { bg: colors.amber50, text: colors.amber700 }
     case 'offered': return { bg: colors.green50, text: colors.green700 }
     case 'rejected': return { bg: colors.red50, text: colors.red700 }
+    // rejected_by_customer is an internal status — caller gates rendering on !isCustomer
+    case 'rejected_by_customer': return { bg: colors.amber50, text: colors.amber700 }
     default: return { bg: colors.slate100, text: colors.slate500 }
   }
 }
@@ -421,6 +423,7 @@ function statusLabel(status: Candidate['status']): string {
     interviewing: 'Interviewing',
     offered: 'Offered',
     rejected: 'Rejected',
+    rejected_by_customer: 'Rejected by Customer',
     hired: 'Hired',
   }
   return map[status]

--- a/tests/unit/actions/candidates.test.ts
+++ b/tests/unit/actions/candidates.test.ts
@@ -497,6 +497,15 @@ describe('bulkUpdateCandidateStatus', () => {
     expect(result.updated).toBeGreaterThanOrEqual(0)
     expect(mockUpdateSet).toHaveBeenCalledWith({ status: 'shortlisted' })
   })
+
+  it('accepts rejected_by_customer as a valid status', async () => {
+    const { bulkUpdateCandidateStatus } = await import('@/actions/candidates')
+
+    const result = await bulkUpdateCandidateStatus([CANDIDATE_ID], 'rejected_by_customer')
+
+    expect(result.success).toBe(true)
+    expect(mockUpdateSet).toHaveBeenCalledWith({ status: 'rejected_by_customer' })
+  })
 })
 
 // ── updateCandidateAvailability ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds \`rejected_by_customer\` as a new value in the \`candidate_status\` PostgreSQL enum, positioned immediately after \`rejected\` so recruiters can distinguish a customer-driven rejection from an internal one
- Status pill styled with orange tokens matching the team's existing dark-mode pattern: \`bg-orange-100 dark:bg-orange-950 text-orange-700 dark:text-orange-300 border-orange-300 dark:border-orange-800\`
- Status badge in the candidate PDF is already gated on \`!isCustomer\` in \`HeaderSection\` — the new value is **never rendered on customer-facing PDFs**

## Changed files

| File | Change |
|---|---|
| \`src/db/schema/candidates.ts\` | Added \`'rejected_by_customer'\` to \`candidateStatusEnum\` |
| \`src/db/migrations/0032_candidate_status_rejected_by_customer.sql\` | Additive migration: \`ALTER TYPE candidate_status ADD VALUE IF NOT EXISTS\` |
| \`src/db/migrations/meta/_journal.json\` | Journal entry idx 32 added |
| \`src/components/candidates/status-selector.tsx\` | New STATUS_OPTIONS entry + orange STATUS_BADGE |
| \`src/components/candidates/bulk-status-bar.tsx\` | STATUS_OPTIONS updated |
| \`src/actions/candidates.ts\` | VALID_STATUSES updated |
| \`src/app/api/candidates/[candidateId]/status/route.ts\` | Zod enum updated |
| \`src/lib/mcp/tools/candidates.ts\` | ListCandidatesInput + UpdateStatusInput enums updated |
| \`src/lib/pdf/candidate-pdf.tsx\` | statusColors + statusLabel extended |
| \`src/app/(dashboard)/dashboard/candidates/page.tsx\` | validStatuses filter array updated |
| \`tests/unit/actions/candidates.test.ts\` | +1 test: bulkUpdateCandidateStatus accepts rejected_by_customer |

## Migration note

The migration is **NOT auto-applied**. Operator must run after merge:

\`\`\`bash
docker exec -i skillai-db-1 psql -U skillai -d skillai \
  < src/db/migrations/0032_candidate_status_rejected_by_customer.sql
\`\`\`

\`ALTER TYPE ... ADD VALUE IF NOT EXISTS\` is safe on live data — it does not lock the table and requires no downtime.

## Audience gating decision

\`rejected_by_customer\` reveals that the customer rejected the candidate, which is commercially sensitive internal information. The PDF \`HeaderSection\` already wraps the entire status badge in \`{!isCustomer && ...}\`, so this status — like all pipeline statuses — is hidden from customer-facing PDFs with no additional code change required.

## Test results

- 957 tests passed, 4 skipped (pre-existing skips, unchanged)
- \`npx tsc --noEmit\`: clean
- \`npx eslint . --max-warnings=99999\`: 0 errors, 79 pre-existing warnings (none from this PR)

## Test plan

- [ ] Operator applies migration via the command above
- [ ] Open any candidate and change status to "Rejected by Customer" — orange pill appears
- [ ] Bulk-select candidates and set status to "Rejected by Customer" — bulk bar applies correctly
- [ ] Audit log shows \`candidate.status_changed\` with \`newStatus: 'rejected_by_customer'\`
- [ ] Export candidate PDF as customer audience — status badge absent; as internal — shows "REJECTED BY CUSTOMER" in orange/amber

🤖 Generated with [Claude Code](https://claude.com/claude-code)