### PR TITLE
feat(roles): surface role expiry as filterable first-class state

### DIFF
--- a/src/app/(dashboard)/dashboard/roles/[roleId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/roles/[roleId]/page.tsx
@@ -20,6 +20,7 @@ import { SentToCustomerPanel } from '@/components/roles/sent-to-customer-panel'
 import { DownloadCvsButton } from '@/components/roles/download-cvs-button'
 import { PriorityKeywordsPanel } from '@/components/roles/priority-keywords-panel'
 import { isScoreOutdatedAgainstPriorities } from '@/lib/scores/staleness'
+import { isRoleExpired } from '@/lib/roles/expiry'
 import { ManagerAssignmentDialog } from '@/components/roles/manager-assignment-dialog'
 import { SendForApprovalButton } from '@/components/roles/send-for-approval-button'
 import { ShortlistStatusPill } from '@/components/manager/shortlist-status-pill'
@@ -97,8 +98,8 @@ export default async function RoleDetailPage({ params }: Props) {
     ? customer.portalBaseUrl.replace(/\/$/, '') + (role.customerPortalPath.startsWith('/') ? '' : '/') + role.customerPortalPath
     : customer?.portalBaseUrl || null
 
-  // Compute expired state for banner
-  const isExpired = role.isActive && role.cutoffDate && new Date(role.cutoffDate) < new Date(new Date().setHours(0, 0, 0, 0))
+  // Compute expired state for banner — uses shared helper (DEC-008: no auto-archive)
+  const isExpired = role.isActive && isRoleExpired(role.cutoffDate)
 
   // Fetch scored candidates for this role
   const scoredCandidates = await withTenant(tenantId, async (tx) =>

--- a/src/app/(dashboard)/dashboard/roles/page.tsx
+++ b/src/app/(dashboard)/dashboard/roles/page.tsx
@@ -1,27 +1,40 @@
-import { headers } from 'next/headers'
-import { and, desc, eq, ilike, or } from 'drizzle-orm'
+import { and, desc, eq, ilike, isNotNull, isNull, lt, or, sql } from 'drizzle-orm'
 import Link from 'next/link'
 import { PlusIcon, BriefcaseIcon, SearchIcon } from 'lucide-react'
 import { withTenant } from '@/db'
 import { roles, customers } from '@/db/schema'
 import { auth } from '@/lib/auth'
+import { isRoleExpired } from '@/lib/roles/expiry'
 
 export const metadata = { title: 'Roles — SkillAI' }
 
+// Valid values for the ?expired= query param (undefined = 'all').
+type ExpiryFilter = 'only' | 'exclude' | 'all'
+
+function parseExpiryFilter(raw: string | undefined): ExpiryFilter {
+  if (raw === 'only' || raw === 'exclude') return raw
+  return 'all'
+}
+
 interface PageProps {
-  searchParams: Promise<{ q?: string }>
+  searchParams: Promise<{ q?: string; expired?: string }>
 }
 
 export default async function RolesPage({ searchParams }: PageProps) {
   const session = await auth()
   const tenantId = session?.user.tenantId
 
-  const { q } = await searchParams
+  const { q, expired: expiredParam } = await searchParams
   const trimmedQ = q?.trim() ?? ''
+  const expiryFilter = parseExpiryFilter(expiredParam)
+
+  // Today's date string for DB-level expiry comparisons (YYYY-MM-DD).
+  const todayStr = new Date().toISOString().split('T')[0]
 
   const allRoles = tenantId
     ? await withTenant(tenantId, async (tx) => {
         const conditions = [eq(roles.isActive, true)]
+
         if (trimmedQ) {
           conditions.push(
             or(
@@ -30,6 +43,22 @@ export default async function RolesPage({ searchParams }: PageProps) {
             )!
           )
         }
+
+        // Expiry filter — DEC-008: never auto-archive; just filter the view.
+        if (expiryFilter === 'only') {
+          // cutoffDate IS NOT NULL AND cutoffDate < today
+          conditions.push(isNotNull(roles.cutoffDate))
+          conditions.push(lt(roles.cutoffDate, sql`${todayStr}::date`))
+        } else if (expiryFilter === 'exclude') {
+          // cutoffDate IS NULL OR cutoffDate >= today
+          conditions.push(
+            or(
+              isNull(roles.cutoffDate),
+              sql`${roles.cutoffDate} >= ${todayStr}::date`
+            )!
+          )
+        }
+
         return tx
           .select({
             id: roles.id,
@@ -53,12 +82,28 @@ export default async function RolesPage({ searchParams }: PageProps) {
 
   const canCreate = session?.user.role !== 'viewer'
 
+  // Build chip href helpers — preserve the search query, swap the expired param.
+  function chipHref(nextExpired: 'all' | 'only' | 'exclude'): string {
+    const params = new URLSearchParams()
+    if (trimmedQ) params.set('q', trimmedQ)
+    if (nextExpired !== 'all') params.set('expired', nextExpired)
+    const qs = params.toString()
+    return `/dashboard/roles${qs ? `?${qs}` : ''}`
+  }
+
+  const countLabel =
+    expiryFilter === 'only'
+      ? `${allRoles.length} expired role${allRoles.length !== 1 ? 's' : ''}`
+      : expiryFilter === 'exclude'
+        ? `${allRoles.length} active role${allRoles.length !== 1 ? 's' : ''} (non-expired)`
+        : `${allRoles.length} active role${allRoles.length !== 1 ? 's' : ''}`
+
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
         <div>
           <h1 className="text-2xl font-bold text-[var(--color-fg)]">Roles</h1>
-          <p className="text-[var(--color-fg-subtle)] mt-1">{allRoles.length} active role{allRoles.length !== 1 ? 's' : ''}</p>
+          <p className="text-[var(--color-fg-subtle)] mt-1">{countLabel}</p>
         </div>
         {canCreate && (
           <Link
@@ -86,6 +131,45 @@ export default async function RolesPage({ searchParams }: PageProps) {
           />
         </div>
       </form>
+
+      {/* Expiry filter chips */}
+      <div className="flex items-center gap-2 mb-4 flex-wrap">
+        <span className="text-xs text-[var(--color-fg-subtle)]">Show:</span>
+        <Link
+          href={chipHref('all')}
+          className={[
+            'inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors',
+            expiryFilter === 'all'
+              ? 'bg-blue-600 border-blue-500 text-white'
+              : 'bg-[var(--color-bg-elevated)] border-[var(--color-border)] text-[var(--color-fg-muted)] hover:border-blue-500',
+          ].join(' ')}
+        >
+          All
+        </Link>
+        <Link
+          href={chipHref('exclude')}
+          className={[
+            'inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors',
+            expiryFilter === 'exclude'
+              ? 'bg-blue-600 border-blue-500 text-white'
+              : 'bg-[var(--color-bg-elevated)] border-[var(--color-border)] text-[var(--color-fg-muted)] hover:border-blue-500',
+          ].join(' ')}
+        >
+          Active only
+        </Link>
+        <Link
+          href={chipHref('only')}
+          className={[
+            'inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors',
+            expiryFilter === 'only'
+              ? 'bg-red-600 border-red-500 text-white'
+              : 'bg-[var(--color-bg-elevated)] border-[var(--color-border)] text-[var(--color-fg-muted)] hover:border-red-500',
+          ].join(' ')}
+        >
+          Expired
+        </Link>
+      </div>
+
       {trimmedQ && (
         <p className="text-xs text-[var(--color-fg-subtle)] mb-3">
           Showing {allRoles.length} result{allRoles.length !== 1 ? 's' : ''} for &ldquo;{trimmedQ}&rdquo;
@@ -96,8 +180,10 @@ export default async function RolesPage({ searchParams }: PageProps) {
         <div className="flex flex-col items-center justify-center rounded-xl border-2 border-dashed
                         border-[var(--color-border)] bg-[var(--color-bg-app)] px-6 py-16 text-center">
           <BriefcaseIcon className="h-10 w-10 text-[var(--color-fg-subtle)] mb-3" />
-          <p className="text-[var(--color-fg-muted)] font-medium">No roles yet</p>
-          {canCreate && (
+          <p className="text-[var(--color-fg-muted)] font-medium">
+            {expiryFilter === 'only' ? 'No expired roles' : 'No roles yet'}
+          </p>
+          {canCreate && expiryFilter !== 'only' && (
             <p className="text-[var(--color-fg-subtle)] text-sm mt-1">
               <Link href="/dashboard/roles/new" className="text-blue-400 hover:underline">
                 Create your first role
@@ -108,83 +194,89 @@ export default async function RolesPage({ searchParams }: PageProps) {
         </div>
       ) : (
         <div className="grid gap-3">
-          {allRoles.map((role) => (
-            <Link
-              key={role.id}
-              href={`/dashboard/roles/${role.id}`}
-              className="rounded-xl bg-[var(--color-bg-elevated)] border border-[var(--color-border)] px-6 py-5
-                         hover:border-blue-500 hover:shadow-sm transition-all block"
-            >
-              <div className="flex items-start justify-between">
-                <div className="flex items-center gap-2 flex-wrap">
-                  <h2 className="font-semibold text-[var(--color-fg)]">{role.title}</h2>
-                  {(() => {
-                    if (!role.cutoffDate) return null
-                    const target = new Date(role.cutoffDate)
-                    target.setHours(0, 0, 0, 0)
-                    const today = new Date()
-                    today.setHours(0, 0, 0, 0)
-                    const days = Math.round((target.getTime() - today.getTime()) / (1000 * 60 * 60 * 24))
-                    if (days < 0) {
-                      return (
-                        <span className="inline-flex items-center rounded-full bg-red-950 border border-red-800 text-red-300 text-xs font-semibold px-2 py-0.5">
-                          EXPIRED
-                        </span>
-                      )
-                    }
-                    if (days <= 7) {
-                      return (
-                        <span className="inline-flex items-center rounded-full bg-amber-950 border border-amber-800 text-amber-300 text-xs font-medium px-2 py-0.5">
-                          Cut-off in {days} day{days !== 1 ? 's' : ''}
-                        </span>
-                      )
-                    }
-                    return null
-                  })()}
-                  {role.customerDayRate && (
-                    <span className="inline-flex items-center rounded-full bg-emerald-950 border border-emerald-800 text-emerald-300 text-xs font-medium px-2 py-0.5">
-                      {role.rateCurrency ?? ''} {Number(role.customerDayRate).toFixed(0)}/day
-                    </span>
-                  )}
-                  {role.customerRoleId && (
-                    <span
-                      className="inline-flex items-center rounded-full bg-slate-800 border border-slate-700
-                                 text-slate-300 text-xs font-medium px-2 py-0.5"
-                      title={`${role.customerRoleIdLabel ?? 'Customer Role ID'}: ${role.customerRoleId}`}
-                    >
-                      {role.customerRoleIdLabel ?? 'Customer Role ID'}: {role.customerRoleId}
-                    </span>
-                  )}
+          {allRoles.map((role) => {
+            const expired = isRoleExpired(role.cutoffDate)
+            return (
+              <Link
+                key={role.id}
+                href={`/dashboard/roles/${role.id}`}
+                className="rounded-xl bg-[var(--color-bg-elevated)] border border-[var(--color-border)] px-6 py-5
+                           hover:border-blue-500 hover:shadow-sm transition-all block"
+              >
+                <div className="flex items-start justify-between">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <h2 className="font-semibold text-[var(--color-fg)]">{role.title}</h2>
+
+                    {/* Expiry / countdown badge — uses isRoleExpired from src/lib/roles/expiry.ts */}
+                    {expired ? (
+                      <span className="inline-flex items-center rounded-full
+                                       bg-red-100 dark:bg-red-950 border border-red-300 dark:border-red-800
+                                       text-red-700 dark:text-red-300 text-xs font-semibold px-2 py-0.5">
+                        EXPIRED
+                      </span>
+                    ) : role.cutoffDate ? (() => {
+                      const target = new Date(role.cutoffDate)
+                      target.setHours(0, 0, 0, 0)
+                      const today = new Date()
+                      today.setHours(0, 0, 0, 0)
+                      const days = Math.round((target.getTime() - today.getTime()) / (1000 * 60 * 60 * 24))
+                      if (days <= 7) {
+                        return (
+                          <span className="inline-flex items-center rounded-full
+                                           bg-amber-100 dark:bg-amber-950 border border-amber-300 dark:border-amber-800
+                                           text-amber-700 dark:text-amber-300 text-xs font-medium px-2 py-0.5">
+                            Cut-off in {days} day{days !== 1 ? 's' : ''}
+                          </span>
+                        )
+                      }
+                      return null
+                    })() : null}
+
+                    {role.customerDayRate && (
+                      <span className="inline-flex items-center rounded-full bg-emerald-950 border border-emerald-800 text-emerald-300 text-xs font-medium px-2 py-0.5">
+                        {role.rateCurrency ?? ''} {Number(role.customerDayRate).toFixed(0)}/day
+                      </span>
+                    )}
+                    {role.customerRoleId && (
+                      <span
+                        className="inline-flex items-center rounded-full bg-slate-800 border border-slate-700
+                                   text-slate-300 text-xs font-medium px-2 py-0.5"
+                        title={`${role.customerRoleIdLabel ?? 'Customer Role ID'}: ${role.customerRoleId}`}
+                      >
+                        {role.customerRoleIdLabel ?? 'Customer Role ID'}: {role.customerRoleId}
+                      </span>
+                    )}
+                  </div>
+                  <time className="text-xs text-[var(--color-fg-subtle)] whitespace-nowrap ml-4 mt-0.5 flex-shrink-0">
+                    {new Date(role.createdAt).toLocaleDateString('en-GB')}
+                  </time>
                 </div>
-                <time className="text-xs text-[var(--color-fg-subtle)] whitespace-nowrap ml-4 mt-0.5 flex-shrink-0">
-                  {new Date(role.createdAt).toLocaleDateString('en-GB')}
-                </time>
-              </div>
-              <p className="text-sm text-[var(--color-fg-subtle)] mt-0.5 line-clamp-2">{role.description}</p>
-              {(role.keySkills.length > 0 || role.topRequirements.length > 0) && (
-                <div className="flex flex-wrap gap-1.5 mt-3">
-                  {role.keySkills.slice(0, 6).map((s) => (
-                    <span
-                      key={s}
-                      className="inline-flex items-center rounded-full bg-blue-950 border border-blue-800
-                                 text-blue-300 text-xs px-2.5 py-0.5"
-                    >
-                      {s}
-                    </span>
-                  ))}
-                  {role.topRequirements.slice(0, 3).map((r) => (
-                    <span
-                      key={r}
-                      className="inline-flex items-center rounded-full bg-amber-950 border border-amber-800
-                                 text-amber-300 text-xs px-2.5 py-0.5"
-                    >
-                      {r}
-                    </span>
-                  ))}
-                </div>
-              )}
-            </Link>
-          ))}
+                <p className="text-sm text-[var(--color-fg-subtle)] mt-0.5 line-clamp-2">{role.description}</p>
+                {(role.keySkills.length > 0 || role.topRequirements.length > 0) && (
+                  <div className="flex flex-wrap gap-1.5 mt-3">
+                    {role.keySkills.slice(0, 6).map((s) => (
+                      <span
+                        key={s}
+                        className="inline-flex items-center rounded-full bg-blue-950 border border-blue-800
+                                   text-blue-300 text-xs px-2.5 py-0.5"
+                      >
+                        {s}
+                      </span>
+                    ))}
+                    {role.topRequirements.slice(0, 3).map((r) => (
+                      <span
+                        key={r}
+                        className="inline-flex items-center rounded-full bg-amber-950 border border-amber-800
+                                   text-amber-300 text-xs px-2.5 py-0.5"
+                      >
+                        {r}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </Link>
+            )
+          })}
         </div>
       )}
     </div>

--- a/src/lib/roles/expiry.ts
+++ b/src/lib/roles/expiry.ts
@@ -1,0 +1,22 @@
+/**
+ * Pure expiry helpers for roles.
+ *
+ * DEC-008: when cutoffDate passes, the role is flagged as expired but
+ * remains isActive = true until a recruiter explicitly archives it.
+ * No auto-archiving is ever triggered from this module.
+ */
+
+/**
+ * Returns true when the role's cutoff date is in the past (before today,
+ * midnight local time).  Returns false when cutoffDate is null/undefined,
+ * which means the role has no deadline and cannot expire.
+ */
+export function isRoleExpired(cutoffDate: string | Date | null | undefined): boolean {
+  if (!cutoffDate) return false
+  const cutoff = typeof cutoffDate === 'string' ? new Date(cutoffDate) : cutoffDate
+  // Compare against today at midnight so a role expiring today is NOT expired
+  // until the calendar date has actually passed.
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  return cutoff.getTime() < today.getTime()
+}

--- a/tests/unit/lib/roles/expiry.test.ts
+++ b/tests/unit/lib/roles/expiry.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for src/lib/roles/expiry.ts
+ *
+ * Covers: isRoleExpired with null, undefined, a future date, a past date,
+ * exactly today, and both string and Date inputs.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { isRoleExpired } from '@/lib/roles/expiry'
+
+// Helpers to build date strings relative to today
+function toDateStr(d: Date): string {
+  return d.toISOString().split('T')[0]
+}
+
+function daysFromNow(n: number): string {
+  const d = new Date()
+  d.setDate(d.getDate() + n)
+  return toDateStr(d)
+}
+
+describe('isRoleExpired', () => {
+  it('returns false when cutoffDate is null', () => {
+    expect(isRoleExpired(null)).toBe(false)
+  })
+
+  it('returns false when cutoffDate is undefined', () => {
+    expect(isRoleExpired(undefined)).toBe(false)
+  })
+
+  it('returns false for a date in the future', () => {
+    expect(isRoleExpired(daysFromNow(7))).toBe(false)
+  })
+
+  it('returns false for a date exactly today (not yet expired)', () => {
+    expect(isRoleExpired(daysFromNow(0))).toBe(false)
+  })
+
+  it('returns true for a date in the past', () => {
+    expect(isRoleExpired(daysFromNow(-1))).toBe(true)
+  })
+
+  it('returns true for a date well in the past', () => {
+    expect(isRoleExpired('2020-01-01')).toBe(true)
+  })
+
+  it('accepts a Date object as input — past date returns true', () => {
+    const pastDate = new Date()
+    pastDate.setDate(pastDate.getDate() - 30)
+    expect(isRoleExpired(pastDate)).toBe(true)
+  })
+
+  it('accepts a Date object as input — future date returns false', () => {
+    const futureDate = new Date()
+    futureDate.setDate(futureDate.getDate() + 30)
+    expect(isRoleExpired(futureDate)).toBe(false)
+  })
+
+  it('accepts an ISO datetime string — past returns true', () => {
+    expect(isRoleExpired('2024-03-15T00:00:00.000Z')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `src/lib/roles/expiry.ts` — single pure `isRoleExpired(cutoffDate)` helper shared across all surfaces (list page, detail page). No more inline date math duplicated in two places.
- Extends the roles list page (`/dashboard/roles`) with an `?expired=` query-param filter (`all` / `exclude` / `only`) applied inside the Drizzle query; no DB schema change required (`cutoffDate` already exists).
- Three filter chips render above the role list: **All**, **Active only**, **Expired** — active chip highlighted, chips preserve `?q=` search across navigations.
- Per-row **EXPIRED** badge updated to use `isRoleExpired` and now uses the project-standard dual-mode token classes (`bg-red-100 dark:bg-red-950 text-red-700 dark:text-red-300 border-red-300 dark:border-red-800`) for correct light/dark rendering.
- Role detail page `isExpired` computation replaced with the shared helper (deduplication, consistent midnight-truncation semantics).
- `ForYouSection` expired-roles widget is unmodified — it was already wired and correctly queries `cutoffDate < today` directly in `dashboard-tasks.ts`.
- **No auto-archiving** — per DEC-008, expiry is a visual + filterable signal only. Recruiters retain full control of the role lifecycle.

## Filter param schema

| `?expired=` | DB clause |
|---|---|
| *(omitted / `all`)* | no additional filter |
| `exclude` | `cutoffDate IS NULL OR cutoffDate >= today` |
| `only` | `cutoffDate IS NOT NULL AND cutoffDate < today` |

## Files changed

| File | Change |
|---|---|
| `src/lib/roles/expiry.ts` | new — pure `isRoleExpired` helper |
| `tests/unit/lib/roles/expiry.test.ts` | new — 9 unit tests |
| `src/app/(dashboard)/dashboard/roles/page.tsx` | filter chips + query param + badge refactor |
| `src/app/(dashboard)/dashboard/roles/[roleId]/page.tsx` | use shared helper for `isExpired` |

## Test count

9 new unit tests — all passing. Full suite: 965 tests, 0 failures.

Relates to DEC-008 (manual archive on cut-off expiry, no auto-archive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)