### PR TITLE
fix(submissions): show role title + customer name in tenant-wide list

### DIFF
--- a/src/actions/role-submissions/reads.ts
+++ b/src/actions/role-submissions/reads.ts
@@ -82,6 +82,11 @@ export async function getSubmissionsForRole(
   return rows.map((r) => ({
     id: r.id,
     roleId: r.roleId,
+    // Per-role loader: the caller already knows the role title from page
+    // context, so we leave these `null`. The tenant-wide loader populates
+    // them.
+    roleTitle: null,
+    customerName: null,
     candidateId: r.candidateId,
     sentAt: r.sentAt,
     sentByUserId: r.sentByUserId,
@@ -252,6 +257,7 @@ export async function getAllSubmissionsForTenant(opts: {
         .select({
           id: roleSubmissions.id,
           roleId: roleSubmissions.roleId,
+          roleTitle: roles.title,
           candidateId: roleSubmissions.candidateId,
           sentAt: roleSubmissions.sentAt,
           sentByUserId: roleSubmissions.sentByUserId,
@@ -269,6 +275,7 @@ export async function getAllSubmissionsForTenant(opts: {
           scoreOverall: scores.overallScore,
           submitterName: users.name,
           submitterEmail: users.email,
+          customerName: customers.name,
         })
         .from(roleSubmissions)
         .innerJoin(candidates, eq(roleSubmissions.candidateId, candidates.id))
@@ -337,6 +344,8 @@ export async function getAllSubmissionsForTenant(opts: {
     rows: rows.map((r) => ({
       id: r.id,
       roleId: r.roleId,
+      roleTitle: r.roleTitle,
+      customerName: r.customerName ?? null,
       candidateId: r.candidateId,
       sentAt: r.sentAt,
       sentByUserId: r.sentByUserId,

--- a/src/actions/role-submissions/shared.ts
+++ b/src/actions/role-submissions/shared.ts
@@ -12,6 +12,20 @@ export type ActionResult<T = void> =
 export type SubmissionWithDetails = {
   id: string
   roleId: string
+  /**
+   * Role title — populated by the tenant-wide loader
+   * (`getAllSubmissionsForTenant`) which JOINs `roles`. The per-role loader
+   * (`getSubmissionsForRole`) leaves this `null` because the caller already
+   * knows the role title from the page context.
+   */
+  roleTitle: string | null
+  /**
+   * Customer name — populated by the tenant-wide loader
+   * (`getAllSubmissionsForTenant`) which JOINs `customers` via
+   * `roles.customer_id`. `null` when the role has no linked customer, OR
+   * when the loader doesn't join customers (per-role loader).
+   */
+  customerName: string | null
   candidateId: string
   sentAt: Date
   sentByUserId: string | null

--- a/src/app/(dashboard)/dashboard/submissions/page.tsx
+++ b/src/app/(dashboard)/dashboard/submissions/page.tsx
@@ -6,22 +6,11 @@ import { auth } from '@/lib/auth'
 import { hasRole } from '@/lib/auth/require-role'
 import { withTenant } from '@/db'
 import { roles, customers, agencies } from '@/db/schema'
-import {
-  getAllSubmissionsForTenant,
-  type SubmissionWithDetails,
-} from '@/actions/role-submissions'
+import { getAllSubmissionsForTenant } from '@/actions/role-submissions'
 import { SubmissionFilters } from '@/components/submissions/submission-filters'
 import { SubmissionStatusPill } from '@/components/roles/submission-status-pill'
 import { SubmissionCard } from '@/components/submissions/submission-card'
 import type { SubmissionStatus } from '@/db/schema/role-submissions'
-
-// Agent A extends SubmissionWithDetails with roleTitle and customerName for the
-// tenant-wide loader. We declare the extended shape here so the page is
-// self-documenting about what it expects.
-type SubmissionRow = SubmissionWithDetails & {
-  roleTitle: string
-  customerName: string | null
-}
 
 export const metadata = { title: 'Submissions — SkillAI' }
 
@@ -169,8 +158,7 @@ export default async function SubmissionsPage({ searchParams }: PageProps) {
     }),
   ])
 
-  // Cast to the extended row shape Agent A exports (includes roleTitle + customerName)
-  const allSubmissions = submissionsResult.rows as SubmissionRow[]
+  const allSubmissions = submissionsResult.rows
   const totalCount = submissionsResult.totalCount
 
   const totalPages = Math.ceil(totalCount / PAGE_SIZE)
@@ -360,7 +348,9 @@ export default async function SubmissionsPage({ searchParams }: PageProps) {
                           href={`/dashboard/roles/${sub.roleId}`}
                           className="text-blue-400 hover:text-blue-300 hover:underline"
                         >
-                          {sub.roleTitle}
+                          {sub.roleTitle ?? (
+                            <span className="text-[var(--color-fg-subtle)]">—</span>
+                          )}
                         </Link>
                       </td>
 

--- a/src/components/submissions/submission-card.tsx
+++ b/src/components/submissions/submission-card.tsx
@@ -2,14 +2,8 @@ import Link from 'next/link'
 import { SubmissionStatusPill } from '@/components/roles/submission-status-pill'
 import type { SubmissionWithDetails } from '@/actions/role-submissions'
 
-// Page-level extended type: getAllSubmissionsForTenant joins roleTitle + customerName
-// onto SubmissionWithDetails. We re-declare the minimal shape the card needs so this
-// component doesn't have to import the page-private SubmissionRow typedef.
 type SubmissionCardProps = {
-  submission: SubmissionWithDetails & {
-    roleTitle: string
-    customerName: string | null
-  }
+  submission: SubmissionWithDetails
   timeAgo: (date: Date) => string
 }
 
@@ -21,9 +15,10 @@ export function SubmissionCard({ submission, timeAgo }: SubmissionCardProps) {
     (candidate.lastName[0] ?? '')
   ).toUpperCase()
 
+  const roleTitle = submission.roleTitle ?? '—'
   const roleLine = submission.customerName
-    ? `${submission.roleTitle} · ${submission.customerName}`
-    : submission.roleTitle
+    ? `${roleTitle} · ${submission.customerName}`
+    : roleTitle
 
   return (
     <div

--- a/tests/unit/actions/role-submissions.test.ts
+++ b/tests/unit/actions/role-submissions.test.ts
@@ -90,7 +90,8 @@ function makeSelectChain(rows: unknown[]) {
   c.innerJoin = vi.fn(() => c)
   c.where     = vi.fn(() => c)
   c.orderBy   = vi.fn(() => c)
-  c.limit     = vi.fn(() => Promise.resolve(rows))
+  c.limit     = vi.fn(() => c)
+  c.offset    = vi.fn(() => Promise.resolve(rows))
   return c
 }
 
@@ -218,6 +219,16 @@ vi.mock('drizzle-orm', () => ({
   eq:      vi.fn(() => ({ type: 'eq' })),
   and:     vi.fn((...args: unknown[]) => ({ type: 'and', args })),
   inArray: vi.fn(() => ({ type: 'inArray' })),
+  // Used by getAllSubmissionsForTenant and getRecentSubmissionsForTenant
+  // for filtering + sorting + count aggregation.
+  asc:     vi.fn((col: unknown) => ({ type: 'asc', col })),
+  desc:    vi.fn((col: unknown) => ({ type: 'desc', col })),
+  lt:      vi.fn(() => ({ type: 'lt' })),
+  gte:     vi.fn(() => ({ type: 'gte' })),
+  lte:     vi.fn(() => ({ type: 'lte' })),
+  ilike:   vi.fn(() => ({ type: 'ilike' })),
+  or:      vi.fn((...args: unknown[]) => ({ type: 'or', args })),
+  count:   vi.fn(() => ({ type: 'count' })),
   sql:     vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
     type: 'sql', strings, values,
   })),
@@ -884,5 +895,104 @@ describe('getSubmissionByToken', () => {
     const result = await getSubmissionByToken(SHARE_TOKEN)
 
     expect(result).toBeNull()
+  })
+})
+
+// ── getAllSubmissionsForTenant (tenant-wide list) ─────────────────────────────
+
+describe('getAllSubmissionsForTenant', () => {
+  beforeEach(resetState)
+
+  const buildJoinedRow = (overrides: Record<string, unknown> = {}) => ({
+    id: SUBMISSION_ID,
+    roleId: ROLE_ID,
+    roleTitle: 'Senior TypeScript Engineer',
+    candidateId: CANDIDATE_ID,
+    sentAt: new Date('2026-05-01T10:00:00Z'),
+    sentByUserId: USER_ID,
+    status: 'submitted',
+    statusUpdatedAt: new Date('2026-05-01T10:00:00Z'),
+    notes: null,
+    createdAt: new Date('2026-05-01T10:00:00Z'),
+    shareToken: null,
+    shareTokenCreatedAt: null,
+    candidateFirstName: 'Jane',
+    candidateLastName: 'Doe',
+    agencyId: null,
+    agencyName: null,
+    agencyLogoPath: null,
+    scoreOverall: 85,
+    submitterName: 'Recruiter R',
+    submitterEmail: 'r@example.com',
+    customerName: 'ClientCo',
+    ...overrides,
+  })
+
+  it('returns empty result when unauthenticated', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { getAllSubmissionsForTenant } = await import('@/actions/role-submissions')
+
+    const result = await getAllSubmissionsForTenant({})
+
+    expect(result.rows).toEqual([])
+    expect(result.totalCount).toBe(0)
+  })
+
+  it('returns empty result when role is below recruiter', async () => {
+    mockGetActionContext.mockResolvedValue({
+      tenantId: TENANT_ID, userId: USER_ID, userRole: 'viewer' as const,
+    })
+    const { getAllSubmissionsForTenant } = await import('@/actions/role-submissions')
+
+    const result = await getAllSubmissionsForTenant({})
+
+    expect(result.rows).toEqual([])
+    expect(result.totalCount).toBe(0)
+  })
+
+  it('projects roleTitle and customerName onto each row', async () => {
+    // Two parallel withTenant calls: paginated rows + count
+    withTenantResults = [
+      [buildJoinedRow()],
+      [{ total: 1 }],
+    ]
+    const { getAllSubmissionsForTenant } = await import('@/actions/role-submissions')
+
+    const result = await getAllSubmissionsForTenant({})
+
+    expect(result.totalCount).toBe(1)
+    expect(result.rows).toHaveLength(1)
+    expect(result.rows[0].roleTitle).toBe('Senior TypeScript Engineer')
+    expect(result.rows[0].customerName).toBe('ClientCo')
+    expect(result.rows[0].candidate.firstName).toBe('Jane')
+    expect(result.rows[0].candidate.lastName).toBe('Doe')
+  })
+
+  it('returns customerName as null when the role has no linked customer', async () => {
+    // The LEFT JOIN on customers returns NULL for customerName when
+    // roles.customer_id is null.
+    withTenantResults = [
+      [buildJoinedRow({ customerName: null })],
+      [{ total: 1 }],
+    ]
+    const { getAllSubmissionsForTenant } = await import('@/actions/role-submissions')
+
+    const result = await getAllSubmissionsForTenant({})
+
+    expect(result.rows[0].roleTitle).toBe('Senior TypeScript Engineer')
+    expect(result.rows[0].customerName).toBeNull()
+  })
+
+  it('returns empty rows + zero count when there are no submissions', async () => {
+    withTenantResults = [
+      [],
+      [{ total: 0 }],
+    ]
+    const { getAllSubmissionsForTenant } = await import('@/actions/role-submissions')
+
+    const result = await getAllSubmissionsForTenant({})
+
+    expect(result.rows).toEqual([])
+    expect(result.totalCount).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary

The `/dashboard/submissions` table was rendering "—" in both the **Role** and **Customer** columns for every row. The bug was in `getAllSubmissionsForTenant` (`src/actions/role-submissions/reads.ts`): it correctly added `innerJoin(roles)` and `leftJoin(customers, eq(roles.customerId, customers.id))` but never projected `roles.title` or `customers.name` into the SELECT — so the returned row shape had neither field at runtime.

The consuming page (`src/app/(dashboard)/dashboard/submissions/page.tsx`) and `SubmissionCard` each compensated by declaring a local type-extension hack:

```ts
type SubmissionRow = SubmissionWithDetails & {
  roleTitle: string
  customerName: string | null
}
const allSubmissions = submissionsResult.rows as SubmissionRow[]
```

— so TypeScript silently accepted `sub.roleTitle` / `sub.customerName ?? "—"` while the values were `undefined` at runtime. Customer cell fell back to "—" via nullish coalescing; Role cell was empty text inside the link.

## What changed

- **`src/actions/role-submissions/shared.ts`** — `SubmissionWithDetails` gains `roleTitle: string | null` and `customerName: string | null`. JSDoc on both fields documents which loader populates them.
- **`src/actions/role-submissions/reads.ts`** — `getAllSubmissionsForTenant` now SELECTs `roleTitle: roles.title` and `customerName: customers.name`, and the return mapping surfaces both fields. `getSubmissionsForRole` (the per-role variant) returns `null` for both — preserving existing semantics (the caller already knows the role title from the page context).
- **`src/app/(dashboard)/dashboard/submissions/page.tsx`** — removes the `SubmissionRow` type-extension hack and the `as SubmissionRow[]` cast. The Role cell defensively falls back to em-dash if `roleTitle` is null.
- **`src/components/submissions/submission-card.tsx`** — removes the matching type-extension hack and handles nullable `roleTitle`.
- **`tests/unit/actions/role-submissions.test.ts`** — 5 new tests covering `getAllSubmissionsForTenant`: unauthenticated, role-below-recruiter, happy-path projection of role title + customer name, customer null fallthrough (LEFT JOIN), empty result.

## Files touched

```
 src/actions/role-submissions/reads.ts              |   9 ++
 src/actions/role-submissions/shared.ts             |  14 +++
 src/app/(dashboard)/dashboard/submissions/page.tsx |  20 +---
 src/components/submissions/submission-card.tsx     |  13 +--
 tests/unit/actions/role-submissions.test.ts        | 112 ++++++++++++++++++++-
 5 files changed, 143 insertions(+), 25 deletions(-)
```

## Test count delta

- Before: 41 tests in `tests/unit/actions/role-submissions.test.ts`
- After: 46 tests (+5)
- Full suite: 961 passing / 4 skipped (unchanged skip count)

## Test plan

- [x] `npm test` — 961 passing, 4 skipped (pre-existing)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint . --max-warnings=99999` — 0 errors, 79 warnings (all pre-existing, none introduced)
- [ ] Manual check on `/dashboard/submissions`: Role column shows linked role title, Customer column shows the customer name (or "—" only when the role has no linked customer)
- [ ] Manual check that per-role submissions list (`/dashboard/roles/{id}` → submissions tab) still renders correctly (no regression — those rows now carry `roleTitle: null`, `customerName: null`, which the existing per-role components don't read)