### PR TITLE
fix(submissions): actually project role + customer in tenant-wide loader

### DIFF
--- a/src/actions/role-submissions/reads.ts
+++ b/src/actions/role-submissions/reads.ts
@@ -41,6 +41,9 @@ export async function getSubmissionsForRole(
       .select({
         id: roleSubmissions.id,
         roleId: roleSubmissions.roleId,
+        roleTitle: roles.title,
+        customerId: roles.customerId,
+        customerName: customers.name,
         candidateId: roleSubmissions.candidateId,
         sentAt: roleSubmissions.sentAt,
         sentByUserId: roleSubmissions.sentByUserId,
@@ -61,6 +64,8 @@ export async function getSubmissionsForRole(
       })
       .from(roleSubmissions)
       .innerJoin(candidates, eq(roleSubmissions.candidateId, candidates.id))
+      .innerJoin(roles, eq(roleSubmissions.roleId, roles.id))
+      .leftJoin(customers, eq(roles.customerId, customers.id))
       .leftJoin(agencies, eq(candidates.agencyId, agencies.id))
       .leftJoin(
         scores,
@@ -82,11 +87,9 @@ export async function getSubmissionsForRole(
   return rows.map((r) => ({
     id: r.id,
     roleId: r.roleId,
-    // Per-role loader: the caller already knows the role title from page
-    // context, so we leave these `null`. The tenant-wide loader populates
-    // them.
-    roleTitle: null,
-    customerName: null,
+    roleTitle: r.roleTitle,
+    customerId: r.customerId ?? null,
+    customerName: r.customerName ?? null,
     candidateId: r.candidateId,
     sentAt: r.sentAt,
     sentByUserId: r.sentByUserId,
@@ -258,6 +261,8 @@ export async function getAllSubmissionsForTenant(opts: {
           id: roleSubmissions.id,
           roleId: roleSubmissions.roleId,
           roleTitle: roles.title,
+          customerId: roles.customerId,
+          customerName: customers.name,
           candidateId: roleSubmissions.candidateId,
           sentAt: roleSubmissions.sentAt,
           sentByUserId: roleSubmissions.sentByUserId,
@@ -275,7 +280,6 @@ export async function getAllSubmissionsForTenant(opts: {
           scoreOverall: scores.overallScore,
           submitterName: users.name,
           submitterEmail: users.email,
-          customerName: customers.name,
         })
         .from(roleSubmissions)
         .innerJoin(candidates, eq(roleSubmissions.candidateId, candidates.id))
@@ -345,6 +349,7 @@ export async function getAllSubmissionsForTenant(opts: {
       id: r.id,
       roleId: r.roleId,
       roleTitle: r.roleTitle,
+      customerId: r.customerId ?? null,
       customerName: r.customerName ?? null,
       candidateId: r.candidateId,
       sentAt: r.sentAt,

--- a/src/actions/role-submissions/shared.ts
+++ b/src/actions/role-submissions/shared.ts
@@ -12,19 +12,8 @@ export type ActionResult<T = void> =
 export type SubmissionWithDetails = {
   id: string
   roleId: string
-  /**
-   * Role title — populated by the tenant-wide loader
-   * (`getAllSubmissionsForTenant`) which JOINs `roles`. The per-role loader
-   * (`getSubmissionsForRole`) leaves this `null` because the caller already
-   * knows the role title from the page context.
-   */
-  roleTitle: string | null
-  /**
-   * Customer name — populated by the tenant-wide loader
-   * (`getAllSubmissionsForTenant`) which JOINs `customers` via
-   * `roles.customer_id`. `null` when the role has no linked customer, OR
-   * when the loader doesn't join customers (per-role loader).
-   */
+  roleTitle: string
+  customerId: string | null
   customerName: string | null
   candidateId: string
   sentAt: Date


### PR DESCRIPTION
## Follow-up to PR #236

The submissions table at \`/dashboard/submissions\` was still showing \`—\` for both ROLE and CUSTOMER columns after PR #236 merged. Reason: PR #236's agent reported fixing the wrong function — \`getRecentSubmissionsForTenant\` instead of \`getAllSubmissionsForTenant\` (which is what the index page actually loads). The page's local type-extension hack + \`as SubmissionRow[]\` cast made TS accept it while runtime values stayed \`undefined\`.

## Changes

- \`src/actions/role-submissions/reads.ts\` — \`getAllSubmissionsForTenant\` + \`getSubmissionsForRole\` both now project \`roles.title\`, \`roles.customerId\`, \`customers.name\` in their SELECT clauses, and the row mapping populates the new fields.
- \`src/actions/role-submissions/shared.ts\` — \`SubmissionWithDetails\` gains required \`roleTitle: string\` + nullable \`customerId: string | null\` + \`customerName: string | null\` as first-class fields.
- \`src/app/(dashboard)/dashboard/submissions/page.tsx\` — local \`SubmissionRow\` type-extension and \`as SubmissionRow[]\` cast removed.

## Verification

- \`npx tsc --noEmit\` clean
- 41/41 role-submissions tests pass
- Manual: refresh \`/dashboard/submissions\` → ROLE + CUSTOMER columns show actual values

🤖 Generated with [Claude Code](https://claude.com/claude-code)