### PR TITLE
infra(k8s): base + overlays + platform manifests for skillai

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,4 +64,6 @@ infra/terraform/terraform.tfstate.backup
 infra/terraform/.terraform/
 
 # Rendered k8s secrets — produced locally by 50-render-secret.sh; never committed
-infra/k8s/base/secret.yaml
+# Only the committed template (secret.template.yaml) is allowed in git.
+/infra/k8s/base/secret.yaml
+/infra/k8s/**/secret.yaml

--- a/infra/k8s/base/deployment.yaml
+++ b/infra/k8s/base/deployment.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: skillai-app
+  namespace: skillai
+  labels:
+    app.kubernetes.io/name: skillai
+    app.kubernetes.io/component: app
+spec:
+  replicas: 1
+  # Single-replica + RWO-equivalent semantics on a single-node EKS: Recreate avoids
+  # two pods trying to mount the same EFS access point during rollover.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: skillai
+      app.kubernetes.io/component: app
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: skillai
+        app.kubernetes.io/component: app
+    spec:
+      # nextjs:nodejs (1001:1001) — matches the Dockerfile runner stage.
+      securityContext:
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+        runAsNonRoot: true
+      containers:
+        - name: app
+          # Tag pinned by overlay (kustomize images: transform).
+          image: skillai:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          envFrom:
+            - secretRef:
+                name: skillai-secrets
+          volumeMounts:
+            - name: uploads
+              mountPath: /app/uploads
+            - name: tmp
+              mountPath: /tmp
+            - name: next-cache
+              mountPath: /app/.next/cache
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              cpu: 800m
+              memory: 1.5Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: uploads
+          persistentVolumeClaim:
+            claimName: skillai-uploads
+        - name: tmp
+          emptyDir: {}
+        - name: next-cache
+          emptyDir: {}

--- a/infra/k8s/base/ingress.yaml
+++ b/infra/k8s/base/ingress.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: skillai-app
+  namespace: skillai
+  labels:
+    app.kubernetes.io/name: skillai
+    app.kubernetes.io/component: app
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    # 12 MiB request body cap: CV uploads max out at 10 MiB plus form overhead.
+    nginx.ingress.kubernetes.io/proxy-body-size: 12m
+    # 10 min upstream read timeout: covers long-running AI scoring requests.
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - __INGRESS_HOST__
+      secretName: skillai-tls
+  rules:
+    - host: __INGRESS_HOST__
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: skillai-app
+                port:
+                  number: 80

--- a/infra/k8s/base/kustomization.yaml
+++ b/infra/k8s/base/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: skillai
+
+resources:
+  - namespace.yaml
+  - deployment.yaml
+  - migrate-job.yaml
+  - service.yaml
+  - ingress.yaml
+  - pvc.yaml
+
+# NOTE: secret.template.yaml is intentionally NOT in resources.
+# The deploy script renders secret.yaml from .envrc and applies it directly.

--- a/infra/k8s/base/migrate-job.yaml
+++ b/infra/k8s/base/migrate-job.yaml
@@ -1,0 +1,45 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: skillai-migrate
+  namespace: skillai
+  labels:
+    app.kubernetes.io/name: skillai
+    app.kubernetes.io/component: migrate
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: skillai
+        app.kubernetes.io/component: migrate
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+        runAsNonRoot: true
+      containers:
+        - name: migrate
+          # Same image as the app; tag pinned by overlay.
+          image: skillai:latest
+          imagePullPolicy: IfNotPresent
+          command: ["node", "/app/scripts/migrate.mjs"]
+          envFrom:
+            - secretRef:
+                name: skillai-secrets
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 768Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop:
+                - ALL

--- a/infra/k8s/base/namespace.yaml
+++ b/infra/k8s/base/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: skillai
+  labels:
+    app.kubernetes.io/name: skillai
+    app.kubernetes.io/part-of: skillai

--- a/infra/k8s/base/pvc.yaml
+++ b/infra/k8s/base/pvc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: skillai-uploads
+  namespace: skillai
+  labels:
+    app.kubernetes.io/name: skillai
+    app.kubernetes.io/component: uploads
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: efs-sc
+  resources:
+    requests:
+      storage: 5Gi

--- a/infra/k8s/base/secret.template.yaml
+++ b/infra/k8s/base/secret.template.yaml
@@ -1,0 +1,28 @@
+# AUTO-RENDERED TARGET — DO NOT COMMIT secret.yaml.
+# Real values are populated by infra/scripts/50-render-secret.sh from .envrc and
+# the rendered file is gitignored. This template documents the required keys and
+# is the only secret-shaped manifest checked into the repo.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: skillai-secrets
+  namespace: skillai
+  labels:
+    app.kubernetes.io/name: skillai
+    app.kubernetes.io/component: app
+type: Opaque
+stringData:
+  DATABASE_URL: __PLACEHOLDER__
+  AUTH_SECRET: __PLACEHOLDER__
+  NEXTAUTH_URL: __PLACEHOLDER__
+  ENCRYPTION_KEY: __PLACEHOLDER__
+  ANTHROPIC_API_KEY: __PLACEHOLDER__
+  GEMINI_API_KEY: __PLACEHOLDER__
+  OPENAI_API_KEY: __PLACEHOLDER__
+  BRAVE_SEARCH_API_KEY: __PLACEHOLDER__
+  GITHUB_TOKEN: __PLACEHOLDER__
+  CRON_SECRET: __PLACEHOLDER__
+  NODE_ENV: production
+  UPLOAD_DIR: /app/uploads
+  APP_URL: __PLACEHOLDER__
+  NEXT_PUBLIC_APP_URL: __PLACEHOLDER__

--- a/infra/k8s/base/service.yaml
+++ b/infra/k8s/base/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: skillai-app
+  namespace: skillai
+  labels:
+    app.kubernetes.io/name: skillai
+    app.kubernetes.io/component: app
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: skillai
+    app.kubernetes.io/component: app
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000
+      protocol: TCP

--- a/infra/k8s/overlays/prod/kustomization.yaml
+++ b/infra/k8s/overlays/prod/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: skillai
+
+resources:
+  - ../../base
+
+# Placeholders substituted by infra/scripts/80-deploy.sh from terraform outputs.
+images:
+  - name: skillai
+    newName: __ECR_REPO__
+    newTag: __IMAGE_TAG__

--- a/infra/k8s/platform/cluster-issuer.yaml
+++ b/infra/k8s/platform/cluster-issuer.yaml
@@ -1,0 +1,39 @@
+# cert-manager ClusterIssuers for SkillAi. Apply AFTER cert-manager itself is
+# installed (via helm in 30-bootstrap-cluster.sh).
+#
+# Use letsencrypt-staging while iterating on DNS / ingress to avoid Let's Encrypt
+# production rate limits, then switch the ingress annotation to letsencrypt-prod.
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+  labels:
+    app.kubernetes.io/part-of: skillai
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: olaf@freundcloud.com
+    privateKeySecretRef:
+      name: letsencrypt-staging-key
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: nginx
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+  labels:
+    app.kubernetes.io/part-of: skillai
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: olaf@freundcloud.com
+    privateKeySecretRef:
+      name: letsencrypt-prod-key
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: nginx

--- a/infra/k8s/platform/efs-csi-storageclass.yaml
+++ b/infra/k8s/platform/efs-csi-storageclass.yaml
@@ -1,0 +1,17 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: efs-sc
+  labels:
+    app.kubernetes.io/part-of: skillai
+provisioner: efs.csi.aws.com
+parameters:
+  provisioningMode: efs-ap
+  # Substituted by infra/scripts/80-deploy.sh from terraform output.
+  fileSystemId: __EFS_ID__
+  directoryPerms: "0755"
+  uid: "1001"
+  gid: "1001"
+# Retain so a PVC delete never erases candidate CVs / logos.
+reclaimPolicy: Retain
+volumeBindingMode: Immediate

--- a/infra/k8s/platform/nginx-ingress.values.yaml
+++ b/infra/k8s/platform/nginx-ingress.values.yaml
@@ -1,0 +1,26 @@
+# Helm values for ingress-nginx (chart: ingress-nginx/ingress-nginx).
+# Installed by infra/scripts/30-bootstrap-cluster.sh:
+#   helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx \
+#     -n ingress-nginx --create-namespace \
+#     -f infra/k8s/platform/nginx-ingress.values.yaml
+controller:
+  replicaCount: 1
+  service:
+    type: LoadBalancer
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-type: "external"
+      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+      service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+  resources:
+    requests:
+      cpu: 100m
+      memory: 90Mi
+  # Match cluster-issuer expectations.
+  ingressClassResource:
+    name: nginx
+    enabled: true
+    default: false
+  watchIngressWithoutClass: false
+  # Internal tool — minimal admission webhook footprint is fine.
+  admissionWebhooks:
+    enabled: true


### PR DESCRIPTION
## Summary

Adds the kustomize tree under `infra/k8s/` for SkillAi's AWS EKS deployment, per the approved plan at `~/.claude/plans/purrfect-percolating-mango.md`. No application code or runtime is touched.

The Terraform agent (EKS / VPC / RDS / EFS / ECR) and the scripts agent (`50-render-secret.sh`, `80-deploy.sh`) run in parallel; this PR is the manifest-layer half of the trio. The scripts agent substitutes the placeholders below from Terraform outputs at deploy time.

## File tree

```
infra/k8s/
├── base/
│   ├── kustomization.yaml
│   ├── namespace.yaml                # Namespace skillai
│   ├── deployment.yaml               # 1 replica, Recreate, runAsUser 1001,
│   │                                 # /api/health probes, envFrom secretRef,
│   │                                 # EFS PVC + emptyDir for /tmp + .next/cache
│   ├── migrate-job.yaml              # one-shot `node /app/scripts/migrate.mjs`,
│   │                                 # backoffLimit 2, ttlSecondsAfterFinished 300
│   ├── service.yaml                  # ClusterIP 80 → 3000
│   ├── ingress.yaml                  # nginx, cert-manager letsencrypt-prod,
│   │                                 # 12m body cap, 600s read timeout
│   ├── pvc.yaml                      # RWX, storageClassName efs-sc, 5Gi
│   └── secret.template.yaml          # placeholder-only TEMPLATE (committed)
├── overlays/prod/
│   └── kustomization.yaml            # pins image to __ECR_REPO__:__IMAGE_TAG__
└── platform/
    ├── efs-csi-storageclass.yaml     # provisioningMode efs-ap, uid/gid 1001, Retain
    ├── nginx-ingress.values.yaml     # internet-facing NLB target-type ip
    └── cluster-issuer.yaml           # letsencrypt-staging + letsencrypt-prod
```

## Placeholders (substituted by `infra/scripts/80-deploy.sh`)

| Placeholder | Substituted with | File |
|---|---|---|
| `__ECR_REPO__` | ECR repository URL | `overlays/prod/kustomization.yaml` |
| `__IMAGE_TAG__` | Image tag (commit SHA) | `overlays/prod/kustomization.yaml` |
| `__INGRESS_HOST__` | Production hostname | `base/ingress.yaml` |
| `__EFS_ID__` | EFS file system id | `platform/efs-csi-storageclass.yaml` |
| `__PLACEHOLDER__` (× 12) | Secret values from `.envrc` | `base/secret.template.yaml` → renders to gitignored `base/secret.yaml` via `50-render-secret.sh` |

## Decisions worth flagging (not strictly in the plan)

1. **Strategy `Recreate` on the Deployment** (single-replica + single-AZ EFS mount): avoids two pods racing on the same access point during rolling updates. The plan said "1 replica" and the upload PVC is RWX — Recreate is the safe pairing.
2. **`fsGroup: 1001` on both Deployment and Job pods**, plus `uid: "1001"` + `gid: "1001"` + `directoryPerms: "0755"` on the EFS StorageClass: makes the EFS access point land owned by the `nextjs` user so the app's existing write paths (`/app/uploads`) work without a chown step (which the worktree is forbidden to run anyway).
3. **`reclaimPolicy: Retain`** on the StorageClass: a PVC delete on `skillai-uploads` won't erase CVs / logos — operator must explicitly clean up the EFS access point.
4. **Two ClusterIssuers** in `cluster-issuer.yaml` (staging + prod) rather than just prod: lets the operator switch the ingress annotation to `letsencrypt-staging` while iterating on DNS without burning LE production rate limits. The Ingress defaults to `letsencrypt-prod` as specified.
5. **`/infra/k8s/**/secret.yaml` gitignored** to defensively block accidental commit of rendered secrets — pairs with the `secret.template.yaml` header banner.

## Verification

- `kubectl kustomize infra/k8s/overlays/prod` → exit 0, **4558 bytes**, image transform applied to both `Deployment/skillai-app` and `Job/skillai-migrate`.
- Per-file syntactic check via `kubectl apply --dry-run=client` is not meaningfully runnable offline (kubectl requires API discovery against a live cluster to recognise GVKs). The kustomize build performs full YAML parsing across every file and is the strongest offline guarantee available; it succeeds.

## Test plan

- [ ] After Terraform agent + scripts agent land: `infra/scripts/80-deploy.sh` produces a fully-substituted overlay that kubectl can apply
- [ ] `kubectl apply` against the platform manifests (EFS StorageClass, ingress-nginx Helm release, ClusterIssuers) succeeds on a fresh EKS cluster
- [ ] `kubectl apply -k infra/k8s/overlays/prod` (with rendered `secret.yaml` present) produces a healthy Pod
- [ ] `/api/health` returns 200 within `initialDelaySeconds + periodSeconds * failureThreshold` (= 60 + 30×3 = 150s budget)
- [ ] `skillai-migrate` Job completes with exit 0 before the Deployment is applied (deploy script orchestrates this)
- [ ] Ingress provisions a Let's Encrypt cert via cert-manager and HTTPS resolves at `__INGRESS_HOST__`

Plan reference: `~/.claude/plans/purrfect-percolating-mango.md`