### PR TITLE
fix(infra): pin EKS addon versions to prevent silent auto-update (#249)

### DIFF
--- a/infra/terraform/eks.tf
+++ b/infra/terraform/eks.tf
@@ -61,23 +61,59 @@ module "eks" {
   cluster_enabled_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
 
   # ---------------------------------------------------------------------------
-  # Cluster add-ons — managed by EKS so AWS handles version compatibility.
-  # aws-ebs-csi-driver: required for any PersistentVolume backed by gp3.
-  # vpc-cni / kube-proxy / coredns: the standard three.
+  # Cluster add-ons — pinned to explicit versions for deterministic applies.
+  # Silent auto-updates on every `terraform apply` are prevented by using
+  # addon_version instead of most_recent = true (issue #249).
+  #
+  # To discover the current latest stable version for each addon, run:
+  #   aws eks describe-addon-versions \
+  #     --kubernetes-version 1.30 \
+  #     --addon-name vpc-cni \
+  #     --query 'addons[0].addonVersions[0].addonVersion' \
+  #     --output text
+  #
+  #   aws eks describe-addon-versions \
+  #     --kubernetes-version 1.30 \
+  #     --addon-name kube-proxy \
+  #     --query 'addons[0].addonVersions[0].addonVersion' \
+  #     --output text
+  #
+  #   aws eks describe-addon-versions \
+  #     --kubernetes-version 1.30 \
+  #     --addon-name coredns \
+  #     --query 'addons[0].addonVersions[0].addonVersion' \
+  #     --output text
+  #
+  #   aws eks describe-addon-versions \
+  #     --kubernetes-version 1.30 \
+  #     --addon-name aws-ebs-csi-driver \
+  #     --query 'addons[0].addonVersions[0].addonVersion' \
+  #     --output text
+  #
+  # Replace the TODO placeholders below with the output of those commands
+  # before applying. Bump versions intentionally when upgrading the cluster.
   # ---------------------------------------------------------------------------
   cluster_addons = {
     vpc-cni = {
-      most_recent = true
+      addon_version               = "# TODO: pin to current latest stable, see commands above"
+      resolve_conflicts_on_create = "OVERWRITE"
+      resolve_conflicts_on_update = "PRESERVE"
     }
     kube-proxy = {
-      most_recent = true
+      addon_version               = "# TODO: pin to current latest stable, see commands above"
+      resolve_conflicts_on_create = "OVERWRITE"
+      resolve_conflicts_on_update = "PRESERVE"
     }
     coredns = {
-      most_recent = true
+      addon_version               = "# TODO: pin to current latest stable, see commands above"
+      resolve_conflicts_on_create = "OVERWRITE"
+      resolve_conflicts_on_update = "PRESERVE"
     }
     aws-ebs-csi-driver = {
-      most_recent              = true
-      service_account_role_arn = module.ebs_csi_irsa_role.iam_role_arn
+      addon_version               = "# TODO: pin to current latest stable, see commands above"
+      resolve_conflicts_on_create = "OVERWRITE"
+      resolve_conflicts_on_update = "PRESERVE"
+      service_account_role_arn    = module.ebs_csi_irsa_role.iam_role_arn
     }
   }
 


### PR DESCRIPTION
Closes #249.

## Summary

- Replaces `most_recent = true` with explicit `addon_version` placeholders on all four EKS cluster addons (`vpc-cni`, `kube-proxy`, `coredns`, `aws-ebs-csi-driver`) to prevent silent version drift on every `terraform apply`.
- Adds `resolve_conflicts_on_create = "OVERWRITE"` and `resolve_conflicts_on_update = "PRESERVE"` to each addon block so operator config overrides survive intentional version bumps.
- Includes AWS CLI commands as a comment block directly above the addon blocks — fill in the `# TODO` placeholders with the output of those commands before merging.

> **Note:** AWS CLI `describe-addon-versions` was not run here (no creds in the agent environment). The `addon_version` values are marked `# TODO` and must be filled in by the operator before apply. See the comment block in `infra/terraform/eks.tf` lines 31–58 for the exact commands.

> **Rebase note:** PRs #244, #245, #246 also touch `infra/terraform/eks.tf` — expect a rebase before merge.

## Test plan

- [ ] Fill in `addon_version` values using the AWS CLI commands in the comment block
- [ ] Run `terraform fmt -recursive` (already clean — exits 0)
- [ ] Run `terraform init && terraform plan` in a dev environment and confirm no unexpected addon updates in the diff
- [ ] Confirm `terraform apply` is idempotent on subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)