### PR TITLE
fix(infra): enable EKS control plane logging + retention (#246)

### DIFF
--- a/docs/aws-deploy.md
+++ b/docs/aws-deploy.md
@@ -345,6 +345,17 @@ What "healthy" looks like:
 
 Also prints `kubectl get all,certificate,ingress -n skillai`. All pods should be `Running`, the certificate should show `Ready=True`.
 
+To confirm EKS control plane audit logging is active, check that log streams are appearing in the CloudWatch Logs group `/aws/eks/skillai/cluster`:
+
+```bash
+aws logs describe-log-streams \
+  --log-group-name /aws/eks/skillai/cluster \
+  --region eu-west-2 \
+  --query 'logStreams[*].logStreamName'
+```
+
+You should see streams for each enabled log type (e.g. `kube-apiserver-audit-*`, `authenticator-*`). Logs are retained for 90 days.
+
 ### Manual end-to-end checks
 
 After `90-verify.sh` passes, confirm these manually:

--- a/infra/terraform/eks.tf
+++ b/infra/terraform/eks.tf
@@ -1,4 +1,32 @@
 # ---------------------------------------------------------------------------
+# Common tags — reused by EKS-adjacent resources (e.g. CloudWatch log group).
+# The provider default_tags block covers all aws_ resources automatically;
+# this locals map is used explicitly where a resource-level tags argument is
+# required (e.g. aws_cloudwatch_log_group).
+# ---------------------------------------------------------------------------
+
+locals {
+  common_tags = {
+    Project     = var.project
+    ManagedBy   = "terraform"
+    Environment = "production"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# CloudWatch log group for EKS control plane logs.
+# Created BEFORE the cluster so the retention policy is in place from day 1.
+# Without this resource EKS auto-creates the group with infinite retention,
+# which accumulates unbounded CloudWatch Logs storage costs.
+# ---------------------------------------------------------------------------
+
+resource "aws_cloudwatch_log_group" "eks" {
+  name              = "/aws/eks/${var.project}/cluster"
+  retention_in_days = 90
+  tags              = local.common_tags
+}
+
+# ---------------------------------------------------------------------------
 # EKS Cluster — using the community EKS module (terraform-aws-modules/eks)
 # Module version pinned to ~> 20.0 for stability; 20.x is the LTS-equivalent
 # line for aws provider v5 compatibility.
@@ -23,6 +51,14 @@ module "eks" {
   # OIDC issuer — required for IRSA (IAM Roles for Service Accounts).
   # The EKS module creates the OIDC provider automatically when this is true.
   enable_irsa = true
+
+  # ---------------------------------------------------------------------------
+  # Control plane logging — all five log types enabled for security/audit
+  # visibility. Logs land in the CloudWatch log group provisioned above.
+  # EKS does not start writing until the group exists, so depends_on ensures
+  # the group (and its retention policy) are in place before cluster creation.
+  # ---------------------------------------------------------------------------
+  cluster_enabled_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
 
   # ---------------------------------------------------------------------------
   # Cluster add-ons — managed by EKS so AWS handles version compatibility.
@@ -75,6 +111,8 @@ module "eks" {
   tags = {
     Name = var.project
   }
+
+  depends_on = [aws_cloudwatch_log_group.eks]
 }
 
 # ---------------------------------------------------------------------------

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -65,3 +65,8 @@ output "kubeconfig_command" {
   description = "Shell command to update the local kubeconfig for this cluster."
   value       = "aws eks update-kubeconfig --region ${var.aws_region} --name ${module.eks.cluster_name}"
 }
+
+output "eks_cloudwatch_log_group_arn" {
+  description = "ARN of the CloudWatch log group receiving EKS control plane logs. Use this to grant read access to observability tooling or to configure metric filters."
+  value       = aws_cloudwatch_log_group.eks.arn
+}


### PR DESCRIPTION
Closes #246.

## Summary

- Adds `cluster_enabled_log_types` to the EKS module (all five: api, audit, authenticator, controllerManager, scheduler)
- Provisions `aws_cloudwatch_log_group` `/aws/eks/skillai/cluster` with 90-day retention **before** cluster creation via `depends_on`, preventing EKS from auto-creating the group with infinite retention
- Outputs the log group ARN as `eks_cloudwatch_log_group_arn`
- Documents audit log verification in `docs/aws-deploy.md` section 5

Note: parallel PRs #244/#245/#249 also touch `eks.tf` — expect a rebase before merge.