### PR TITLE
fix(infra): lock EKS API endpoint to operator CIDRs (#244)

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -30,6 +30,11 @@ export AWS_REGION="eu-west-2"         # London — matches EU/UK data residency 
 # export TF_VAR_db_allocated_storage="20"          # default 20 GB gp3
 # export TF_VAR_project_name="skillai"             # default; must match ECR repo name
 
+# REQUIRED — lock the EKS public API endpoint to your operator IP(s).
+# Get your current IP:  curl -s ifconfig.me
+# Then set the value below (JSON list of CIDR strings).
+# export TF_VAR_allowed_operator_cidrs='["X.X.X.X/32"]'  # YOUR operator IP, lock down the EKS API endpoint
+
 # ==========================================================================
 # App secrets — COPY VERBATIM FROM .env.local
 #

--- a/docs/aws-deploy.md
+++ b/docs/aws-deploy.md
@@ -65,6 +65,7 @@ Fill in `.envrc`:
 - `ENCRYPTION_KEY` — copy **verbatim** from your local `.env.local`
 - `AUTH_SECRET` — copy **verbatim** from your local `.env.local`
 - `ANTHROPIC_API_KEY` — your Anthropic API key
+- `TF_VAR_allowed_operator_cidrs` — **required**; restricts the EKS public API endpoint to your operator IP(s). Get your IP with `curl -s ifconfig.me`, then set: `export TF_VAR_allowed_operator_cidrs='["X.X.X.X/32"]'`. Terraform will refuse to apply if this variable is empty.
 - Leave `NEXTAUTH_URL`, `APP_URL`, `NEXT_PUBLIC_APP_URL` blank for now — set them after step 2.3
 
 Activate:

--- a/infra/terraform/eks.tf
+++ b/infra/terraform/eks.tf
@@ -17,7 +17,8 @@ module "eks" {
   # Allow operator's laptop to reach the API server.
   # For a hardened deployment, set to false and access via AWS VPN or
   # a bastion host in the public subnet.
-  cluster_endpoint_public_access = true
+  cluster_endpoint_public_access       = true
+  cluster_endpoint_public_access_cidrs = var.allowed_operator_cidrs
 
   # OIDC issuer — required for IRSA (IAM Roles for Service Accounts).
   # The EKS module creates the OIDC provider automatically when this is true.

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -76,3 +76,14 @@ variable "force_destroy" {
   type        = bool
   default     = false
 }
+
+variable "allowed_operator_cidrs" {
+  description = "CIDR blocks allowed to reach the EKS public API endpoint. Set in .envrc via TF_VAR_allowed_operator_cidrs='[\"X.X.X.X/32\"]'."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = length(var.allowed_operator_cidrs) > 0
+    error_message = "allowed_operator_cidrs must not be empty. Set TF_VAR_allowed_operator_cidrs='[\"X.X.X.X/32\"]' in your .envrc (get your IP: curl -s ifconfig.me)."
+  }
+}


### PR DESCRIPTION
Closes #244.

## Summary

- Adds `allowed_operator_cidrs` variable to `variables.tf` with a `validation` block that fails if the list is empty — Terraform refuses to plan/apply when the EKS API endpoint would be open to `0.0.0.0/0`.
- Sets `cluster_endpoint_public_access_cidrs = var.allowed_operator_cidrs` in the EKS module block in `eks.tf`.
- Updates `.envrc.example` with a commented-out `TF_VAR_allowed_operator_cidrs` line and instructions to get the operator IP via `curl -s ifconfig.me`.
- Updates `docs/aws-deploy.md` preflight section to call out this required variable.

`terraform fmt` and `terraform validate` both pass.

> Note: parallel PRs #245/#246/#249 also touch `eks.tf` — expect a rebase at merge time.