### PR TITLE
fix(infra): enable EKS envelope encryption for K8s secrets via KMS (#245)

### DIFF
--- a/docs/aws-deploy.md
+++ b/docs/aws-deploy.md
@@ -154,6 +154,21 @@ infra/scripts/10-terraform-apply.sh
 ```
 Re-run the script — Terraform is idempotent. Resources already created are detected and skipped; the apply continues from where it left off.
 
+> **Envelope encryption note**: The Terraform config enables KMS envelope encryption for
+> Kubernetes Secrets in etcd (`cluster_encryption_config`). Because this cluster has not
+> been provisioned yet, the key is applied at creation time — no migration is needed.
+>
+> If you ever enable this on an **existing** cluster (one that was provisioned without the
+> setting), every pre-existing Secret must be re-saved so the API server re-encrypts its
+> data key under the new KMS CMK:
+>
+> ```bash
+> kubectl get secrets -A -o yaml | kubectl replace -f -
+> ```
+>
+> Run this immediately after `terraform apply` on an existing cluster before relying on
+> envelope encryption to protect any secrets.
+
 ### 2.3 Configure kubeconfig
 
 ```bash

--- a/infra/terraform/eks.tf
+++ b/infra/terraform/eks.tf
@@ -48,6 +48,16 @@ module "eks" {
   cluster_endpoint_public_access       = true
   cluster_endpoint_public_access_cidrs = var.allowed_operator_cidrs
 
+  # ---------------------------------------------------------------------------
+  # Envelope encryption — encrypt K8s Secrets in etcd with a customer-managed
+  # KMS key (defined in kms.tf).  The module accepts a map; the EKS API only
+  # supports a single encryption config entry today.
+  # ---------------------------------------------------------------------------
+  cluster_encryption_config = {
+    resources        = ["secrets"]
+    provider_key_arn = aws_kms_key.eks_secrets.arn
+  }
+
   # OIDC issuer — required for IRSA (IAM Roles for Service Accounts).
   # The EKS module creates the OIDC provider automatically when this is true.
   enable_irsa = true

--- a/infra/terraform/kms.tf
+++ b/infra/terraform/kms.tf
@@ -1,0 +1,27 @@
+# ---------------------------------------------------------------------------
+# KMS key for EKS envelope encryption of Kubernetes Secrets at rest in etcd.
+#
+# Envelope encryption means every K8s Secret's data encryption key (DEK) is
+# itself encrypted by this CMK before being written to etcd. Compromise of
+# etcd without access to this KMS key yields unreadable secret values.
+#
+# Key rotation is enabled (annual automatic rotation via AWS KMS).
+# Deletion window is set to 30 days — the longest available window — to
+# minimise the risk of accidental key destruction while still allowing
+# eventual deletion if the cluster is torn down.
+# ---------------------------------------------------------------------------
+
+resource "aws_kms_key" "eks_secrets" {
+  description             = "EKS envelope encryption for K8s Secrets — ${var.project}"
+  deletion_window_in_days = 30
+  enable_key_rotation     = true
+
+  tags = {
+    Name = "${var.project}-eks-secrets"
+  }
+}
+
+resource "aws_kms_alias" "eks_secrets" {
+  name          = "alias/${var.project}-eks-secrets"
+  target_key_id = aws_kms_key.eks_secrets.key_id
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -70,3 +70,8 @@ output "eks_cloudwatch_log_group_arn" {
   description = "ARN of the CloudWatch log group receiving EKS control plane logs. Use this to grant read access to observability tooling or to configure metric filters."
   value       = aws_cloudwatch_log_group.eks.arn
 }
+
+output "eks_secrets_kms_key_arn" {
+  description = "ARN of the KMS key used for EKS envelope encryption of Kubernetes Secrets. Required if you need to grant additional IAM principals permission to decrypt secrets."
+  value       = aws_kms_key.eks_secrets.arn
+}


### PR DESCRIPTION
Closes #245.

## Summary

- New `infra/terraform/kms.tf`: customer-managed KMS key + alias for EKS etcd envelope encryption (30-day deletion window, annual rotation).
- `infra/terraform/eks.tf`: wire `cluster_encryption_config = { resources = ["secrets"], provider_key_arn }` into the `terraform-aws-modules/eks` module block.
- `infra/terraform/outputs.tf`: export `eks_secrets_kms_key_arn`.
- `docs/aws-deploy.md`: document the one-shot nature of this config (new cluster) and the `kubectl get secrets -A -o yaml | kubectl replace -f -` re-save requirement for any future existing-cluster enablement.

`terraform fmt -recursive` clean; `terraform validate` passes.

Note: parallel PRs #244/#246/#249 also touch `eks.tf` — expect rebase before merge.