### PR TITLE
fix(infra): destroy.sh tears down cluster-side resources before terraform destroy (#252)

### DIFF
--- a/docs/aws-deploy.md
+++ b/docs/aws-deploy.md
@@ -437,17 +437,41 @@ Both the RDS instance and the EFS filesystem are protected against accidental de
 infra/scripts/destroy.sh
 ```
 
-The script prompts twice for confirmation, then proceeds through a two-phase destroy:
+The script prompts twice for confirmation, then runs a **two-phase destroy** that combines cluster-side teardown with the snapshot-preserving Terraform destroy:
+
+### Phase 1 — cluster-side teardown
+
+Before Terraform touches the VPC, the script uses `kubectl` and `helm` to release resources that live inside the cluster but are billed outside it:
+
+1. Deletes the `skillai` namespace (releases EBS PVCs — volumes are freed immediately)
+2. Uninstalls `ingress-nginx` (causes AWS to delete the NLB and release EIPs)
+3. Uninstalls `cert-manager`
+4. Waits up to 90 s for the NLB ENIs to drain — Terraform will fail to delete subnets while ENIs are attached
+
+If the current `kubectl` context does not match the cluster name read from Terraform state, Phase 1 is skipped gracefully and a warning is printed.
+
+### Phase 2 — Terraform destroy (with final snapshot)
+
+After cluster-side resources are released, the script then:
 
 1. Empties the ECR repository (Terraform cannot delete a non-empty ECR repo).
 2. Writes a temporary `override_prevent_destroy.tf.json` file to remove the `prevent_destroy` lifecycle constraints (this file is gitignored and never committed).
 3. Runs a targeted `terraform apply -target=aws_db_instance.main` with `skip_final_snapshot=false` to disable `deletion_protection` while keeping the snapshot behaviour intact.
-4. Runs `terraform destroy`. Before the RDS instance is deleted, AWS automatically creates a **final snapshot** named `skillai-db-final-<YYYYMMDD-hhmm>`. This snapshot is recoverable from the AWS RDS console under Manual Snapshots.
+4. Runs `terraform destroy -auto-approve`. Before the RDS instance is deleted, AWS automatically creates a **final snapshot** named `skillai-db-final-<YYYYMMDD-hhmm>`. This snapshot is recoverable from the AWS RDS console under Manual Snapshots. Terraform also tears down the remaining infrastructure: EKS control plane, EFS, ECR, VPC, subnets, NAT Gateway, and security groups.
 5. Removes the temporary override file.
 
 The EFS filesystem is **not** automatically snapshotted. If you need to preserve uploaded CVs, run `infra/scripts/70-uploads-sync.sh` to pull files to local disk before starting the destroy.
 
 After destroy completes, a reminder is printed with the snapshot name. Delete it in the RDS console once you have confirmed data is no longer needed (it incurs minimal storage charges while retained).
+
+### Post-destroy verification
+
+After `terraform destroy` completes, the script queries AWS for any orphaned resources that escaped Terraform tracking:
+
+- EBS volumes tagged `kubernetes.io/cluster/<name>=owned`
+- Network interfaces whose description contains the cluster name
+
+If any are listed, they must be deleted manually in the AWS Console or via the CLI to stop billing.
 
 ### Force path — skip snapshot (data loss, dev/throwaway only)
 

--- a/infra/scripts/destroy.sh
+++ b/infra/scripts/destroy.sh
@@ -134,6 +134,47 @@ fi
 log "Proceeding with destroy ..."
 
 # ---------------------------------------------------------------------------
+# Resolve cluster name from Terraform state (needed for Phase 1 + post-verify)
+# ---------------------------------------------------------------------------
+CLUSTER_NAME=""
+if [[ -d "${TF_DIR}" ]]; then
+  CLUSTER_NAME="$(cd "${TF_DIR}" && terraform output -raw cluster_name 2>/dev/null || echo "")"
+fi
+if [[ -z "${CLUSTER_NAME}" ]]; then
+  CLUSTER_NAME="${PROJECT_NAME}"
+  log "WARN: could not read cluster_name from Terraform state; defaulting to '${CLUSTER_NAME}'"
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 1: cluster-side teardown — releases NLB + EBS PVCs that Terraform
+#          doesn't track. Must happen BEFORE terraform destroy, otherwise
+#          Terraform fails to delete subnets/VPC because the NLB ENIs are
+#          still live.
+# ---------------------------------------------------------------------------
+echo "==> Phase 1: cluster-side teardown"
+
+# Skip gracefully if kubectl context is not the target cluster
+if kubectl config current-context 2>/dev/null | grep -q "${CLUSTER_NAME}"; then
+  kubectl delete namespace skillai --wait --timeout=180s --ignore-not-found || true
+  helm uninstall ingress-nginx -n ingress-nginx --wait --timeout=180s 2>/dev/null || true
+  helm uninstall cert-manager -n cert-manager --wait --timeout=180s 2>/dev/null || true
+
+  # Wait for NLB ENIs to drain (otherwise Terraform fails to delete subnets)
+  echo "    waiting up to 90s for NLB ENIs to drain..."
+  for _ in $(seq 1 18); do
+    enis=$(aws ec2 describe-network-interfaces \
+      --filters "Name=description,Values=*ELB*${CLUSTER_NAME}*" \
+      --region "${REGION}" \
+      --query 'length(NetworkInterfaces)' --output text 2>/dev/null || echo 0)
+    [[ "${enis}" -eq 0 ]] && break
+    sleep 5
+  done
+  log "cluster-side teardown complete."
+else
+  log "kubectl context does not match ${CLUSTER_NAME}; skipping cluster-side teardown"
+fi
+
+# ---------------------------------------------------------------------------
 # Step 1 — Empty the ECR repository
 # Terraform cannot delete an ECR repo with images in it.
 # ---------------------------------------------------------------------------
@@ -236,8 +277,9 @@ terraform apply \
   }
 
 # ---------------------------------------------------------------------------
-# Step 4 — terraform destroy
+# Step 4 — Phase 2: terraform destroy
 # ---------------------------------------------------------------------------
+echo "==> Phase 2: terraform destroy"
 log "Running terraform destroy ..."
 terraform destroy ${FORCE_VARS} -auto-approve
 
@@ -247,6 +289,29 @@ terraform destroy ${FORCE_VARS} -auto-approve
 log "Removing temporary lifecycle override file ..."
 rm -f "${OVERRIDE_FILE}"
 
+# ---------------------------------------------------------------------------
+# Post-destroy verification — list any orphaned resources that escaped
+# Terraform and may still be accruing charges.
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Post-destroy verification"
+echo "    Checking for orphaned EBS volumes tagged to cluster '${CLUSTER_NAME}'..."
+aws ec2 describe-volumes \
+  --filters "Name=tag:kubernetes.io/cluster/${CLUSTER_NAME},Values=owned" \
+  --query 'Volumes[*].[VolumeId,State]' \
+  --output table \
+  --region "${REGION}" 2>/dev/null || true
+
+echo ""
+echo "    Checking for orphaned network interfaces matching '${CLUSTER_NAME}'..."
+aws ec2 describe-network-interfaces \
+  --filters "Name=description,Values=*${CLUSTER_NAME}*" \
+  --query 'NetworkInterfaces[*].[NetworkInterfaceId,Status]' \
+  --output table \
+  --region "${REGION}" 2>/dev/null || true
+
+echo ""
+log "If any resources are listed above, they are orphans — delete manually to stop billing."
 echo ""
 log "Destroy complete. All AWS resources have been deleted."
 log "Billing for EKS, RDS, NLB, and NAT has stopped."


### PR DESCRIPTION
Closes #252.

## Summary

- Adds **Phase 1: cluster-side teardown** after the typed confirmation, before `terraform destroy`: deletes the `skillai` namespace (frees EBS PVCs), uninstalls `ingress-nginx` (releases the NLB + EIPs), uninstalls `cert-manager`, then polls for up to 90 s until NLB ENIs drain — preventing Terraform from failing on subnet deletion
- Skips Phase 1 gracefully if the current `kubectl` context does not match the cluster name read from Terraform state
- Adds a **post-destroy verification** block that queries AWS for orphaned EBS volumes and network interfaces tagged/named after the cluster, prompting manual cleanup if any remain
- Updates `docs/aws-deploy.md` §7 to document the two-phase flow

Note: parallel PR #247 also modifies `destroy.sh` for RDS deletion-protection — expect a minor rebase when one merges first.

## Test plan

- [ ] `bash -n infra/scripts/destroy.sh` passes (verified)
- [ ] `shellcheck infra/scripts/destroy.sh` clean (verified)
- [ ] Phase 1 skips cleanly when kubectl context does not match cluster name
- [ ] Full tear-down on a live cluster leaves no orphaned ENIs, EIPs, or EBS volumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)