### PR TITLE
fix(infra): RDS deletion protection + final snapshot + EFS prevent_destroy (#247)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,8 @@ infra/terraform/.terraform/
 infra/terraform/terraform.tfstate
 infra/terraform/terraform.tfstate.*
 infra/terraform/tfplan
+# Temporary lifecycle override written by destroy.sh — never commit
+infra/terraform/override_prevent_destroy.tf.json
 
 # Rendered k8s secrets — produced locally by 50-render-secret.sh; never committed
 # Only the committed template (secret.template.yaml) is allowed in git.

--- a/docs/aws-deploy.md
+++ b/docs/aws-deploy.md
@@ -338,15 +338,51 @@ kubectl logs deployment/cert-manager -n cert-manager --tail=50
 
 ## 7. Tear-Down
 
+### Deletion safety (issue #247)
+
+Both the RDS instance and the EFS filesystem are protected against accidental deletion:
+
+- `deletion_protection = true` on the RDS instance prevents AWS from deleting it via the console or API without first disabling this flag.
+- `lifecycle { prevent_destroy = true }` on both `aws_db_instance.main` and `aws_efs_file_system.uploads` prevents a plain `terraform destroy` from removing them without an explicit override.
+
+### Default path — final snapshot taken
+
 ```bash
 infra/scripts/destroy.sh
 ```
 
-The script prompts twice for confirmation before proceeding. It:
-1. Empties the ECR repository (Terraform cannot delete a non-empty ECR)
-2. Runs `terraform destroy -auto-approve`
+The script prompts twice for confirmation, then proceeds through a two-phase destroy:
 
-**Take a backup first** if you want to preserve data:
+1. Empties the ECR repository (Terraform cannot delete a non-empty ECR repo).
+2. Writes a temporary `override_prevent_destroy.tf.json` file to remove the `prevent_destroy` lifecycle constraints (this file is gitignored and never committed).
+3. Runs a targeted `terraform apply -target=aws_db_instance.main` with `skip_final_snapshot=false` to disable `deletion_protection` while keeping the snapshot behaviour intact.
+4. Runs `terraform destroy`. Before the RDS instance is deleted, AWS automatically creates a **final snapshot** named `skillai-db-final-<YYYYMMDD-hhmm>`. This snapshot is recoverable from the AWS RDS console under Manual Snapshots.
+5. Removes the temporary override file.
+
+The EFS filesystem is **not** automatically snapshotted. If you need to preserve uploaded CVs, run `infra/scripts/70-uploads-sync.sh` to pull files to local disk before starting the destroy.
+
+After destroy completes, a reminder is printed with the snapshot name. Delete it in the RDS console once you have confirmed data is no longer needed (it incurs minimal storage charges while retained).
+
+### Force path — skip snapshot (data loss, dev/throwaway only)
+
+Use this only for non-production environments where data loss is acceptable:
+
+```bash
+FORCE_DESTROY=1 infra/scripts/destroy.sh
+# or
+infra/scripts/destroy.sh --force
+```
+
+When `FORCE_DESTROY=1` is set:
+- `skip_final_snapshot` is set to `true` via `-var force_destroy=true`.
+- No RDS snapshot is created; all database data is permanently deleted.
+- `deletion_protection` is disabled before the destroy.
+- The `prevent_destroy` override is still applied so the destroy can proceed.
+
+### Manual backup before destroy (recommended)
+
+Regardless of which path you take, a manual pg_dump is the safest backup:
+
 ```bash
 PGPASSWORD=<rds-password> pg_dump \
   -h <rds-endpoint> -U skillai -d skillai \

--- a/infra/scripts/destroy.sh
+++ b/infra/scripts/destroy.sh
@@ -2,22 +2,56 @@
 # infra/scripts/destroy.sh
 # Tear down ALL AWS resources created by this project.
 #
+# IMPORTANT — DELETION SAFETY (issue #247)
+# =========================================
+# Both the RDS instance and the EFS filesystem now have:
+#   - deletion_protection = true   (RDS — blocks AWS-level deletion)
+#   - lifecycle { prevent_destroy = true }  (Terraform — blocks plan/apply destroy)
+#
+# DEFAULT BEHAVIOUR (safe path)
+# --------------------------------
+# terraform destroy will be blocked by prevent_destroy.  This script performs a
+# two-phase destroy:
+#   Phase A: targeted apply that sets skip_final_snapshot=false, which causes RDS
+#            to take a FINAL SNAPSHOT before the instance is deleted.  The snapshot
+#            name includes a timestamp and appears in the AWS RDS console under
+#            "Manual snapshots".  The EFS data is NOT automatically backed up —
+#            run 70-uploads-sync.sh to pull files before proceeding if needed.
+#   Phase B: terraform destroy after the prevent_destroy constraints have been
+#            removed by temporarily overriding the Terraform source.
+#
+# FORCE PATH (data loss — use only for dev/throwaway environments)
+# ----------------------------------------------------------------
+#   FORCE_DESTROY=1 ./destroy.sh
+# or
+#   ./destroy.sh --force
+#
+# When FORCE_DESTROY=1:
+#   - skip_final_snapshot is set to true via -var force_destroy=true
+#   - The script still prompts for confirmation but skips the final snapshot
+#   - lifecycle.prevent_destroy is removed via a temporary override file
+#   - deletion_protection is disabled via a targeted apply before destroy
+#
+# NOTE ON lifecycle.prevent_destroy
+# ----------------------------------
+# Terraform does not allow lifecycle.prevent_destroy to be driven by a variable.
+# This script works around that by writing a temporary override file
+# (override_prevent_destroy.tf.json) that replaces the lifecycle block with
+# prevent_destroy=false, runs the destroy, then removes the override.
+# The override file is gitignored — it must never be committed.
+#
 # WARNING: This is irreversible. It will delete:
 #   - EKS cluster (all workloads, PVCs, etc.)
-#   - RDS instance (ALL candidate data — take a pg_dump first!)
-#   - EFS filesystem (ALL uploaded CVs)
+#   - RDS PostgreSQL instance (ALL candidate data — snapshot taken unless --force)
+#   - EFS filesystem (ALL uploaded CVs — not automatically snapshotted)
 #   - ECR repository (ALL images)
 #   - VPC, subnets, NAT, NLB
-#
-# The script:
-#   1. Prompts for the project name to confirm intent (twice).
-#   2. Empties the ECR repository (Terraform cannot delete a non-empty ECR).
-#   3. Runs terraform destroy.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 TF_DIR="${REPO_ROOT}/infra/terraform"
+OVERRIDE_FILE="${TF_DIR}/override_prevent_destroy.tf.json"
 
 # shellcheck source=/dev/null
 eval "$(direnv export bash 2>/dev/null)" || source "${REPO_ROOT}/.envrc"
@@ -27,11 +61,22 @@ log() { echo "[destroy] $(date -u +%H:%M:%SZ) $*"; }
 PROJECT_NAME="skillai"
 REGION="${AWS_REGION:-eu-west-2}"
 
+# ---------------------------------------------------------------------------
+# Parse flags
+# ---------------------------------------------------------------------------
+FORCE_DESTROY="${FORCE_DESTROY:-0}"
+for arg in "$@"; do
+  case "${arg}" in
+    --force) FORCE_DESTROY=1 ;;
+    *) ;;
+  esac
+done
+
 command -v terraform &>/dev/null || { echo "[destroy] ERROR: terraform not found."; exit 1; }
 command -v aws       &>/dev/null || { echo "[destroy] ERROR: aws-cli not found."; exit 1; }
 
 # ---------------------------------------------------------------------------
-# Cost warning
+# Cost warning + snapshot notice
 # ---------------------------------------------------------------------------
 echo ""
 echo "[destroy] ============================================================"
@@ -48,8 +93,21 @@ echo "[destroy]    - EFS filesystem (ALL uploaded CVs!)"
 echo "[destroy]    - ECR repository and all container images"
 echo "[destroy]    - VPC, NAT Gateway, NLB (billing stops immediately)"
 echo "[destroy]"
-echo "[destroy]  TAKE A BACKUP FIRST if you want to preserve data:"
-echo "[destroy]    pg_dump -U skillai -h <rds-endpoint> skillai > backup.dump"
+
+if [[ "${FORCE_DESTROY}" == "1" ]]; then
+  echo "[destroy]  !! FORCE MODE ACTIVE — final snapshot will be SKIPPED !!"
+  echo "[destroy]  !! All data will be permanently lost. !!"
+else
+  echo "[destroy]  SNAPSHOT: A final RDS snapshot will be taken before deletion."
+  echo "[destroy]    The snapshot will appear in the AWS RDS console under"
+  echo "[destroy]    Manual Snapshots as:  ${PROJECT_NAME}-db-final-<timestamp>"
+  echo "[destroy]    Keep or delete it manually after this script completes."
+  echo "[destroy]"
+  echo "[destroy]  EFS data is NOT automatically snapshotted. If you need to"
+  echo "[destroy]  preserve uploaded CVs, run 70-uploads-sync.sh first."
+fi
+
+echo "[destroy]"
 echo "[destroy] ============================================================"
 echo ""
 
@@ -110,15 +168,95 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Step 2 — terraform destroy
+# Step 2 — Write a temporary override file to remove lifecycle.prevent_destroy
+#
+# lifecycle.prevent_destroy cannot be controlled by a variable in HCL — the
+# only way to override it is to replace the lifecycle block in a .tf.json
+# override file.  This file is written here, used during destroy, then removed.
+# It is listed in .gitignore and MUST NOT be committed.
+# ---------------------------------------------------------------------------
+cd "${TF_DIR}"
+log "Writing temporary lifecycle override to disable prevent_destroy ..."
+cat > "${OVERRIDE_FILE}" <<'JSON'
+{
+  "resource": {
+    "aws_db_instance": {
+      "main": {
+        "lifecycle": {
+          "prevent_destroy": false
+        }
+      }
+    },
+    "aws_efs_file_system": {
+      "uploads": {
+        "lifecycle": {
+          "prevent_destroy": false
+        }
+      }
+    }
+  }
+}
+JSON
+
+# ---------------------------------------------------------------------------
+# Step 3 — Disable RDS deletion_protection and, if force mode, skip snapshot
+# ---------------------------------------------------------------------------
+if [[ "${FORCE_DESTROY}" == "1" ]]; then
+  FORCE_VARS="-var force_destroy=true"
+  log "Force mode: disabling deletion_protection and skipping final snapshot ..."
+else
+  FORCE_VARS="-var force_destroy=false"
+  log "Disabling RDS deletion_protection (final snapshot will be taken on destroy) ..."
+fi
+
+# Targeted apply — only modifies the RDS instance attribute, does not touch
+# other resources.  Runs non-interactively.
+terraform apply \
+  -target=aws_db_instance.main \
+  ${FORCE_VARS} \
+  -var "deletion_protection=false" \
+  -auto-approve 2>/dev/null || {
+    # Fallback: use AWS CLI to flip deletion protection directly if targeted
+    # apply fails (e.g. state drift).
+    log "WARN: targeted apply failed — attempting AWS CLI fallback to disable deletion_protection."
+    RDS_ID="$(terraform output -raw rds_endpoint 2>/dev/null | cut -d'.' -f1 || echo '')"
+    if [[ -n "${RDS_ID}" ]]; then
+      aws rds modify-db-instance \
+        --db-instance-identifier "${RDS_ID}" \
+        --no-deletion-protection \
+        --apply-immediately \
+        --region "${REGION}" > /dev/null
+      log "deletion_protection disabled via AWS CLI."
+    else
+      log "ERROR: Could not determine RDS identifier. Disable deletion_protection manually"
+      log "       in the AWS console before re-running this script."
+      rm -f "${OVERRIDE_FILE}"
+      exit 1
+    fi
+  }
+
+# ---------------------------------------------------------------------------
+# Step 4 — terraform destroy
 # ---------------------------------------------------------------------------
 log "Running terraform destroy ..."
-cd "${TF_DIR}"
-terraform destroy -auto-approve
+terraform destroy ${FORCE_VARS} -auto-approve
+
+# ---------------------------------------------------------------------------
+# Step 5 — Clean up the override file
+# ---------------------------------------------------------------------------
+log "Removing temporary lifecycle override file ..."
+rm -f "${OVERRIDE_FILE}"
 
 echo ""
 log "Destroy complete. All AWS resources have been deleted."
 log "Billing for EKS, RDS, NLB, and NAT has stopped."
+log ""
+if [[ "${FORCE_DESTROY}" != "1" ]]; then
+  log "REMINDER: The RDS final snapshot '${PROJECT_NAME}-db-final-<timestamp>' still"
+  log "          exists in your AWS account and will incur minimal storage charges."
+  log "          Delete it in the RDS console once you have confirmed data is no"
+  log "          longer needed."
+fi
 log ""
 log "NOTE: Your local .envrc and terraform state files still exist."
 log "      Review and remove them manually if no longer needed."

--- a/infra/terraform/efs.tf
+++ b/infra/terraform/efs.tf
@@ -51,6 +51,10 @@ resource "aws_efs_file_system" "uploads" {
   tags = {
     Name = "${var.project}-uploads"
   }
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 # Mount targets — one per private subnet so pods on any node can reach EFS.

--- a/infra/terraform/rds.tf
+++ b/infra/terraform/rds.tf
@@ -114,13 +114,26 @@ resource "aws_db_instance" "main" {
   backup_window           = "03:00-04:00"
   maintenance_window      = "Mon:04:00-Mon:05:00"
 
-  # skip_final_snapshot = true is appropriate for dev/staging. For production
-  # deployments change this to false and provide a final_snapshot_identifier.
-  skip_final_snapshot = true
+  # skip_final_snapshot: set false normally so a named snapshot is created before
+  # the instance is deleted.  Set var.force_destroy=true ONLY via destroy.sh
+  # --force / FORCE_DESTROY=1 to bypass the snapshot when intentionally wiping
+  # the environment (e.g. dev tear-down where data loss is acceptable).
+  skip_final_snapshot = var.force_destroy
 
-  deletion_protection = false # set to true for production
+  # Final snapshot identifier includes a timestamp so each destroy produces a
+  # uniquely named, recoverable snapshot in the AWS console.
+  final_snapshot_identifier = "${var.project}-db-final-${formatdate("YYYYMMDDhhmm", timestamp())}"
+
+  # Prevent accidental deletion via the AWS console or an unguarded
+  # terraform destroy.  The destroy.sh script documents the two-phase
+  # procedure required to remove this protection intentionally.
+  deletion_protection = true
 
   tags = {
     Name = "${var.project}-db"
+  }
+
+  lifecycle {
+    prevent_destroy = true
   }
 }

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -63,3 +63,16 @@ variable "vpc_cidr" {
   type        = string
   default     = "10.10.0.0/16"
 }
+
+variable "force_destroy" {
+  description = <<-EOT
+    Set to true ONLY via the destroy.sh --force path or FORCE_DESTROY=1 env var.
+    When true, skip_final_snapshot is set to true so that terraform destroy can
+    proceed without waiting for a final RDS snapshot.  NOTE: lifecycle.prevent_destroy
+    cannot be driven by a variable at the HCL level — the two-phase destroy procedure
+    in infra/scripts/destroy.sh handles removal of the prevent_destroy constraint
+    via targeted overrides.  Never set this to true in normal operations.
+  EOT
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Closes #247.

## Summary

- **rds.tf**: `deletion_protection=true`, `skip_final_snapshot` driven by `var.force_destroy` (default `false`), `final_snapshot_identifier` with `formatdate` timestamp, `lifecycle { prevent_destroy = true }`.
- **efs.tf**: `lifecycle { prevent_destroy = true }` on `aws_efs_file_system.uploads`.
- **variables.tf**: new `var.force_destroy` (default `false`) that controls `skip_final_snapshot`; documents the two-phase destroy workaround for `lifecycle.prevent_destroy`.
- **destroy.sh**: rewritten with two-phase destroy — writes a temporary `override_prevent_destroy.tf.json`, runs a targeted apply to clear `deletion_protection`, then runs full destroy; adds `--force` / `FORCE_DESTROY=1` flag to skip the final snapshot (dev/throwaway only); prominent snapshot notice and post-destroy reminder.
- **docs/aws-deploy.md**: tear-down section updated with default path (snapshot taken) and force path (data loss) procedures.
- **.gitignore**: exclude `override_prevent_destroy.tf.json`.

## Test plan

- [ ] `terraform fmt -recursive -check` exits 0 — verified.
- [ ] `bash -n infra/scripts/destroy.sh` exits 0 — verified.
- [ ] `terraform validate` produces no HCL syntax errors in changed files (module-not-installed errors are pre-existing, unrelated to this PR).
- [ ] Run `destroy.sh` against a dev environment and confirm final snapshot appears in AWS RDS console.
- [ ] Run `FORCE_DESTROY=1 destroy.sh` against a throwaway environment and confirm no snapshot is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)