### PR TITLE
feat(auto-match): pre-filter pipeline + orchestrator (#268)

### DIFF
--- a/src/actions/auto-match.ts
+++ b/src/actions/auto-match.ts
@@ -1,0 +1,58 @@
+'use server'
+
+import { prefilterCandidatesForRole } from '@/lib/auto-match'
+import { writeAuditLog } from '@/lib/audit'
+
+/**
+ * Auto-match orchestrator (epic #267).
+ *
+ * Called from the createRole after() hook (issue #270). Runs the pre-filter
+ * pipeline and audits the lifecycle. Designed to NEVER throw — failures are
+ * captured as `role.auto_match_failed` audit rows so the caller's main
+ * response path is never affected.
+ *
+ * Scoring of the top survivors is owned by issue #269; this function currently
+ * audits the candidate IDs that WOULD be scored (`scoringPending: true` in
+ * metadata) and leaves the Claude-scoring step as a follow-up.
+ */
+export async function triggerAutoMatch(
+  roleId: string,
+  tenantId: string,
+): Promise<void> {
+  const startedAt = Date.now()
+
+  await writeAuditLog(tenantId, {
+    action: 'role.auto_match_started',
+    entityType: 'role',
+    entityId: roleId,
+  })
+
+  try {
+    const survivors = await prefilterCandidatesForRole({ roleId, tenantId })
+    const topCandidateIds = survivors.slice(0, 3).map((s) => s.candidateId)
+
+    await writeAuditLog(tenantId, {
+      action: 'role.auto_match_completed',
+      entityType: 'role',
+      entityId: roleId,
+      metadata: {
+        candidateIds: topCandidateIds,
+        survivorCount: survivors.length,
+        durationMs: Date.now() - startedAt,
+        // Flipped to false by #269 once Claude scoring is integrated.
+        scoringPending: true,
+      },
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    await writeAuditLog(tenantId, {
+      action: 'role.auto_match_failed',
+      entityType: 'role',
+      entityId: roleId,
+      metadata: {
+        error: message,
+        durationMs: Date.now() - startedAt,
+      },
+    })
+  }
+}

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -13,6 +13,7 @@ export type AuditAction =
   | 'candidate.profile_confirmed'
   | 'candidate.profile_dismissed'
   | 'role.created' | 'role.updated' | 'role.archived' | 'role.unarchived' | 'role.deleted_hard'
+  | 'role.auto_match_started' | 'role.auto_match_completed' | 'role.auto_match_failed'
   | 'score.completed' | 'score.failed' | 'score.removed'
   | 'interview_pack.created' | 'interview_pack.completed' | 'interview_pack.failed'
   | 'interview_pack.deleted' | 'interview_pack.retried'

--- a/src/lib/auto-match/index.ts
+++ b/src/lib/auto-match/index.ts
@@ -1,0 +1,7 @@
+export { hasBeenRejectedByCustomer } from './rejection'
+export { prefilterCandidatesForRole } from './prefilter'
+export type {
+  AvailabilityResult,
+  PrefilterResult,
+  RateMatch,
+} from './types'

--- a/src/lib/auto-match/prefilter.ts
+++ b/src/lib/auto-match/prefilter.ts
@@ -1,0 +1,157 @@
+import { and, eq, sql } from 'drizzle-orm'
+import { withTenant } from '@/db'
+import { roles } from '@/db/schema'
+import { generateEmbedding } from '@/lib/ai/embeddings'
+import { hasBeenRejectedByCustomer } from './rejection'
+import type { AvailabilityResult, PrefilterResult, RateMatch } from './types'
+
+const VECTOR_TOP_N = 30
+const PREFILTER_CAP = 20
+const BUDGET_OVERAGE_MAX = 1.25 // candidates >25% over budget are excluded
+
+type VectorRow = {
+  id: string
+  availability_status: 'available' | 'on_project' | 'unavailable'
+  available_from: string | null
+  candidate_rate: string | null
+  rate_currency: string | null
+  similarity: number
+}
+
+/**
+ * Pre-filters the candidate archive for auto-match. Returns up to 20 candidates
+ * ordered by pgvector cosine similarity to the role's text, after excluding:
+ *
+ *   - candidates with availabilityStatus = 'unavailable'
+ *   - candidates previously rejected by this role's customer (any prior role)
+ *   - candidates whose day rate exceeds 125% of role.customerDayRate when
+ *     currencies match (mismatched currencies pass through, flagged in result)
+ *
+ * Returns [] when the role isn't found, the embedding can't be generated, or
+ * no candidate survives. The orchestrator (triggerAutoMatch) treats [] as a
+ * normal "no matches" outcome, not an error.
+ */
+export async function prefilterCandidatesForRole(args: {
+  roleId: string
+  tenantId: string
+}): Promise<PrefilterResult[]> {
+  const { roleId, tenantId } = args
+
+  const [role] = await withTenant(tenantId, async (tx) =>
+    tx
+      .select({
+        id: roles.id,
+        title: roles.title,
+        description: roles.description,
+        requirements: roles.requirements,
+        customerId: roles.customerId,
+        customerDayRate: roles.customerDayRate,
+        rateCurrency: roles.rateCurrency,
+      })
+      .from(roles)
+      .where(and(eq(roles.id, roleId), eq(roles.tenantId, tenantId)))
+      .limit(1),
+  )
+  if (!role) return []
+
+  const roleText = `${role.title}\n\n${role.description}\n\n${role.requirements}`
+  const roleEmbedding = await generateEmbedding(roleText, tenantId)
+  if (!roleEmbedding) return []
+  const embeddingStr = JSON.stringify(roleEmbedding)
+
+  // pgvector cosine top-N. Unlike getSuggestedCandidates we do NOT exclude
+  // already-scored candidates — auto-match reconsiders the archive regardless
+  // of prior scoring on other roles. Availability filter pushed into SQL.
+  const rawRows = await withTenant(tenantId, async (tx) =>
+    tx.execute(sql`
+      SELECT
+        id,
+        availability_status,
+        available_from,
+        candidate_rate,
+        rate_currency,
+        ROUND((1 - (embedding <=> ${embeddingStr}::vector))::numeric, 3) AS similarity
+      FROM candidates
+      WHERE
+        tenant_id = current_setting('app.tenant_id', true)::uuid
+        AND is_active = true
+        AND embedding IS NOT NULL
+        AND availability_status != 'unavailable'
+      ORDER BY embedding <=> ${embeddingStr}::vector
+      LIMIT ${VECTOR_TOP_N}
+    `),
+  )
+
+  const rows = Array.from(rawRows) as VectorRow[]
+  if (rows.length === 0) return []
+
+  // Customer-rejection filter — only meaningful when the role has a customer.
+  // Run all checks in parallel: at N=30 candidates we issue 30 small queries,
+  // bounded by the postgres pool (max=10 connections, see src/db/index.ts).
+  let rejectedIds = new Set<string>()
+  if (role.customerId) {
+    const customerId = role.customerId
+    const checks = await Promise.all(
+      rows.map(async (r) => ({
+        id: r.id,
+        rejected: await hasBeenRejectedByCustomer(r.id, customerId, tenantId),
+      })),
+    )
+    rejectedIds = new Set(checks.filter((c) => c.rejected).map((c) => c.id))
+  }
+
+  const budget =
+    role.customerDayRate !== null && role.customerDayRate !== undefined
+      ? Number(role.customerDayRate)
+      : null
+  const budgetCurrency = role.rateCurrency
+
+  const results: PrefilterResult[] = []
+  for (const r of rows) {
+    if (rejectedIds.has(r.id)) continue
+
+    const candidateRate =
+      r.candidate_rate !== null && r.candidate_rate !== undefined
+        ? Number(r.candidate_rate)
+        : null
+    const candidateCurrency = r.rate_currency
+
+    let rateMatch: RateMatch
+    let rateOveragePercent: number | null = null
+
+    if (budget === null || candidateRate === null) {
+      rateMatch = 'unknown'
+    } else if (
+      !budgetCurrency ||
+      !candidateCurrency ||
+      budgetCurrency !== candidateCurrency
+    ) {
+      rateMatch = 'currency_mismatch'
+    } else if (candidateRate > budget * BUDGET_OVERAGE_MAX) {
+      // >25% over budget — exclude entirely (hard cap)
+      continue
+    } else if (candidateRate > budget) {
+      rateMatch = 'over'
+      rateOveragePercent = Math.round(((candidateRate - budget) / budget) * 100)
+    } else {
+      rateMatch = 'within'
+    }
+
+    const availability: AvailabilityResult =
+      r.availability_status === 'on_project'
+        ? { status: 'on_project', availableFrom: r.available_from ?? null }
+        : { status: 'available' }
+
+    results.push({
+      candidateId: r.id,
+      similarity: Math.round(Number(r.similarity) * 100),
+      rateMatch,
+      rateOveragePercent,
+      availability,
+    })
+
+    if (results.length >= PREFILTER_CAP) break
+  }
+
+  return results
+}

--- a/src/lib/auto-match/rejection.ts
+++ b/src/lib/auto-match/rejection.ts
@@ -1,0 +1,43 @@
+import { sql } from 'drizzle-orm'
+import { withTenant } from '@/db'
+
+/**
+ * Returns true if this candidate has been rejected by the given customer on
+ * any prior role (active or archived). Two signals count:
+ *
+ *   1. role_submissions.status = 'rejected' on a role tied to this customer
+ *   2. candidate_role_approvals.decision = 'rejected' on a role tied to this customer
+ *
+ * Both signals are joined through roles.customer_id so the rejection must
+ * have been against THIS customer specifically. Rejections on other customers'
+ * roles do not count.
+ */
+export async function hasBeenRejectedByCustomer(
+  candidateId: string,
+  customerId: string,
+  tenantId: string,
+): Promise<boolean> {
+  return withTenant(tenantId, async (tx) => {
+    const submissionRows = await tx.execute(sql`
+      SELECT 1
+      FROM role_submissions rs
+      INNER JOIN roles r ON r.id = rs.role_id
+      WHERE rs.candidate_id = ${candidateId}::uuid
+        AND r.customer_id = ${customerId}::uuid
+        AND rs.status = 'rejected'
+      LIMIT 1
+    `)
+    if (Array.from(submissionRows).length > 0) return true
+
+    const approvalRows = await tx.execute(sql`
+      SELECT 1
+      FROM candidate_role_approvals cra
+      INNER JOIN roles r ON r.id = cra.role_id
+      WHERE cra.candidate_id = ${candidateId}::uuid
+        AND r.customer_id = ${customerId}::uuid
+        AND cra.decision = 'rejected'
+      LIMIT 1
+    `)
+    return Array.from(approvalRows).length > 0
+  })
+}

--- a/src/lib/auto-match/types.ts
+++ b/src/lib/auto-match/types.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared types for the auto-match pipeline (epic #267).
+ *
+ * The pipeline pre-filters the candidate archive when a new role is created
+ * and surfaces the top survivors to the role detail page. See
+ * `prefilter.ts` for the filter logic and `rejection.ts` for the
+ * customer-rejection signal.
+ */
+
+export type RateMatch = 'within' | 'over' | 'currency_mismatch' | 'unknown'
+
+export type AvailabilityResult =
+  | { status: 'available' }
+  | { status: 'on_project'; availableFrom: string | null }
+
+export type PrefilterResult = {
+  candidateId: string
+  similarity: number
+  rateMatch: RateMatch
+  rateOveragePercent: number | null
+  availability: AvailabilityResult
+}

--- a/tests/unit/actions/auto-match.test.ts
+++ b/tests/unit/actions/auto-match.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for src/actions/auto-match.ts
+ *
+ * Covers triggerAutoMatch — the orchestrator that wraps prefilter execution
+ * with audit logging (epic #267, issue #268). The orchestrator MUST NOT throw;
+ * failures surface as role.auto_match_failed audit rows.
+ *
+ * Scoring of survivors is owned by issue #269 — this test asserts the audit
+ * shape carries the candidate IDs that WOULD be scored plus
+ * `scoringPending: true` so the follow-up PR can flip the flag and add the
+ * scoring step without changing the audit contract.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { PrefilterResult } from '@/lib/auto-match'
+
+const TENANT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const ROLE_ID   = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+
+const mockPrefilter = vi.fn()
+vi.mock('@/lib/auto-match', () => ({
+  prefilterCandidatesForRole: (...args: unknown[]) => mockPrefilter(...args),
+}))
+
+const mockAudit = vi.fn().mockResolvedValue(undefined)
+vi.mock('@/lib/audit', () => ({
+  writeAuditLog: (...args: unknown[]) => mockAudit(...args),
+}))
+
+function survivor(id: string): PrefilterResult {
+  return {
+    candidateId: id,
+    similarity: 85,
+    rateMatch: 'within',
+    rateOveragePercent: null,
+    availability: { status: 'available' },
+  }
+}
+
+describe('triggerAutoMatch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPrefilter.mockReset()
+    mockAudit.mockReset()
+    mockAudit.mockResolvedValue(undefined)
+  })
+
+  it('writes started then completed audit rows on the happy path', async () => {
+    mockPrefilter.mockResolvedValue([
+      survivor('cand-1'),
+      survivor('cand-2'),
+      survivor('cand-3'),
+      survivor('cand-4'),
+    ])
+    const { triggerAutoMatch } = await import('@/actions/auto-match')
+
+    await triggerAutoMatch(ROLE_ID, TENANT_ID)
+
+    expect(mockAudit).toHaveBeenCalledTimes(2)
+    expect(mockAudit.mock.calls[0]).toEqual([
+      TENANT_ID,
+      expect.objectContaining({
+        action: 'role.auto_match_started',
+        entityType: 'role',
+        entityId: ROLE_ID,
+      }),
+    ])
+    expect(mockAudit.mock.calls[1]).toEqual([
+      TENANT_ID,
+      expect.objectContaining({
+        action: 'role.auto_match_completed',
+        entityType: 'role',
+        entityId: ROLE_ID,
+      }),
+    ])
+  })
+
+  it('caps candidateIds at 3 in the completed metadata', async () => {
+    mockPrefilter.mockResolvedValue([
+      survivor('cand-1'),
+      survivor('cand-2'),
+      survivor('cand-3'),
+      survivor('cand-4'),
+      survivor('cand-5'),
+    ])
+    const { triggerAutoMatch } = await import('@/actions/auto-match')
+
+    await triggerAutoMatch(ROLE_ID, TENANT_ID)
+
+    const completedCall = mockAudit.mock.calls[1]
+    expect(completedCall[1].metadata.candidateIds).toEqual(['cand-1', 'cand-2', 'cand-3'])
+    expect(completedCall[1].metadata.survivorCount).toBe(5)
+    expect(completedCall[1].metadata.scoringPending).toBe(true)
+    expect(typeof completedCall[1].metadata.durationMs).toBe('number')
+  })
+
+  it('writes completed with empty candidateIds when prefilter returns no survivors', async () => {
+    mockPrefilter.mockResolvedValue([])
+    const { triggerAutoMatch } = await import('@/actions/auto-match')
+
+    await triggerAutoMatch(ROLE_ID, TENANT_ID)
+
+    const completedCall = mockAudit.mock.calls[1]
+    expect(completedCall[1].action).toBe('role.auto_match_completed')
+    expect(completedCall[1].metadata.candidateIds).toEqual([])
+    expect(completedCall[1].metadata.survivorCount).toBe(0)
+  })
+
+  it('writes failed audit row when prefilter throws', async () => {
+    mockPrefilter.mockRejectedValue(new Error('pgvector unavailable'))
+    const { triggerAutoMatch } = await import('@/actions/auto-match')
+
+    await triggerAutoMatch(ROLE_ID, TENANT_ID)
+
+    expect(mockAudit).toHaveBeenCalledTimes(2)
+    const lastCall = mockAudit.mock.calls[1]
+    expect(lastCall[1].action).toBe('role.auto_match_failed')
+    expect(lastCall[1].metadata.error).toBe('pgvector unavailable')
+    expect(typeof lastCall[1].metadata.durationMs).toBe('number')
+  })
+
+  it('does not throw when prefilter throws — failure is contained', async () => {
+    mockPrefilter.mockRejectedValue(new Error('boom'))
+    const { triggerAutoMatch } = await import('@/actions/auto-match')
+
+    await expect(triggerAutoMatch(ROLE_ID, TENANT_ID)).resolves.toBeUndefined()
+  })
+
+  it('coerces non-Error throwables to a string in the failed metadata', async () => {
+    mockPrefilter.mockRejectedValue('a bare string')
+    const { triggerAutoMatch } = await import('@/actions/auto-match')
+
+    await triggerAutoMatch(ROLE_ID, TENANT_ID)
+
+    const lastCall = mockAudit.mock.calls[1]
+    expect(lastCall[1].metadata.error).toBe('a bare string')
+  })
+})

--- a/tests/unit/lib/auto-match/prefilter.test.ts
+++ b/tests/unit/lib/auto-match/prefilter.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Unit tests for src/lib/auto-match/prefilter.ts
+ *
+ * Covers prefilterCandidatesForRole — the pre-filter pipeline behind
+ * auto-match (epic #267, issue #268). Sequence inside the action:
+ *   1. withTenant → load role (select)
+ *   2. generateEmbedding (mocked)
+ *   3. withTenant → pgvector cosine top-N (execute)
+ *   4. hasBeenRejectedByCustomer per candidate (mocked)
+ *   5. Budget / rate-match annotation in JS
+ *
+ * Mocks isolate the action from drizzle / pgvector / rejection / embeddings
+ * so each filter branch is testable in pure JS.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const TENANT_ID    = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const ROLE_ID      = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const CUSTOMER_ID  = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function role(overrides: Partial<{
+  customerId: string | null
+  customerDayRate: string | null
+  rateCurrency: string | null
+}> = {}) {
+  return {
+    id: ROLE_ID,
+    title: 'Senior Engineer',
+    description: 'Build distributed systems.',
+    requirements: 'TypeScript, Node.js, distributed systems experience',
+    customerId: CUSTOMER_ID,
+    customerDayRate: '500',
+    rateCurrency: 'GBP',
+    ...overrides,
+  }
+}
+
+function vectorRow(id: string, overrides: Partial<{
+  availability_status: 'available' | 'on_project' | 'unavailable'
+  available_from: string | null
+  candidate_rate: string | null
+  rate_currency: string | null
+  similarity: number
+}> = {}) {
+  return {
+    id,
+    availability_status: 'available' as const,
+    available_from: null,
+    candidate_rate: '450',
+    rate_currency: 'GBP',
+    similarity: 0.85,
+    ...overrides,
+  }
+}
+
+// ── Mock builders ─────────────────────────────────────────────────────────────
+
+function makeSelectChain(rows: unknown[]) {
+  const c: Record<string, unknown> = {}
+  const resolved = Promise.resolve(rows)
+  c.then    = resolved.then.bind(resolved)
+  c.catch   = resolved.catch.bind(resolved)
+  c.from    = vi.fn(() => c)
+  c.where   = vi.fn(() => c)
+  c.limit   = vi.fn(() => Promise.resolve(rows))
+  return c
+}
+
+// Per-test state
+let withTenantSelectQueue: unknown[][] = []
+let withTenantSelectCallCount = 0
+let executeResult: unknown[] = []
+
+vi.mock('@/db', () => ({
+  db: {},
+  withTenant: vi.fn().mockImplementation(
+    async (_tenantId: string, fn: (tx: unknown) => unknown) => {
+      const rows = withTenantSelectQueue[withTenantSelectCallCount] ?? []
+      withTenantSelectCallCount++
+      const tx = {
+        select:  vi.fn(() => makeSelectChain(rows)),
+        execute: vi.fn(() => Promise.resolve(executeResult)),
+      }
+      return fn(tx)
+    },
+  ),
+}))
+
+vi.mock('@/db/schema', () => ({
+  roles: {
+    id: 'id', tenantId: 'tenant_id', title: 'title', description: 'description',
+    requirements: 'requirements', customerId: 'customer_id',
+    customerDayRate: 'customer_day_rate', rateCurrency: 'rate_currency',
+  },
+}))
+
+vi.mock('drizzle-orm', () => ({
+  eq:  vi.fn(() => ({ type: 'eq' })),
+  and: vi.fn((...args: unknown[]) => ({ type: 'and', args })),
+  sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
+    type: 'sql',
+    strings,
+    values,
+  })),
+}))
+
+const mockGenerateEmbedding = vi.fn()
+vi.mock('@/lib/ai/embeddings', () => ({
+  generateEmbedding: (...args: unknown[]) => mockGenerateEmbedding(...args),
+}))
+
+const mockHasBeenRejected = vi.fn()
+vi.mock('@/lib/auto-match/rejection', () => ({
+  hasBeenRejectedByCustomer: (...args: unknown[]) => mockHasBeenRejected(...args),
+}))
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('prefilterCandidatesForRole', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    withTenantSelectQueue = []
+    withTenantSelectCallCount = 0
+    executeResult = []
+    mockGenerateEmbedding.mockResolvedValue([0.1, 0.2, 0.3])
+    mockHasBeenRejected.mockResolvedValue(false)
+  })
+
+  it('returns [] when role is not found', async () => {
+    withTenantSelectQueue = [[]] // role lookup returns nothing
+    const { prefilterCandidatesForRole } = await import('@/lib/auto-match/prefilter')
+
+    const result = await prefilterCandidatesForRole({ roleId: ROLE_ID, tenantId: TENANT_ID })
+
+    expect(result).toEqual([])
+    expect(mockGenerateEmbedding).not.toHaveBeenCalled()
+  })
+
+  it('returns [] when generateEmbedding returns null', async () => {
+    withTenantSelectQueue = [[role()]]
+    mockGenerateEmbedding.mockResolvedValue(null)
+    const { prefilterCandidatesForRole } = await import('@/lib/auto-match/prefilter')
+
+    const result = await prefilterCandidatesForRole({ roleId: ROLE_ID, tenantId: TENANT_ID })
+
+    expect(result).toEqual([])
+  })
+
+  it('returns [] when pgvector finds no candidates', async () => {
+    withTenantSelectQueue = [[role()], []] // role, then pgvector withTenant
+    executeResult = []
+    const { prefilterCandidatesForRole } = await import('@/lib/auto-match/prefilter')
+
+    const result = await prefilterCandidatesForRole({ roleId: ROLE_ID, tenantId: TENANT_ID })
+
+    expect(result).toEqual([])
+  })
+
+  it('filters out rejected candidates', async () => {
+    withTenantSelectQueue = [[role()], []]
+    executeResult = [
+      vectorRow('cand-1'),
+      vectorRow('cand-2'),
+      vectorRow('cand-3'),
+    ]
+    // cand-2 is rejected by this customer
+    mockHasBeenRejected.mockImplementation((candidateId: string) =>
+      Promise.resolve(candidateId === 'cand-2'),
+    )
+    const { prefilterCandidatesForRole } = await import('@/lib/auto-match/prefilter')
+
+    const result = await prefilterCandidatesForRole({ roleId: ROLE_ID, tenantId: TENANT_ID })
+
+    expect(result.map((r) => r.candidateId)).toEqual(['cand-1', 'cand-3'])
+  })
+
+  it('skips rejection check when role has no customerId', async () => {
+    withTenantSelectQueue = [[role({ customerId: null })], []]
+    executeResult = [vectorRow('cand-1')]
+    const { prefilterCandidatesForRole } = await import('@/lib/auto-match/prefilter')
+
+    const result = await prefilterCandidatesForRole({ roleId: ROLE_ID, tenantId: TENANT_ID })
+
+    expect(result).toHaveLength(1)
+    expect(mockHasBeenRejected).not.toHaveBeenCalled()
+  })
+
+  it('annotates rateMatch=within when candidate is at or under budget', async () => {
+    withTenantSelectQueue = [[role()], []] // budget 500 GBP
+    executeResult = [vectorRow('cand-1', { candidate_rate: '450', rate_currency: 'GBP' })]
+    const { prefilterCandidatesForRole } = await import('@/lib/auto-match/prefilter')
+
+    const result = await prefilterCandidatesForRole({ roleId: ROLE_ID, tenantId: TENANT_ID })
+
+    expect(result[0].rateMatch).toBe('within')
+    expect(result[0].rateOveragePercent).toBeNull()
+  })
+
+  it('annotates rateMatch=over with overage percent when over budget but within 25%', async () => {
+    withTenantSelectQueue = [[role()], []] // budget 500 GBP
+    executeResult = [vectorRow('cand-1', { candidate_rate: '550', rate_currency: 'GBP' })]
+    const { prefilterCandidatesForRole } = await import('@/lib/auto-match/prefilter')
+
+    const result = await prefilterCandidatesForRole({ roleId: ROLE_ID, tenantId: TENANT_ID })
+
+    expect(result[0].rateMatch).toBe('over')
+    expect(result[0].rateOveragePercent).toBe(10) // (550-500)/500 = 10%
+  })
+
+  it('excludes candidates more than 25% over budget', async () => {
+    withTenantSelectQueue = [[role()], []] // budget 500 GBP
+    executeResult = [
+      vectorRow('within',  { candidate_rate: '450', rate_currency: 'GBP' }),
+      vectorRow('barely',  { candidate_rate: '625', rate_currency: 'GBP' }), // exactly 25% over → allowed
+      vectorRow('overcap', { candidate_rate: '626', rate_currency: 'GBP' }), // 25.2% over → excluded
+    ]
+    const { prefilterCandidatesForRole } = await import('@/lib/auto-match/prefilter')
+
+    const result = await prefilterCandidatesForRole({ roleId: ROLE_ID, tenantId: TENANT_ID })
+
+    expect(result.map((r) => r.candidateId)).toEqual(['within', 'barely'])
+  })
+
+  it('annotates rateMatch=currency_mismatch when currencies differ', async () => {
+    withTenantSelectQueue = [[role()], []] // budget GBP
+    executeResult = [vectorRow('cand-1', { candidate_rate: '550', rate_currency: 'EUR' })]
+    const { prefilterCandidatesForRole } = await import('@/lib/auto-match/prefilter')
+
+    const result = await prefilterCandidatesForRole({ roleId: ROLE_ID, tenantId: TENANT_ID })
+
+    expect(result[0].rateMatch).toBe('currency_mismatch')
+    expect(result[0].rateOveragePercent).toBeNull()
+  })
+
+  it('annotates rateMatch=unknown when role has no budget', async () => {
+    withTenantSelectQueue = [[role({ customerDayRate: null, rateCurrency: null })], []]
+    executeResult = [vectorRow('cand-1')]
+    const { prefilterCandidatesForRole } = await import('@/lib/auto-match/prefilter')
+
+    const result = await prefilterCandidatesForRole({ roleId: ROLE_ID, tenantId: TENANT_ID })
+
+    expect(result[0].rateMatch).toBe('unknown')
+  })
+
+  it('annotates rateMatch=unknown when candidate has no rate', async () => {
+    withTenantSelectQueue = [[role()], []]
+    executeResult = [vectorRow('cand-1', { candidate_rate: null, rate_currency: null })]
+    const { prefilterCandidatesForRole } = await import('@/lib/auto-match/prefilter')
+
+    const result = await prefilterCandidatesForRole({ roleId: ROLE_ID, tenantId: TENANT_ID })
+
+    expect(result[0].rateMatch).toBe('unknown')
+  })
+
+  it('returns on_project availability with availableFrom for on_project candidates', async () => {
+    withTenantSelectQueue = [[role()], []]
+    executeResult = [
+      vectorRow('cand-1', { availability_status: 'on_project', available_from: '2026-06-15' }),
+    ]
+    const { prefilterCandidatesForRole } = await import('@/lib/auto-match/prefilter')
+
+    const result = await prefilterCandidatesForRole({ roleId: ROLE_ID, tenantId: TENANT_ID })
+
+    expect(result[0].availability).toEqual({
+      status: 'on_project',
+      availableFrom: '2026-06-15',
+    })
+  })
+
+  it('returns flat available status for available candidates', async () => {
+    withTenantSelectQueue = [[role()], []]
+    executeResult = [vectorRow('cand-1', { availability_status: 'available' })]
+    const { prefilterCandidatesForRole } = await import('@/lib/auto-match/prefilter')
+
+    const result = await prefilterCandidatesForRole({ roleId: ROLE_ID, tenantId: TENANT_ID })
+
+    expect(result[0].availability).toEqual({ status: 'available' })
+  })
+
+  it('caps results at 20 even if pgvector returns 30', async () => {
+    withTenantSelectQueue = [[role()], []]
+    executeResult = Array.from({ length: 30 }, (_, i) => vectorRow(`cand-${i}`))
+    const { prefilterCandidatesForRole } = await import('@/lib/auto-match/prefilter')
+
+    const result = await prefilterCandidatesForRole({ roleId: ROLE_ID, tenantId: TENANT_ID })
+
+    expect(result).toHaveLength(20)
+  })
+
+  it('rounds similarity to integer percent', async () => {
+    withTenantSelectQueue = [[role()], []]
+    executeResult = [vectorRow('cand-1', { similarity: 0.876 })]
+    const { prefilterCandidatesForRole } = await import('@/lib/auto-match/prefilter')
+
+    const result = await prefilterCandidatesForRole({ roleId: ROLE_ID, tenantId: TENANT_ID })
+
+    expect(result[0].similarity).toBe(88) // Math.round(0.876 * 100)
+  })
+})

--- a/tests/unit/lib/auto-match/rejection.test.ts
+++ b/tests/unit/lib/auto-match/rejection.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Unit tests for src/lib/auto-match/rejection.ts
+ *
+ * Covers hasBeenRejectedByCustomer — the customer-rejection signal that drives
+ * the auto-match pre-filter (epic #267, issue #268).
+ *
+ * Two SQL queries are issued inside one withTenant() call:
+ *   1. role_submissions JOIN roles WHERE status='rejected' AND customer_id matches
+ *   2. candidate_role_approvals JOIN roles WHERE decision='rejected' AND customer_id matches
+ *
+ * Tests verify the OR semantics: either query finding a row returns true.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const TENANT_ID    = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const CANDIDATE_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const CUSTOMER_ID  = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+
+// The rejection helper calls tx.execute() twice in sequence inside ONE
+// withTenant block. We control the two return values via this queue.
+let executeQueue: unknown[][] = []
+let executeCallCount = 0
+
+vi.mock('@/db', () => ({
+  db: {},
+  withTenant: vi.fn().mockImplementation(
+    async (_tenantId: string, fn: (tx: unknown) => unknown) => {
+      const tx = {
+        execute: vi.fn(() => {
+          const rows = executeQueue[executeCallCount] ?? []
+          executeCallCount++
+          return Promise.resolve(rows)
+        }),
+      }
+      return fn(tx)
+    },
+  ),
+}))
+
+vi.mock('drizzle-orm', () => ({
+  sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
+    type: 'sql',
+    strings,
+    values,
+  })),
+}))
+
+describe('hasBeenRejectedByCustomer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    executeQueue = []
+    executeCallCount = 0
+  })
+
+  it('returns true when role_submissions has a rejected row for the customer', async () => {
+    // First execute (submissions) returns a row, so the helper short-circuits
+    // and never runs the approvals query.
+    executeQueue = [[{ '?column?': 1 }], []]
+    const { hasBeenRejectedByCustomer } = await import('@/lib/auto-match/rejection')
+
+    const result = await hasBeenRejectedByCustomer(CANDIDATE_ID, CUSTOMER_ID, TENANT_ID)
+
+    expect(result).toBe(true)
+    expect(executeCallCount).toBe(1) // short-circuited
+  })
+
+  it('returns true when candidate_role_approvals has a rejected row (submissions empty)', async () => {
+    executeQueue = [[], [{ '?column?': 1 }]]
+    const { hasBeenRejectedByCustomer } = await import('@/lib/auto-match/rejection')
+
+    const result = await hasBeenRejectedByCustomer(CANDIDATE_ID, CUSTOMER_ID, TENANT_ID)
+
+    expect(result).toBe(true)
+    expect(executeCallCount).toBe(2)
+  })
+
+  it('returns true when both signals fire', async () => {
+    // Short-circuits on the submissions row; the second query never runs.
+    executeQueue = [[{ '?column?': 1 }], [{ '?column?': 1 }]]
+    const { hasBeenRejectedByCustomer } = await import('@/lib/auto-match/rejection')
+
+    const result = await hasBeenRejectedByCustomer(CANDIDATE_ID, CUSTOMER_ID, TENANT_ID)
+
+    expect(result).toBe(true)
+  })
+
+  it('returns false when neither query finds a rejection row', async () => {
+    executeQueue = [[], []]
+    const { hasBeenRejectedByCustomer } = await import('@/lib/auto-match/rejection')
+
+    const result = await hasBeenRejectedByCustomer(CANDIDATE_ID, CUSTOMER_ID, TENANT_ID)
+
+    expect(result).toBe(false)
+    expect(executeCallCount).toBe(2)
+  })
+
+  it('runs both queries inside a single withTenant call', async () => {
+    executeQueue = [[], []]
+    const dbMod = await import('@/db')
+    const { hasBeenRejectedByCustomer } = await import('@/lib/auto-match/rejection')
+
+    await hasBeenRejectedByCustomer(CANDIDATE_ID, CUSTOMER_ID, TENANT_ID)
+
+    expect(dbMod.withTenant).toHaveBeenCalledTimes(1)
+    expect(dbMod.withTenant).toHaveBeenCalledWith(TENANT_ID, expect.any(Function))
+  })
+})


### PR DESCRIPTION
Closes #268. First slice of epic #267.

## Summary

- Backend pipeline that pgvector-ranks the archive against a new role, then prunes for availability, prior customer rejection, and budget cap (>25% over excluded; ≤25% over flagged).
- `triggerAutoMatch(roleId, tenantId)` orchestrator emits `role.auto_match_started` / `role.auto_match_completed` / `role.auto_match_failed` audit rows.
- `scoringPending: true` in the completed metadata — #269 flips this when Claude scoring lands, without changing the audit contract.

## What's NOT in this PR (by design)

- Claude scoring of survivors — issue #269
- `after()` wiring in `createRole` — issue #270
- UI panel — issue #271

## Architecture notes

- `prefilterCandidatesForRole` runs pgvector cosine top-30, then applies hard filters in JS so per-filter behaviour is unit-testable.
- Customer-rejection signal joins through `roles.customer_id` so rejection on a different customer's role doesn't count. Both `role_submissions.status='rejected'` and `candidate_role_approvals.decision='rejected'` are honoured (per epic decision).
- Rate filter only triggers when currencies match — mismatched currencies pass through, flagged `currency_mismatch` for the UI. No FX conversion in V1.
- Already-scored candidates are NOT excluded (unlike `getSuggestedCandidates`) — auto-match reconsiders the archive on every new role.
- All queries use `withTenant()`; per-candidate rejection checks run in parallel bounded by the existing pg pool (max=10).

## Files

- `src/lib/auto-match/{rejection,prefilter,types,index}.ts`
- `src/actions/auto-match.ts`
- `src/lib/audit.ts` — three new actions appended to the union
- `tests/unit/lib/auto-match/{rejection,prefilter}.test.ts`
- `tests/unit/actions/auto-match.test.ts`

No DB schema changes.

## Test plan

- [x] `npm test -- tests/unit/lib/auto-match tests/unit/actions/auto-match.test.ts` — 26/26 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed paths — clean
- [x] Confirmed no regression on `tests/unit/lib/audit-middleware.test.ts` + `tests/unit/actions/roles.test.ts` + `tests/unit/actions/matching.test.ts` (32/32 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)