### PR TITLE
feat(auto-match): ArchiveMatchesPanel on role detail (#271)

### DIFF
--- a/src/actions/auto-match-status.ts
+++ b/src/actions/auto-match-status.ts
@@ -1,0 +1,228 @@
+'use server'
+
+import { and, desc, eq, inArray } from 'drizzle-orm'
+import { withTenant } from '@/db'
+import { auditLogs, candidates, agencies, scores, roles } from '@/db/schema'
+import { getActionContext } from '@/lib/auth/action-context'
+
+export type AutoMatchStatus = 'idle' | 'pending' | 'complete' | 'failed'
+
+export type AutoMatchRateMatch = 'within' | 'over' | 'currency_mismatch' | 'unknown'
+
+export type AutoMatchCandidate = {
+  id: string
+  firstName: string
+  lastName: string
+  agencyName: string | null
+  agencyLogoPath: string | null
+  overallScore: number | null
+  rateMatch: AutoMatchRateMatch
+  rateOveragePercent: number | null
+  availabilityStatus: 'available' | 'on_project' | 'unavailable'
+  availableFrom: string | null
+  scoreStatus: 'pending' | 'processing' | 'complete' | 'failed' | null
+}
+
+export type AutoMatchStatusResult = {
+  status: AutoMatchStatus
+  reason: string | null
+  candidates: AutoMatchCandidate[]
+}
+
+const AUTO_MATCH_ACTIONS = [
+  'role.auto_match_started',
+  'role.auto_match_completed',
+  'role.auto_match_failed',
+] as const
+
+const BUDGET_OVERAGE_MAX = 1.25
+
+type AutoMatchMetadata = {
+  candidateIds?: string[]
+  scoredCandidateIds?: string[]
+  reason?: string
+}
+
+/**
+ * Resolves the live auto-match status for a role by reading its most-recent
+ * audit row and joining to candidate / score / agency data. Used by the
+ * ArchiveMatchesPanel on the role detail page (epic #267, issue #271).
+ *
+ * Returns:
+ *   - status='idle'     when no auto-match has been started (e.g. role created
+ *                       pre-feature)
+ *   - status='pending'  when only role.auto_match_started has been written
+ *   - status='complete' when role.auto_match_completed is the most-recent row
+ *   - status='failed'   when role.auto_match_failed is the most-recent row;
+ *                       candidates may still be present in the cap-exceeded path
+ *
+ * rateMatch is re-derived at query time from the candidate's current rate vs
+ * the role's customerDayRate — keeps the audit metadata small and the panel
+ * always reflects the latest rate edits.
+ */
+export async function getAutoMatchStatus(
+  roleId: string,
+): Promise<AutoMatchStatusResult> {
+  const ctx = await getActionContext()
+  if (!ctx) {
+    return { status: 'idle', reason: null, candidates: [] }
+  }
+  const { tenantId } = ctx
+
+  const [latest] = await withTenant(tenantId, async (tx) =>
+    tx
+      .select({
+        action: auditLogs.action,
+        metadata: auditLogs.metadata,
+      })
+      .from(auditLogs)
+      .where(
+        and(
+          eq(auditLogs.entityType, 'role'),
+          eq(auditLogs.entityId, roleId),
+          inArray(auditLogs.action, AUTO_MATCH_ACTIONS as unknown as string[]),
+        ),
+      )
+      .orderBy(desc(auditLogs.createdAt))
+      .limit(1),
+  )
+
+  if (!latest) {
+    return { status: 'idle', reason: null, candidates: [] }
+  }
+
+  if (latest.action === 'role.auto_match_started') {
+    return { status: 'pending', reason: null, candidates: [] }
+  }
+
+  const metadata = (latest.metadata ?? {}) as AutoMatchMetadata
+  const isFailed = latest.action === 'role.auto_match_failed'
+
+  // Pull whichever candidate-id list is present. Completed rows publish
+  // scoredCandidateIds (the survivors that got scored), candidateIds (top 3
+  // prefilter), or both. Failed rows on the cap-exceeded path carry
+  // candidateIds; failed rows from internal errors may carry nothing.
+  const candidateIds =
+    metadata.scoredCandidateIds && metadata.scoredCandidateIds.length > 0
+      ? metadata.scoredCandidateIds
+      : metadata.candidateIds ?? []
+
+  if (candidateIds.length === 0) {
+    return {
+      status: isFailed ? 'failed' : 'complete',
+      reason: isFailed ? metadata.reason ?? null : null,
+      candidates: [],
+    }
+  }
+
+  // Fetch role budget context for rate-match derivation
+  const [role] = await withTenant(tenantId, async (tx) =>
+    tx
+      .select({
+        customerDayRate: roles.customerDayRate,
+        rateCurrency: roles.rateCurrency,
+      })
+      .from(roles)
+      .where(and(eq(roles.id, roleId), eq(roles.tenantId, tenantId)))
+      .limit(1),
+  )
+  const budget =
+    role && role.customerDayRate !== null && role.customerDayRate !== undefined
+      ? Number(role.customerDayRate)
+      : null
+  const budgetCurrency = role?.rateCurrency ?? null
+
+  const candidateRows = await withTenant(tenantId, async (tx) =>
+    tx
+      .select({
+        id: candidates.id,
+        firstName: candidates.firstName,
+        lastName: candidates.lastName,
+        candidateRate: candidates.candidateRate,
+        rateCurrency: candidates.rateCurrency,
+        availabilityStatus: candidates.availabilityStatus,
+        availableFrom: candidates.availableFrom,
+        agencyName: agencies.name,
+        agencyLogoPath: agencies.logoPath,
+      })
+      .from(candidates)
+      .leftJoin(agencies, eq(agencies.id, candidates.agencyId))
+      .where(
+        and(
+          eq(candidates.tenantId, tenantId),
+          inArray(candidates.id, candidateIds),
+        ),
+      ),
+  )
+
+  const scoreRows = await withTenant(tenantId, async (tx) =>
+    tx
+      .select({
+        candidateId: scores.candidateId,
+        overallScore: scores.overallScore,
+        scoreStatus: scores.scoreStatus,
+      })
+      .from(scores)
+      .where(
+        and(eq(scores.roleId, roleId), inArray(scores.candidateId, candidateIds)),
+      ),
+  )
+  const scoreMap = new Map(scoreRows.map((s) => [s.candidateId, s]))
+
+  // Preserve the order from candidateIds (sorted by similarity → score by the
+  // orchestrator) rather than the unordered DB result.
+  const rowMap = new Map(candidateRows.map((c) => [c.id, c]))
+  const orderedCandidates: AutoMatchCandidate[] = []
+  for (const cid of candidateIds) {
+    const c = rowMap.get(cid)
+    if (!c) continue
+
+    const candidateRate =
+      c.candidateRate !== null && c.candidateRate !== undefined
+        ? Number(c.candidateRate)
+        : null
+
+    let rateMatch: AutoMatchRateMatch
+    let rateOveragePercent: number | null = null
+    if (budget === null || candidateRate === null) {
+      rateMatch = 'unknown'
+    } else if (
+      !budgetCurrency ||
+      !c.rateCurrency ||
+      budgetCurrency !== c.rateCurrency
+    ) {
+      rateMatch = 'currency_mismatch'
+    } else if (candidateRate > budget * BUDGET_OVERAGE_MAX) {
+      // Should have been filtered out by prefilter, but render defensively
+      rateMatch = 'over'
+      rateOveragePercent = Math.round(((candidateRate - budget) / budget) * 100)
+    } else if (candidateRate > budget) {
+      rateMatch = 'over'
+      rateOveragePercent = Math.round(((candidateRate - budget) / budget) * 100)
+    } else {
+      rateMatch = 'within'
+    }
+
+    const score = scoreMap.get(cid)
+
+    orderedCandidates.push({
+      id: c.id,
+      firstName: c.firstName,
+      lastName: c.lastName,
+      agencyName: c.agencyName,
+      agencyLogoPath: c.agencyLogoPath,
+      overallScore: score?.overallScore ?? null,
+      rateMatch,
+      rateOveragePercent,
+      availabilityStatus: c.availabilityStatus,
+      availableFrom: c.availableFrom,
+      scoreStatus: score?.scoreStatus ?? null,
+    })
+  }
+
+  return {
+    status: isFailed ? 'failed' : 'complete',
+    reason: isFailed ? metadata.reason ?? null : null,
+    candidates: orderedCandidates,
+  }
+}

--- a/src/app/(dashboard)/dashboard/roles/[roleId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/roles/[roleId]/page.tsx
@@ -15,6 +15,7 @@ import { RoleContent } from '@/components/roles/role-content'
 import { SelectableRoleCandidateList } from '@/components/roles/selectable-role-candidate-list'
 import type { RoleCandidateRow } from '@/components/roles/selectable-role-candidate-list'
 import { SuggestCandidatesPanel } from '@/components/roles/suggest-candidates-panel'
+import { ArchiveMatchesPanel } from '@/components/roles/archive-matches-panel'
 import { AddCandidatePanel } from '@/components/roles/add-candidate-panel'
 import { ShortlistSummaryPanel } from '@/components/roles/shortlist-summary-panel'
 import { SentToCustomerPanel } from '@/components/roles/sent-to-customer-panel'
@@ -344,6 +345,13 @@ export default async function RoleDetailPage({ params }: Props) {
         </h2>
         <RoleContent text={role.requirements} />
       </div>
+
+      {/* Auto-match top archive candidates (epic #267) — recruiter-only because
+          it surfaces rates + rejection-derived signals. Customer / manager
+          audiences never see this panel. */}
+      {audience === 'recruiter' && (
+        <ArchiveMatchesPanel roleId={roleId} />
+      )}
 
       {/* Auto-suggest matching candidates from archive */}
       <SuggestCandidatesPanel

--- a/src/app/api/roles/[roleId]/auto-match-status/route.ts
+++ b/src/app/api/roles/[roleId]/auto-match-status/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { hasRole } from '@/lib/auth/require-role'
+import { getAutoMatchStatus } from '@/actions/auto-match-status'
+
+/**
+ * Poll endpoint backing the ArchiveMatchesPanel (epic #267 / issue #271).
+ *
+ * Recruiter+ only — the response carries rate-match annotations and
+ * candidate identities derived from internal data (prior customer
+ * rejections). Defence-in-depth alongside the panel's audience gate.
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ roleId: string }> },
+) {
+  const session = await auth()
+  if (!session?.user?.tenantId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const userRole = (session.user as { role?: string }).role
+  if (!hasRole((userRole ?? 'viewer') as 'admin' | 'recruiter' | 'hiring_manager' | 'viewer', 'recruiter')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { roleId } = await params
+  const result = await getAutoMatchStatus(roleId)
+  return NextResponse.json(result)
+}

--- a/src/components/roles/archive-matches-panel.tsx
+++ b/src/components/roles/archive-matches-panel.tsx
@@ -1,0 +1,269 @@
+'use client'
+
+import Link from 'next/link'
+import { useQuery } from '@tanstack/react-query'
+import { Loader2Icon, SparklesIcon, AlertTriangleIcon } from 'lucide-react'
+import type { AutoMatchStatusResult, AutoMatchCandidate, AutoMatchRateMatch } from '@/actions/auto-match-status'
+
+type Props = { roleId: string }
+
+// Polled every 3s while the orchestrator is still running; stops once status
+// reaches a terminal state. Matches the cadence used by ScorePolling so
+// recruiters see a consistent feel across background AI jobs.
+const POLL_INTERVAL_MS = 3000
+
+function RateMatchPill({ match, percent }: { match: AutoMatchRateMatch; percent: number | null }) {
+  if (match === 'within') {
+    return (
+      <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium
+                       bg-emerald-100 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-300
+                       border border-emerald-300 dark:border-emerald-800">
+        Within budget
+      </span>
+    )
+  }
+  if (match === 'over') {
+    return (
+      <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium
+                       bg-amber-100 dark:bg-amber-950 text-amber-700 dark:text-amber-300
+                       border border-amber-300 dark:border-amber-800">
+        Over by {percent ?? 0}%
+      </span>
+    )
+  }
+  if (match === 'currency_mismatch') {
+    return (
+      <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium
+                       bg-[var(--color-bg-input)] text-[var(--color-fg-muted)]
+                       border border-[var(--color-border)]">
+        Currency mismatch
+      </span>
+    )
+  }
+  return null // 'unknown' — silent
+}
+
+function AvailabilityBadge({ status, availableFrom }: { status: AutoMatchCandidate['availabilityStatus']; availableFrom: string | null }) {
+  if (status === 'available') {
+    return (
+      <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium
+                       bg-blue-100 dark:bg-blue-950 text-blue-700 dark:text-blue-300
+                       border border-blue-300 dark:border-blue-800">
+        Available now
+      </span>
+    )
+  }
+  if (status === 'on_project') {
+    const formatted = availableFrom
+      ? new Date(availableFrom).toLocaleDateString('en-GB', { day: '2-digit', month: 'short' })
+      : null
+    return (
+      <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium
+                       bg-violet-100 dark:bg-violet-950 text-violet-700 dark:text-violet-300
+                       border border-violet-300 dark:border-violet-800">
+        {formatted ? `Available from ${formatted}` : 'On project'}
+      </span>
+    )
+  }
+  return null
+}
+
+function AgencyChip({ name, logoPath }: { name: string | null; logoPath: string | null }) {
+  if (logoPath && name) {
+    return (
+      <img
+        src={logoPath}
+        alt={name}
+        width={20}
+        height={20}
+        className="rounded-full bg-zinc-200 dark:bg-zinc-800 object-contain flex-shrink-0"
+        title={name}
+      />
+    )
+  }
+  const initials = name ? name.slice(0, 2).toUpperCase() : '·'
+  return (
+    <span
+      className="inline-flex items-center justify-center rounded-full w-5 h-5 text-[10px] font-semibold
+                 bg-zinc-200 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300 flex-shrink-0"
+      title={name ?? 'No agency'}
+    >
+      {initials}
+    </span>
+  )
+}
+
+function ScoreBadge({ score, status }: { score: number | null; status: AutoMatchCandidate['scoreStatus'] }) {
+  if (status === 'failed') {
+    return (
+      <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium
+                       bg-red-100 dark:bg-red-950 text-red-700 dark:text-red-300
+                       border border-red-300 dark:border-red-800">
+        Scoring failed
+      </span>
+    )
+  }
+  if (score === null) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium
+                       bg-[var(--color-bg-input)] text-[var(--color-fg-muted)]
+                       border border-[var(--color-border)]">
+        <Loader2Icon className="h-3 w-3 animate-spin" />
+        Scoring…
+      </span>
+    )
+  }
+  const tone =
+    score >= 75
+      ? 'bg-emerald-100 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-300 border-emerald-300 dark:border-emerald-800'
+      : score >= 50
+        ? 'bg-blue-100 dark:bg-blue-950 text-blue-700 dark:text-blue-300 border-blue-300 dark:border-blue-800'
+        : 'bg-[var(--color-bg-input)] text-[var(--color-fg-muted)] border-[var(--color-border)]'
+  return (
+    <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold border ${tone}`}>
+      {score}/100
+    </span>
+  )
+}
+
+function CandidateCard({
+  candidate,
+  roleId,
+}: {
+  candidate: AutoMatchCandidate
+  roleId: string
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-lg
+                    bg-[var(--color-bg-input)] border border-[var(--color-border)]
+                    px-4 py-3">
+      <div className="flex items-center gap-3 min-w-0 flex-1">
+        <AgencyChip name={candidate.agencyName} logoPath={candidate.agencyLogoPath} />
+        <div className="min-w-0 flex-1">
+          <Link
+            href={`/dashboard/candidates/${candidate.id}?roleId=${roleId}`}
+            className="text-sm font-medium text-[var(--color-fg)] hover:text-violet-600 dark:hover:text-violet-300
+                       transition-colors truncate block"
+          >
+            {candidate.firstName} {candidate.lastName}
+          </Link>
+          <div className="flex items-center gap-2 mt-1 flex-wrap">
+            <AvailabilityBadge status={candidate.availabilityStatus} availableFrom={candidate.availableFrom} />
+            <RateMatchPill match={candidate.rateMatch} percent={candidate.rateOveragePercent} />
+          </div>
+        </div>
+      </div>
+      <div className="flex items-center gap-2 flex-shrink-0">
+        <ScoreBadge score={candidate.overallScore} status={candidate.scoreStatus} />
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Auto-match panel for the role detail page (epic #267 / issue #271).
+ *
+ * Polls /api/roles/{id}/auto-match-status until the orchestrator publishes
+ * a terminal audit row. Recruiter+ only — gate enforced by the parent page
+ * AND by the API route.
+ */
+export function ArchiveMatchesPanel({ roleId }: Props) {
+  const { data, isLoading } = useQuery<AutoMatchStatusResult>({
+    queryKey: ['auto-match-status', roleId],
+    queryFn: async () => {
+      const res = await fetch(`/api/roles/${roleId}/auto-match-status`)
+      if (!res.ok) {
+        return { status: 'idle', reason: null, candidates: [] }
+      }
+      return res.json()
+    },
+    refetchInterval: (query) => {
+      const status = query.state.data?.status
+      // Stop polling once we have a terminal state. Also stop polling for the
+      // idle case (role created before the feature shipped — no signal coming).
+      if (status === 'complete' || status === 'failed' || status === 'idle') return false
+      return POLL_INTERVAL_MS
+    },
+    refetchOnWindowFocus: false,
+  })
+
+  const status = data?.status ?? (isLoading ? 'pending' : 'idle')
+
+  if (status === 'idle') return null
+
+  return (
+    <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-6 mb-6">
+      <div className="flex items-center gap-2 mb-4">
+        <SparklesIcon className="h-4 w-4 text-violet-500 dark:text-violet-400" />
+        <h2 className="font-semibold text-[var(--color-fg)]">Top archive matches</h2>
+      </div>
+
+      {status === 'pending' && (
+        <div className="grid gap-2">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="flex items-center gap-3 rounded-lg bg-[var(--color-bg-input)] border border-[var(--color-border)]
+                         px-4 py-3 animate-pulse"
+            >
+              <div className="w-5 h-5 rounded-full bg-[var(--color-border)]" />
+              <div className="flex-1 space-y-1.5">
+                <div className="h-3 rounded bg-[var(--color-border)] w-1/3" />
+                <div className="h-2 rounded bg-[var(--color-border)] w-1/4" />
+              </div>
+            </div>
+          ))}
+          <p className="text-xs text-[var(--color-fg-subtle)] mt-1">
+            Scanning archive for matches…
+          </p>
+        </div>
+      )}
+
+      {status === 'failed' && data?.candidates && data.candidates.length > 0 && (
+        <div className="space-y-3">
+          <div className="flex items-start gap-2 rounded-lg bg-amber-50 dark:bg-amber-950/40
+                          border border-amber-300 dark:border-amber-800
+                          text-amber-900 dark:text-amber-200 px-3 py-2 text-xs">
+            <AlertTriangleIcon className="h-4 w-4 flex-shrink-0 mt-0.5" />
+            <p>
+              {data.reason === 'daily_cost_cap_exceeded'
+                ? 'Daily auto-match budget reached. Candidates listed below; scoring will resume tomorrow.'
+                : `Auto-match could not complete${data.reason ? `: ${data.reason}` : '.'}`}
+            </p>
+          </div>
+          <div className="grid gap-2">
+            {data.candidates.map((c) => (
+              <CandidateCard key={c.id} candidate={c} roleId={roleId} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {status === 'failed' && (!data?.candidates || data.candidates.length === 0) && (
+        <div className="flex items-start gap-2 rounded-lg bg-amber-50 dark:bg-amber-950/40
+                        border border-amber-300 dark:border-amber-800
+                        text-amber-900 dark:text-amber-200 px-3 py-2 text-xs">
+          <AlertTriangleIcon className="h-4 w-4 flex-shrink-0 mt-0.5" />
+          <p>
+            Auto-match could not complete{data?.reason ? `: ${data.reason}` : '.'} Try again
+            from the role action menu when ready.
+          </p>
+        </div>
+      )}
+
+      {status === 'complete' && data?.candidates && data.candidates.length === 0 && (
+        <p className="text-sm text-[var(--color-fg-subtle)]">
+          No archive matches found. Try widening the budget or relaxing the requirements.
+        </p>
+      )}
+
+      {status === 'complete' && data?.candidates && data.candidates.length > 0 && (
+        <div className="grid gap-2">
+          {data.candidates.map((c) => (
+            <CandidateCard key={c.id} candidate={c} roleId={roleId} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/tests/unit/actions/auto-match-status.test.ts
+++ b/tests/unit/actions/auto-match-status.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Unit tests for src/actions/auto-match-status.ts
+ *
+ * Covers getAutoMatchStatus — the read action that backs the
+ * ArchiveMatchesPanel polling endpoint (epic #267 / issue #271). Reads the
+ * latest auto-match audit row, joins candidate + score + agency rows,
+ * derives rateMatch from current rates rather than persisted state.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const TENANT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const USER_ID   = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const ROLE_ID   = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+
+function makeSelectChain(rows: unknown[]) {
+  const c: Record<string, unknown> = {}
+  const resolved = Promise.resolve(rows)
+  c.then     = resolved.then.bind(resolved)
+  c.catch    = resolved.catch.bind(resolved)
+  c.from     = vi.fn(() => c)
+  c.leftJoin = vi.fn(() => c)
+  c.where    = vi.fn(() => c)
+  c.orderBy  = vi.fn(() => c)
+  c.limit    = vi.fn(() => Promise.resolve(rows))
+  return c
+}
+
+// Each withTenant() call consumes one entry from this queue
+let selectQueue: unknown[][] = []
+let selectCount = 0
+
+vi.mock('@/db', () => ({
+  db: {},
+  withTenant: vi.fn().mockImplementation(
+    async (_tenantId: string, fn: (tx: unknown) => unknown) => {
+      const rows = selectQueue[selectCount] ?? []
+      selectCount++
+      const tx = {
+        select: vi.fn(() => makeSelectChain(rows)),
+      }
+      return fn(tx)
+    },
+  ),
+}))
+
+vi.mock('@/db/schema', () => ({
+  auditLogs: {
+    action: 'action', tenantId: 'tenant_id', entityType: 'entity_type',
+    entityId: 'entity_id', metadata: 'metadata', createdAt: 'created_at',
+  },
+  candidates: {
+    id: 'id', tenantId: 'tenant_id', firstName: 'first_name', lastName: 'last_name',
+    candidateRate: 'candidate_rate', rateCurrency: 'rate_currency',
+    availabilityStatus: 'availability_status', availableFrom: 'available_from',
+    agencyId: 'agency_id',
+  },
+  agencies: { id: 'id', name: 'name', logoPath: 'logo_path' },
+  scores: {
+    candidateId: 'candidate_id', roleId: 'role_id',
+    overallScore: 'overall_score', scoreStatus: 'score_status',
+  },
+  roles: {
+    id: 'id', tenantId: 'tenant_id',
+    customerDayRate: 'customer_day_rate', rateCurrency: 'rate_currency',
+  },
+}))
+
+vi.mock('drizzle-orm', () => ({
+  eq:       vi.fn(() => ({ type: 'eq' })),
+  and:      vi.fn((...args: unknown[]) => ({ type: 'and', args })),
+  inArray:  vi.fn(() => ({ type: 'inArray' })),
+  desc:     vi.fn(() => ({ type: 'desc' })),
+  sql:      vi.fn(() => ({ type: 'sql' })),
+}))
+
+const mockGetActionContext = vi.fn()
+vi.mock('@/lib/auth/action-context', () => ({
+  getActionContext: () => mockGetActionContext(),
+}))
+
+function recruiterCtx() {
+  return { tenantId: TENANT_ID, userId: USER_ID, userRole: 'recruiter' as const }
+}
+
+function resetState() {
+  selectQueue = []
+  selectCount = 0
+}
+
+describe('getAutoMatchStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetState()
+    mockGetActionContext.mockResolvedValue(recruiterCtx())
+  })
+
+  it('returns idle when no auth context', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { getAutoMatchStatus } = await import('@/actions/auto-match-status')
+
+    const result = await getAutoMatchStatus(ROLE_ID)
+
+    expect(result.status).toBe('idle')
+    expect(result.candidates).toEqual([])
+  })
+
+  it('returns idle when no audit row exists', async () => {
+    selectQueue = [[]] // audit lookup empty
+    const { getAutoMatchStatus } = await import('@/actions/auto-match-status')
+
+    const result = await getAutoMatchStatus(ROLE_ID)
+
+    expect(result.status).toBe('idle')
+  })
+
+  it('returns pending when most-recent audit row is auto_match_started', async () => {
+    selectQueue = [[{ action: 'role.auto_match_started', metadata: null }]]
+    const { getAutoMatchStatus } = await import('@/actions/auto-match-status')
+
+    const result = await getAutoMatchStatus(ROLE_ID)
+
+    expect(result.status).toBe('pending')
+    expect(result.candidates).toEqual([])
+  })
+
+  it('returns complete with empty candidates when scoredCandidateIds is empty', async () => {
+    selectQueue = [
+      [{
+        action: 'role.auto_match_completed',
+        metadata: { scoredCandidateIds: [], candidateIds: [], survivorCount: 0 },
+      }],
+    ]
+    const { getAutoMatchStatus } = await import('@/actions/auto-match-status')
+
+    const result = await getAutoMatchStatus(ROLE_ID)
+
+    expect(result.status).toBe('complete')
+    expect(result.candidates).toEqual([])
+  })
+
+  it('returns failed with reason on cap-exceeded path including candidates', async () => {
+    selectQueue = [
+      [{
+        action: 'role.auto_match_failed',
+        metadata: {
+          reason: 'daily_cost_cap_exceeded',
+          candidateIds: ['c-1'],
+        },
+      }],
+      // Role lookup
+      [{ customerDayRate: '500', rateCurrency: 'GBP' }],
+      // Candidate row
+      [{
+        id: 'c-1',
+        firstName: 'Alice',
+        lastName: 'Walker',
+        candidateRate: '450',
+        rateCurrency: 'GBP',
+        availabilityStatus: 'available',
+        availableFrom: null,
+        agencyName: 'Acme',
+        agencyLogoPath: '/uploads/acme.png',
+      }],
+      // Scores
+      [],
+    ]
+    const { getAutoMatchStatus } = await import('@/actions/auto-match-status')
+
+    const result = await getAutoMatchStatus(ROLE_ID)
+
+    expect(result.status).toBe('failed')
+    expect(result.reason).toBe('daily_cost_cap_exceeded')
+    expect(result.candidates).toHaveLength(1)
+    expect(result.candidates[0]).toMatchObject({
+      id: 'c-1',
+      firstName: 'Alice',
+      rateMatch: 'within',
+      agencyName: 'Acme',
+    })
+  })
+
+  it('returns failed with empty candidates on internal-error path', async () => {
+    selectQueue = [
+      [{
+        action: 'role.auto_match_failed',
+        metadata: { error: 'pgvector unavailable' },
+      }],
+    ]
+    const { getAutoMatchStatus } = await import('@/actions/auto-match-status')
+
+    const result = await getAutoMatchStatus(ROLE_ID)
+
+    expect(result.status).toBe('failed')
+    expect(result.candidates).toEqual([])
+  })
+
+  it('derives rateMatch=within when candidate rate <= role budget', async () => {
+    selectQueue = [
+      [{
+        action: 'role.auto_match_completed',
+        metadata: { scoredCandidateIds: ['c-1'] },
+      }],
+      [{ customerDayRate: '500', rateCurrency: 'GBP' }],
+      [{
+        id: 'c-1', firstName: 'A', lastName: 'B',
+        candidateRate: '450', rateCurrency: 'GBP',
+        availabilityStatus: 'available', availableFrom: null,
+        agencyName: null, agencyLogoPath: null,
+      }],
+      [{ candidateId: 'c-1', overallScore: 88, scoreStatus: 'complete' }],
+    ]
+    const { getAutoMatchStatus } = await import('@/actions/auto-match-status')
+
+    const result = await getAutoMatchStatus(ROLE_ID)
+
+    expect(result.candidates[0].rateMatch).toBe('within')
+    expect(result.candidates[0].overallScore).toBe(88)
+    expect(result.candidates[0].scoreStatus).toBe('complete')
+  })
+
+  it('derives rateMatch=over with overage percent when candidate over budget', async () => {
+    selectQueue = [
+      [{
+        action: 'role.auto_match_completed',
+        metadata: { scoredCandidateIds: ['c-1'] },
+      }],
+      [{ customerDayRate: '500', rateCurrency: 'GBP' }],
+      [{
+        id: 'c-1', firstName: 'A', lastName: 'B',
+        candidateRate: '550', rateCurrency: 'GBP',
+        availabilityStatus: 'available', availableFrom: null,
+        agencyName: null, agencyLogoPath: null,
+      }],
+      [{ candidateId: 'c-1', overallScore: 70, scoreStatus: 'complete' }],
+    ]
+    const { getAutoMatchStatus } = await import('@/actions/auto-match-status')
+
+    const result = await getAutoMatchStatus(ROLE_ID)
+
+    expect(result.candidates[0].rateMatch).toBe('over')
+    expect(result.candidates[0].rateOveragePercent).toBe(10)
+  })
+
+  it('derives rateMatch=currency_mismatch when currencies differ', async () => {
+    selectQueue = [
+      [{
+        action: 'role.auto_match_completed',
+        metadata: { scoredCandidateIds: ['c-1'] },
+      }],
+      [{ customerDayRate: '500', rateCurrency: 'GBP' }],
+      [{
+        id: 'c-1', firstName: 'A', lastName: 'B',
+        candidateRate: '450', rateCurrency: 'EUR',
+        availabilityStatus: 'available', availableFrom: null,
+        agencyName: null, agencyLogoPath: null,
+      }],
+      [{ candidateId: 'c-1', overallScore: 80, scoreStatus: 'complete' }],
+    ]
+    const { getAutoMatchStatus } = await import('@/actions/auto-match-status')
+
+    const result = await getAutoMatchStatus(ROLE_ID)
+
+    expect(result.candidates[0].rateMatch).toBe('currency_mismatch')
+  })
+
+  it('derives rateMatch=unknown when budget or candidate rate is missing', async () => {
+    selectQueue = [
+      [{
+        action: 'role.auto_match_completed',
+        metadata: { scoredCandidateIds: ['c-1'] },
+      }],
+      [{ customerDayRate: null, rateCurrency: null }],
+      [{
+        id: 'c-1', firstName: 'A', lastName: 'B',
+        candidateRate: null, rateCurrency: null,
+        availabilityStatus: 'available', availableFrom: null,
+        agencyName: null, agencyLogoPath: null,
+      }],
+      [{ candidateId: 'c-1', overallScore: 90, scoreStatus: 'complete' }],
+    ]
+    const { getAutoMatchStatus } = await import('@/actions/auto-match-status')
+
+    const result = await getAutoMatchStatus(ROLE_ID)
+
+    expect(result.candidates[0].rateMatch).toBe('unknown')
+  })
+
+  it('preserves the order of candidateIds from audit metadata (not DB row order)', async () => {
+    // Audit IDs in order: c-3, c-1, c-2.  Candidate rows come back unordered.
+    selectQueue = [
+      [{
+        action: 'role.auto_match_completed',
+        metadata: { scoredCandidateIds: ['c-3', 'c-1', 'c-2'] },
+      }],
+      [{ customerDayRate: '500', rateCurrency: 'GBP' }],
+      [
+        { id: 'c-1', firstName: 'One', lastName: 'X', candidateRate: '450', rateCurrency: 'GBP',
+          availabilityStatus: 'available', availableFrom: null, agencyName: null, agencyLogoPath: null },
+        { id: 'c-2', firstName: 'Two', lastName: 'X', candidateRate: '460', rateCurrency: 'GBP',
+          availabilityStatus: 'available', availableFrom: null, agencyName: null, agencyLogoPath: null },
+        { id: 'c-3', firstName: 'Three', lastName: 'X', candidateRate: '470', rateCurrency: 'GBP',
+          availabilityStatus: 'available', availableFrom: null, agencyName: null, agencyLogoPath: null },
+      ],
+      [
+        { candidateId: 'c-1', overallScore: 70, scoreStatus: 'complete' },
+        { candidateId: 'c-2', overallScore: 75, scoreStatus: 'complete' },
+        { candidateId: 'c-3', overallScore: 80, scoreStatus: 'complete' },
+      ],
+    ]
+    const { getAutoMatchStatus } = await import('@/actions/auto-match-status')
+
+    const result = await getAutoMatchStatus(ROLE_ID)
+
+    expect(result.candidates.map((c) => c.id)).toEqual(['c-3', 'c-1', 'c-2'])
+  })
+})


### PR DESCRIPTION
Closes #271. Fourth slice of epic #267 (follows merged #268 + #269 + #270). This is the first user-visible piece — the recruiter now sees the top-3 archive matches without leaving the role detail page.

## Summary

- **`getAutoMatchStatus(roleId)`** — reads the latest auto-match audit row for a role, joins to candidates / scores / agencies, returns a serializable shape for the UI. Re-derives `rateMatch` from current rate fields at query time (not from persisted state) so rate edits surface immediately without a re-run.
- **`/api/roles/[roleId]/auto-match-status`** — recruiter+ poll endpoint; defence-in-depth alongside the panel's audience gate.
- **`<ArchiveMatchesPanel>`** — client component using `useQuery` with 3s `refetchInterval`. Terminal-state stop (complete / failed / idle). Skeleton loading state during `pending`. Distinct empty / cap-exceeded / generic-failed copy.
- **Mounted in role detail page** above `SuggestCandidatesPanel`, gated on `audience === 'recruiter'`.

## UX behaviour

- **Pending**: three skeleton card rows + "Scanning archive for matches…" caption.
- **Complete with candidates**: cards show agency chip (logo or initials fallback), name, availability badge, rate-fit pill, and overall score badge. Score badge animates while individual scores are still landing (the orchestrator audits "completed" once survivors are picked even if scoring takes another few seconds).
- **Complete empty**: "No archive matches found. Try widening the budget or relaxing the requirements."
- **Failed with cap reason**: amber banner ("Daily auto-match budget reached. Candidates listed below; scoring will resume tomorrow.") + the survivor cards (cap path still surfaces them).
- **Failed without candidates** (internal error): amber banner alone.
- **Idle** (role created pre-feature, no audit row): renders nothing — zero banner clutter.

## Architecture notes

- Polling stops on `complete` / `failed` / `idle` so the panel doesn't burn cycles after the orchestrator is done.
- Candidate order in the response preserves the audit-metadata order (similarity ranking from prefilter), not DB row order.
- Score badge derives from the current `scores.scoreStatus` column — `failed` shows a red "Scoring failed" pill instead of the spinner so partial failures are visible.
- `rateMatch` defensively re-computes for >25%-over candidates even though prefilter should have excluded them, so an out-of-sync UI never crashes.

## Files

- `src/actions/auto-match-status.ts` (new)
- `src/app/api/roles/[roleId]/auto-match-status/route.ts` (new)
- `src/components/roles/archive-matches-panel.tsx` (new)
- `tests/unit/actions/auto-match-status.test.ts` (new — 11 tests)
- `src/app/(dashboard)/dashboard/roles/[roleId]/page.tsx` (mounted the panel + import)

## Test plan

- [x] `npm test -- tests/unit/actions/auto-match-status.test.ts` — 11/11 pass
- [x] `npm test -- tests/unit/actions/auto-match-status.test.ts tests/unit/actions/roles.test.ts tests/unit/actions/auto-match.test.ts tests/unit/lib/auto-match` — 69/69 pass (no regression on adjacent suites)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed paths — only lint output is the `<img>` warning on the agency chip, which matches existing pattern in `src/components/candidates/selectable-candidate-list.tsx` (per CLAUDE.md theme rules: 20px agency logo + initials fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)