### PR TITLE
feat(skills): aggregation query + /dashboard/skills page (#272)

### DIFF
--- a/src/actions/skills.ts
+++ b/src/actions/skills.ts
@@ -1,0 +1,95 @@
+'use server'
+
+import { sql } from 'drizzle-orm'
+import { withTenant } from '@/db'
+import { getActionContext } from '@/lib/auth/action-context'
+import { hasRole } from '@/lib/auth/require-role'
+
+export type SkillAggregate = {
+  /** Lowercased + trimmed grouping key (e.g. "react") */
+  skillKey: string
+  /** Most-frequent original casing in the data (e.g. "React") */
+  displayName: string
+  /** Distinct candidates with this skill in their cv_profile */
+  candidateCount: number
+}
+
+type AggregateRow = {
+  skill_key: string
+  display_name: string
+  candidate_count: string | number
+}
+
+/**
+ * Aggregates skills across all candidates in the current tenant. Skills are
+ * grouped case-insensitively (`lower(trim(skill))`) so "React", "react" and
+ * " REACT " collapse into one entry; the display_name is the casing variant
+ * that appears most often in the data.
+ *
+ * Only complete cv_profile rows count — a candidate whose extraction is still
+ * pending or has failed contributes no skills (would otherwise undercount and
+ * surface stale partials).
+ *
+ * Recruiter+ only — skills are not customer / manager / viewer scope.
+ */
+export async function getUniqueSkillsWithCandidateCounts(): Promise<SkillAggregate[]> {
+  const ctx = await getActionContext()
+  if (!ctx) return []
+  const { tenantId, userRole } = ctx
+
+  if (!hasRole(userRole, 'recruiter')) return []
+
+  const rows = await withTenant(tenantId, async (tx) =>
+    tx.execute(sql`
+      WITH unnested AS (
+        SELECT
+          candidate_id,
+          jsonb_array_elements_text(technical_skills) AS skill_raw
+        FROM cv_profiles
+        WHERE tenant_id = current_setting('app.tenant_id', true)::uuid
+          AND extraction_status = 'complete'
+      ),
+      keyed AS (
+        SELECT
+          lower(trim(skill_raw)) AS skill_key,
+          trim(skill_raw)        AS skill_original,
+          candidate_id
+        FROM unnested
+        WHERE length(trim(skill_raw)) > 0
+      ),
+      original_counts AS (
+        SELECT
+          skill_key,
+          skill_original,
+          COUNT(*)                       AS occurrences,
+          ROW_NUMBER() OVER (
+            PARTITION BY skill_key
+            ORDER BY COUNT(*) DESC, skill_original ASC
+          )                              AS rn
+        FROM keyed
+        GROUP BY skill_key, skill_original
+      ),
+      candidate_counts AS (
+        SELECT
+          skill_key,
+          COUNT(DISTINCT candidate_id) AS candidate_count
+        FROM keyed
+        GROUP BY skill_key
+      )
+      SELECT
+        cc.skill_key,
+        oc.skill_original AS display_name,
+        cc.candidate_count
+      FROM candidate_counts cc
+      INNER JOIN original_counts oc
+        ON oc.skill_key = cc.skill_key AND oc.rn = 1
+      ORDER BY cc.candidate_count DESC, cc.skill_key ASC
+    `),
+  )
+
+  return (Array.from(rows) as AggregateRow[]).map((r) => ({
+    skillKey: r.skill_key,
+    displayName: r.display_name,
+    candidateCount: Number(r.candidate_count),
+  }))
+}

--- a/src/app/(dashboard)/dashboard/skills/page.tsx
+++ b/src/app/(dashboard)/dashboard/skills/page.tsx
@@ -1,0 +1,89 @@
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { SparklesIcon } from 'lucide-react'
+import { auth } from '@/lib/auth'
+import { hasRole } from '@/lib/auth/require-role'
+import { getUniqueSkillsWithCandidateCounts } from '@/actions/skills'
+
+export const metadata = { title: 'Skills — SkillAI' }
+
+// DO NOT REMOVE — Next 16.2 + React 19 prerender bug (#41 workaround). Any new
+// route under (dashboard)/ whose layout renders a context-using client
+// component at module scope must opt out of prerender or `next build` will
+// throw `useContext null` for the static path. Remove only when upstream Next
+// ships a fix.
+export const dynamic = 'force-dynamic'
+
+export default async function SkillsPage() {
+  const session = await auth()
+  if (!session?.user?.tenantId) redirect('/login')
+
+  const userRole = (session.user as { role?: string }).role
+  if (!hasRole((userRole ?? 'viewer') as 'admin' | 'recruiter' | 'hiring_manager' | 'viewer', 'recruiter')) {
+    return (
+      <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-8 text-center">
+        <h1 className="text-lg font-medium text-[var(--color-fg)] mb-2">Recruiter access required</h1>
+        <p className="text-sm text-[var(--color-fg-muted)]">
+          The Skills Explorer is only available to recruiters and admins.
+        </p>
+      </div>
+    )
+  }
+
+  const skills = await getUniqueSkillsWithCandidateCounts()
+  const candidateTotal = skills.reduce((acc, s) => Math.max(acc, s.candidateCount), 0)
+
+  return (
+    <div className="space-y-6">
+      <header className="flex items-center justify-between gap-4 flex-wrap">
+        <div className="flex items-center gap-3">
+          <SparklesIcon className="h-5 w-5 text-violet-500 dark:text-violet-400" />
+          <h1 className="text-xl font-semibold text-[var(--color-fg)]">Skills</h1>
+        </div>
+        <p className="text-sm text-[var(--color-fg-muted)]">
+          {skills.length === 0
+            ? 'No skills extracted yet.'
+            : `${skills.length} skill${skills.length === 1 ? '' : 's'} across the candidate archive — click a chip to filter.`}
+        </p>
+      </header>
+
+      <div className="bg-[var(--color-bg-elevated)] rounded-xl border border-[var(--color-border)] p-6">
+        {skills.length === 0 ? (
+          <div className="text-center py-8">
+            <p className="text-sm text-[var(--color-fg-muted)] mb-1">
+              Skills will appear here automatically once CVs have been processed.
+            </p>
+            <p className="text-xs text-[var(--color-fg-subtle)]">
+              New uploads typically take 30 to 60 seconds to extract.
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-wrap gap-2">
+            {skills.map((skill) => (
+              <Link
+                key={skill.skillKey}
+                href={`/dashboard/candidates?skills=${encodeURIComponent(skill.displayName)}`}
+                className="inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-sm
+                           bg-blue-100 dark:bg-blue-950 text-blue-700 dark:text-blue-300
+                           border border-blue-300 dark:border-blue-800
+                           hover:bg-blue-200 dark:hover:bg-blue-900 transition-colors"
+              >
+                <span className="font-medium">{skill.displayName}</span>
+                <span className="text-xs text-blue-600 dark:text-blue-400 font-semibold">
+                  {skill.candidateCount}
+                </span>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {candidateTotal > 0 && (
+        <p className="text-xs text-[var(--color-fg-subtle)]">
+          Skills are extracted from candidate CVs in the background. Chip counts reflect distinct
+          candidates per skill (case-insensitive grouping).
+        </p>
+      )}
+    </div>
+  )
+}

--- a/tests/unit/actions/skills.test.ts
+++ b/tests/unit/actions/skills.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for src/actions/skills.ts
+ *
+ * Covers getUniqueSkillsWithCandidateCounts — the aggregation query backing
+ * the Skills Explorer (epic #267 / issue #272). Uses raw SQL via tx.execute()
+ * so the mock just returns canned aggregate rows.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const TENANT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const USER_ID   = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+
+let executeResult: unknown[] = []
+
+vi.mock('@/db', () => ({
+  db: {},
+  withTenant: vi.fn().mockImplementation(
+    async (_tenantId: string, fn: (tx: unknown) => unknown) => {
+      const tx = {
+        execute: vi.fn(() => Promise.resolve(executeResult)),
+      }
+      return fn(tx)
+    },
+  ),
+}))
+
+vi.mock('drizzle-orm', () => ({
+  sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
+    type: 'sql',
+    strings,
+    values,
+  })),
+}))
+
+const mockGetActionContext = vi.fn()
+vi.mock('@/lib/auth/action-context', () => ({
+  getActionContext: () => mockGetActionContext(),
+}))
+
+function ctx(role: 'admin' | 'recruiter' | 'hiring_manager' | 'viewer') {
+  return { tenantId: TENANT_ID, userId: USER_ID, userRole: role }
+}
+
+describe('getUniqueSkillsWithCandidateCounts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    executeResult = []
+    mockGetActionContext.mockResolvedValue(ctx('recruiter'))
+  })
+
+  it('returns [] when unauthenticated', async () => {
+    mockGetActionContext.mockResolvedValue(null)
+    const { getUniqueSkillsWithCandidateCounts } = await import('@/actions/skills')
+
+    const result = await getUniqueSkillsWithCandidateCounts()
+
+    expect(result).toEqual([])
+  })
+
+  it('returns [] for viewer role (below recruiter)', async () => {
+    mockGetActionContext.mockResolvedValue(ctx('viewer'))
+    const { getUniqueSkillsWithCandidateCounts } = await import('@/actions/skills')
+
+    const result = await getUniqueSkillsWithCandidateCounts()
+
+    expect(result).toEqual([])
+  })
+
+  it('returns [] for hiring_manager role (below recruiter)', async () => {
+    mockGetActionContext.mockResolvedValue(ctx('hiring_manager'))
+    const { getUniqueSkillsWithCandidateCounts } = await import('@/actions/skills')
+
+    const result = await getUniqueSkillsWithCandidateCounts()
+
+    expect(result).toEqual([])
+  })
+
+  it('returns [] when no skills aggregate', async () => {
+    executeResult = []
+    const { getUniqueSkillsWithCandidateCounts } = await import('@/actions/skills')
+
+    const result = await getUniqueSkillsWithCandidateCounts()
+
+    expect(result).toEqual([])
+  })
+
+  it('maps aggregate rows to SkillAggregate shape with Number coercion', async () => {
+    executeResult = [
+      { skill_key: 'react',      display_name: 'React',      candidate_count: '27' },
+      { skill_key: 'typescript', display_name: 'TypeScript', candidate_count: 19 },
+      { skill_key: 'rust',       display_name: 'Rust',       candidate_count: '4' },
+    ]
+    const { getUniqueSkillsWithCandidateCounts } = await import('@/actions/skills')
+
+    const result = await getUniqueSkillsWithCandidateCounts()
+
+    expect(result).toEqual([
+      { skillKey: 'react',      displayName: 'React',      candidateCount: 27 },
+      { skillKey: 'typescript', displayName: 'TypeScript', candidateCount: 19 },
+      { skillKey: 'rust',       displayName: 'Rust',       candidateCount: 4 },
+    ])
+  })
+
+  it('works for admin role too', async () => {
+    mockGetActionContext.mockResolvedValue(ctx('admin'))
+    executeResult = [{ skill_key: 'go', display_name: 'Go', candidate_count: '12' }]
+    const { getUniqueSkillsWithCandidateCounts } = await import('@/actions/skills')
+
+    const result = await getUniqueSkillsWithCandidateCounts()
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({ skillKey: 'go', displayName: 'Go', candidateCount: 12 })
+  })
+})


### PR DESCRIPTION
Closes #272. Fifth slice of epic #267.

## Summary

A recruiter+ landing page that turns the existing `cv_profiles.technical_skills` data into clickable keyword chips. Click a chip → URL navigates to `/dashboard/candidates?skills=<name>` (the candidate list will start honouring the param in #273; until that lands the URL just navigates and the filter is silently ignored).

## Aggregation

- Raw SQL inside `withTenant()` — unnests the JSONB array, groups case-insensitively via `lower(trim(skill))` so `React` / `react` / `" REACT "` collapse into one row.
- `display_name` is the **most-frequent original casing** for that key (deterministic — ties broken alphabetically).
- Only `cv_profile.extraction_status = 'complete'` rows count; in-flight extractions don't undercount or surface partials.
- Sorted by `candidate_count DESC, skill_key ASC` — most common skills first.

## Auth

Three layers:
1. Server component — `redirect('/login')` for no session, plain copy for non-recruiter/admin
2. Server action `getUniqueSkillsWithCandidateCounts` — second `hasRole` check; returns `[]` instead of throwing so the page just renders the empty state defensively
3. Tenant RLS via `withTenant()` — cross-tenant data leakage impossible at the DB level

## UX

- Header shows total skill count
- Chips in the blue token convention (`bg-blue-100 dark:bg-blue-950` etc.) matching the existing status-pill styling cited in CLAUDE.md
- Each chip: skill name + small inline count
- Empty state explains the 30–60s extraction lag for new uploads
- Footnote on case-insensitive grouping so recruiters understand why "React" and "react" aren't separate rows

## Files

- `src/actions/skills.ts` (new)
- `src/app/(dashboard)/dashboard/skills/page.tsx` (new — with `export const dynamic = 'force-dynamic'` per #41 workaround)
- `tests/unit/actions/skills.test.ts` (new — 6 tests)

## Test plan

- [x] `npm test -- tests/unit/actions/skills.test.ts` — 6/6 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed paths — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)