### PR TITLE
feat(backstage): catalog entity + TechDocs synced from GitHub Pages

### DIFF
--- a/.github/workflows/techdocs.yml
+++ b/.github/workflows/techdocs.yml
@@ -1,0 +1,127 @@
+# techdocs.yml
+#
+# Keeps Backstage TechDocs in sync with the public GitHub Pages documentation.
+#
+# The canonical docs source is the Astro/Starlight site under `docs-site/`. This
+# workflow regenerates the auto-derived content (OpenAPI / MCP catalogue / DB
+# schema) and runs scripts/sync-techdocs.mjs to mirror everything into MkDocs
+# markdown (`techdocs/` + `mkdocs.yml`) that Backstage's TechDocs generator
+# consumes via `techdocs-ref: dir:.` in catalog-info.yaml.
+#
+# Behaviour:
+#   - pull_request : regenerate + a `techdocs-cli build` validation, then a DRIFT
+#                    GATE — fails if the committed `techdocs/` is stale, telling
+#                    the author to run `npm run techdocs:sync`.
+#   - push / manual: regenerate + build-validate, then AUTO-COMMIT any drift back
+#                    to the branch so Backstage always serves current docs.
+#
+# Loop-safety: the auto-commit touches `techdocs/**` + `mkdocs.yml`, neither of
+# which is a trigger path, and the commit carries `[skip ci]`.
+
+name: TechDocs
+
+on:
+  push:
+    branches:
+      - core-mvp-foundation
+    paths:
+      - 'docs-site/**'
+      - 'docs/**'
+      - 'src/lib/mcp/**'
+      - 'src/lib/api/openapi.ts'
+      - 'src/db/schema/**'
+      - 'scripts/sync-techdocs.mjs'
+      - 'scripts/generate-mcp-tools-doc.ts'
+      - 'catalog-info.yaml'
+      - '.github/workflows/techdocs.yml'
+  pull_request:
+    branches:
+      - core-mvp-foundation
+    paths:
+      - 'docs-site/**'
+      - 'docs/**'
+      - 'src/lib/mcp/**'
+      - 'src/lib/api/openapi.ts'
+      - 'src/db/schema/**'
+      - 'scripts/sync-techdocs.mjs'
+      - 'scripts/generate-mcp-tools-doc.ts'
+      - 'catalog-info.yaml'
+      - '.github/workflows/techdocs.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: techdocs-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write # auto-commit synced TechDocs on push
+
+jobs:
+  sync:
+    name: Sync & validate TechDocs
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Check out the branch head (not the detached merge ref) so we can push.
+          ref: ${{ github.head_ref || github.ref_name }}
+
+      - name: Setup Node 22 LTS
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Setup Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install root dependencies (for parent route imports + tsx walker)
+        run: npm ci --no-audit --no-fund --ignore-scripts
+
+      - name: Install docs-site dependencies
+        working-directory: docs-site
+        run: npm ci --no-audit --no-fund
+
+      - name: Install TechDocs MkDocs toolchain
+        run: pip install mkdocs-techdocs-core==1.* mkdocs-material
+
+      - name: Regenerate + sync TechDocs from GitHub Pages source
+        env:
+          # Stubs — the postgres driver is lazy and never connects during gen.
+          DATABASE_URL: postgresql://placeholder:placeholder@localhost:5432/placeholder
+          AUTH_SECRET: docs-build-stub-secret-do-not-use
+          NEXTAUTH_SECRET: docs-build-stub-secret-do-not-use
+          ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          SKIP_ENV_VALIDATION: '1'
+          NODE_ENV: production
+        run: npm run techdocs:sync
+
+      - name: Validate TechDocs build (techdocs-cli, no Docker)
+        run: npx -y @techdocs/cli@1 build --no-docker --output-dir /tmp/techdocs-site
+
+      - name: Drift gate (pull requests)
+        if: github.event_name == 'pull_request'
+        run: |
+          if [ -n "$(git status --porcelain techdocs mkdocs.yml)" ]; then
+            echo "::error::TechDocs is out of sync with docs-site/. Run 'npm run techdocs:sync' locally and commit techdocs/ + mkdocs.yml."
+            git --no-pager diff --stat -- techdocs mkdocs.yml
+            exit 1
+          fi
+          echo "TechDocs is in sync."
+
+      - name: Auto-commit synced TechDocs (push / manual)
+        if: github.event_name != 'pull_request'
+        run: |
+          if [ -n "$(git status --porcelain techdocs mkdocs.yml)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add techdocs mkdocs.yml
+            git commit -m "docs(techdocs): sync from GitHub Pages source [skip ci]"
+            git push
+            echo "Committed synced TechDocs."
+          else
+            echo "TechDocs already in sync — nothing to commit."
+          fi

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,107 @@
+# catalog-info.yaml — Backstage Software Catalog descriptor for SkillAI.
+#
+# Registers SkillAI as a Component with TechDocs (techdocs-ref: dir:.), plus the
+# REST API it exposes and the PostgreSQL resource it depends on. TechDocs is
+# built from `mkdocs.yml` + `techdocs/` at the repo root, which is kept in sync
+# with the public GitHub Pages site by scripts/sync-techdocs.mjs (see the Docs
+# CI workflow). Source branch is `core-mvp-foundation` (the repo default).
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: skillai
+  title: SkillAI
+  description: Internal AI-powered recruiting portal — ranks and archives candidates against job roles using Claude and Gemini, with explainable per-dimension scoring.
+  annotations:
+    backstage.io/techdocs-ref: dir:.
+    backstage.io/source-location: url:https://github.com/olafkfreund/SkillAi/tree/core-mvp-foundation/
+    github.com/project-slug: olafkfreund/SkillAi
+  tags:
+    - nextjs
+    - typescript
+    - postgres
+    - pgvector
+    - drizzle
+    - docker
+    - ai
+    - llm
+    - claude
+    - mcp
+    - recruiting
+  links:
+    - url: https://olafkfreund.github.io/SkillAi
+      title: Documentation site (GitHub Pages)
+      icon: docs
+    - url: https://github.com/olafkfreund/SkillAi
+      title: Source repository
+      icon: github
+spec:
+  type: service
+  lifecycle: production
+  owner: olafkfreund
+  providesApis:
+    - skillai-rest-api
+    - skillai-mcp
+  dependsOn:
+    - resource:skillai-db
+---
+# REST API parity layer — 36 HTTP routes wrapping the server actions, described
+# by the OpenAPI 3.1 spec served at /api/openapi.json.
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: skillai-rest-api
+  title: SkillAI REST API
+  description: Bearer-token REST API (OpenAPI 3.1) covering candidate, role, agency, customer, scoring, interview and export operations. Auth via skl_* API tokens with read/write/admin scopes and per-tenant rate limiting.
+  annotations:
+    github.com/project-slug: olafkfreund/SkillAi
+  tags:
+    - rest
+    - openapi
+spec:
+  type: openapi
+  lifecycle: production
+  owner: olafkfreund
+  definition:
+    $text: https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/docs-site/src/data/openapi.json
+---
+# Model Context Protocol server exposed at /api/mcp (streamable-HTTP) plus the
+# standalone skillai-mcp stdio bridge. 48 tools / 4 resources / 3 prompts.
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: skillai-mcp
+  title: SkillAI MCP Server
+  description: Model Context Protocol server (48 tools across 12 modules, 4 resources, 3 prompts) hosted at /api/mcp and via the skillai-mcp stdio bridge. Bearer-token auth, scope checks, per-call audit log.
+  annotations:
+    github.com/project-slug: olafkfreund/SkillAi
+  tags:
+    - mcp
+    - claude
+spec:
+  type: grpc
+  lifecycle: production
+  owner: olafkfreund
+  definition: |
+    SkillAI MCP server — streamable-HTTP transport at /api/mcp.
+    Tools: candidates, roles, agencies, customers, scoring, interviews,
+    approvals, managers, notes, users, settings, exports.
+    See https://olafkfreund.github.io/SkillAi/mcp-server/overview for the
+    full catalogue and connection instructions.
+---
+# Primary datastore — PostgreSQL 17 + pgvector (HNSW), multi-tenant via RLS.
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: skillai-db
+  title: SkillAI PostgreSQL
+  description: PostgreSQL 17 with the pgvector extension (HNSW index for candidate semantic search). Multi-tenant isolation enforced via Row-Level Security and a per-request app.tenant_id session variable.
+  annotations:
+    github.com/project-slug: olafkfreund/SkillAi
+  tags:
+    - postgres
+    - pgvector
+    - database
+spec:
+  type: database
+  lifecycle: production
+  owner: olafkfreund

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,110 @@
+# mkdocs.yml — Backstage TechDocs configuration for SkillAI.
+#
+# GENERATED FILE — do not edit by hand. Regenerate with: npm run techdocs:sync
+# The nav + page content mirror the public GitHub Pages site (docs-site/).
+# Backstage builds this via the TechDocs generator (techdocs-ref: dir:. in
+# catalog-info.yaml), which runs `mkdocs build` against this repo.
+
+site_name: SkillAI
+site_description: Internal AI-powered recruiting portal — ranks candidates fast, archives them forever, integrates with Claude.
+docs_dir: techdocs
+repo_url: https://github.com/olafkfreund/SkillAi
+edit_uri: edit/core-mvp-foundation/docs-site/src/content/docs/
+
+theme:
+  name: material
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - tables
+  - toc:
+      permalink: true
+
+plugins:
+  - techdocs-core
+
+nav:
+  - Home: index.md
+  - Overview:
+    - What is SkillAI: overview/what-is-skillai.md
+    - Product tour: overview/product-tour.md
+    - Live demo: overview/live-demo.md
+  - Getting started:
+    - Quick start: getting-started/quick-start.md
+    - Development workflow: getting-started/development.md
+  - Architecture:
+    - System overview: architecture/system-overview.md
+    - Tech stack: architecture/tech-stack.md
+    - Multi-tenancy & RLS: architecture/multi-tenancy-rls.md
+    - AI scoring pipeline: architecture/ai-scoring-pipeline.md
+    - File storage: architecture/file-storage.md
+    - Performance baselines: architecture/performance.md
+  - REST API:
+    - Overview: rest-api/overview.md
+    - Authentication: rest-api/authentication.md
+    - Rate limiting: rest-api/rate-limiting.md
+    - Endpoint reference: rest-api/endpoints.md
+  - MCP server:
+    - Overview: mcp-server/overview.md
+    - Connecting from Claude Code: mcp-server/connecting.md
+    - Tool catalogue: mcp-server/tools.md
+    - Resources: mcp-server/resources.md
+    - Prompts: mcp-server/prompts.md
+  - Database:
+    - Table reference:
+      - agencies: database/tables/agencies.md
+      - ai usage: database/tables/ai-usage.md
+      - api tokens: database/tables/api-tokens.md
+      - audit logs: database/tables/audit-logs.md
+      - calendar connections: database/tables/calendar-connections.md
+      - candidate enrichments: database/tables/candidate-enrichments.md
+      - candidate role approvals: database/tables/candidate-role-approvals.md
+      - candidates: database/tables/candidates.md
+      - code challenges: database/tables/code-challenges.md
+      - customer frameworks: database/tables/customer-frameworks.md
+      - customers: database/tables/customers.md
+      - cv profiles: database/tables/cv-profiles.md
+      - email templates: database/tables/email-templates.md
+      - interview packs: database/tables/interview-packs.md
+      - interview questions: database/tables/interview-questions.md
+      - interview slots: database/tables/interview-slots.md
+      - interview transcripts: database/tables/interview-transcripts.md
+      - notes: database/tables/notes.md
+      - role managers: database/tables/role-managers.md
+      - role submissions: database/tables/role-submissions.md
+      - roles: database/tables/roles.md
+      - scores: database/tables/scores.md
+      - sent emails: database/tables/sent-emails.md
+      - tenant settings: database/tables/tenant-settings.md
+      - tenants: database/tables/tenants.md
+      - transcript analyses: database/tables/transcript-analyses.md
+      - user invitations: database/tables/user-invitations.md
+      - users: database/tables/users.md
+    - Schema overview: database/overview.md
+  - Code patterns:
+    - Agency logo: code-patterns/agency-logo.md
+    - Audience sanitisation: code-patterns/audience-sanitisation.md
+    - Force dynamic: code-patterns/force-dynamic.md
+    - Help content: code-patterns/help-content.md
+    - Logo upload: code-patterns/logo-upload.md
+    - Theme tokens: code-patterns/theme-tokens.md
+  - Operations:
+    - AWS deployment: operations/aws-deploy.md
+    - Backup & recovery: operations/backup-runbook.md
+    - Health & monitoring: operations/health-monitoring.md
+  - Design decisions:
+    - Index: decisions/index.md
+    - DEC-001 — Build vs buy: decisions/dec-001-build-vs-buy.md
+    - DEC-002 — Drizzle over Prisma: decisions/dec-002-drizzle-over-prisma.md
+    - DEC-003 — Row-Level Security: decisions/dec-003-row-level-security.md
+    - DEC-004 — Claude as primary AI: decisions/dec-004-claude-primary.md
+    - DEC-005 — Local storage + Garage: decisions/dec-005-storage.md
+    - DEC-006 — Auth.js over Clerk: decisions/dec-006-authjs-over-clerk.md
+    - DEC-007 — Manual transcript upload: decisions/dec-007-manual-transcript-upload.md
+    - DEC-008 — Manual archive on expiry: decisions/dec-008-manual-archive.md
+    - DEC-009 — Soft budget signal: decisions/dec-009-soft-budget-signal.md
+    - DEC-010 — Internal bench model: decisions/dec-010-internal-bench.md
+    - DEC-011 — GDPR erasure pattern: decisions/dec-011-gdpr-erasure.md
+  - Roadmap: roadmap.md

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "test:coverage": "NODE_ENV=test vitest run --coverage",
     "test:e2e": "NODE_ENV=test playwright test",
     "docs:mcp-tools": "npx tsx scripts/generate-mcp-tools-doc.ts",
-    "mcp:smoke": "npx tsx scripts/mcp-smoke.ts"
+    "mcp:smoke": "npx tsx scripts/mcp-smoke.ts",
+    "techdocs:gen": "npm --prefix docs-site run docs:gen",
+    "techdocs:sync": "npm run techdocs:gen && node scripts/sync-techdocs.mjs",
+    "techdocs:serve": "techdocs-cli serve"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.86.1",

--- a/scripts/sync-techdocs.mjs
+++ b/scripts/sync-techdocs.mjs
@@ -1,0 +1,478 @@
+#!/usr/bin/env node
+/**
+ * sync-techdocs.mjs
+ *
+ * Mirrors the public GitHub Pages documentation (the Astro/Starlight site under
+ * `docs-site/src/content/docs/**`) into Backstage TechDocs format (MkDocs
+ * markdown under `techdocs/**`) and (re)generates a matching `mkdocs.yml`.
+ *
+ * Why this exists
+ * ---------------
+ * We keep ONE canonical source of documentation — the Starlight content — which
+ * ships to GitHub Pages. Backstage's TechDocs builder, however, consumes plain
+ * MkDocs markdown, not Starlight MDX (it cannot execute the `<Aside>` / `<Card>`
+ * / data-driven JSX components). This script is the bridge: it converts the MDX
+ * to portable CommonMark, rewrites the `/SkillAi/...` site-absolute links into
+ * relative `.md` links, and renders the one data-driven page
+ * (`mcp-server/tools`) from the same `mcp-catalogue.json` the website uses.
+ *
+ * It is deterministic: same input -> same output, so CI can run it and commit
+ * the diff (see `.github/workflows/techdocs.yml`).
+ *
+ * Pipeline ordering: run AFTER `docs-site` `docs:gen` so the auto-derived
+ * content (OpenAPI / MCP catalogue / DB schema) exists before we mirror it.
+ *
+ * No external dependencies — Node stdlib only.
+ */
+import {
+  readFileSync,
+  writeFileSync,
+  readdirSync,
+  statSync,
+  mkdirSync,
+  rmSync,
+  existsSync,
+} from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve, relative, join, sep } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(__dirname, '..')
+const SRC_DIR = resolve(REPO_ROOT, 'docs-site', 'src', 'content', 'docs')
+const DATA_DIR = resolve(REPO_ROOT, 'docs-site', 'src', 'data')
+const OUT_DIR = resolve(REPO_ROOT, 'techdocs')
+const MKDOCS_YML = resolve(REPO_ROOT, 'mkdocs.yml')
+
+const SITE_BASE = '/SkillAi' // Starlight `base` — stripped/rewritten for TechDocs
+
+// ---------------------------------------------------------------------------
+// Navigation — mirrors the Starlight sidebar in docs-site/astro.config.mjs.
+// `autogenerate: { directory: X }` sections are expressed as { dir: 'X' } and
+// globbed at build time so new pages appear automatically.
+// ---------------------------------------------------------------------------
+const NAV = [
+  { label: 'Home', page: 'index' },
+  {
+    label: 'Overview',
+    items: [
+      ['What is SkillAI', 'overview/what-is-skillai'],
+      ['Product tour', 'overview/product-tour'],
+      ['Live demo', 'overview/live-demo'],
+    ],
+  },
+  {
+    label: 'Getting started',
+    items: [
+      ['Quick start', 'getting-started/quick-start'],
+      ['Development workflow', 'getting-started/development'],
+    ],
+  },
+  {
+    label: 'Architecture',
+    items: [
+      ['System overview', 'architecture/system-overview'],
+      ['Tech stack', 'architecture/tech-stack'],
+      ['Multi-tenancy & RLS', 'architecture/multi-tenancy-rls'],
+      ['AI scoring pipeline', 'architecture/ai-scoring-pipeline'],
+      ['File storage', 'architecture/file-storage'],
+      ['Performance baselines', 'architecture/performance'],
+    ],
+  },
+  {
+    label: 'REST API',
+    items: [
+      ['Overview', 'rest-api/overview'],
+      ['Authentication', 'rest-api/authentication'],
+      ['Rate limiting', 'rest-api/rate-limiting'],
+      ['Endpoint reference', 'rest-api/endpoints'],
+    ],
+  },
+  {
+    label: 'MCP server',
+    items: [
+      ['Overview', 'mcp-server/overview'],
+      ['Connecting from Claude Code', 'mcp-server/connecting'],
+      ['Tool catalogue', 'mcp-server/tools'],
+      ['Resources', 'mcp-server/resources'],
+      ['Prompts', 'mcp-server/prompts'],
+    ],
+  },
+  {
+    label: 'Database',
+    items: [
+      ['Schema overview', 'database/overview'],
+      { label: 'Table reference', dir: 'database/tables' },
+    ],
+  },
+  { label: 'Code patterns', dir: 'code-patterns' },
+  {
+    label: 'Operations',
+    items: [
+      ['AWS deployment', 'operations/aws-deploy'],
+      ['Backup & recovery', 'operations/backup-runbook'],
+      ['Health & monitoring', 'operations/health-monitoring'],
+    ],
+  },
+  {
+    label: 'Design decisions',
+    items: [
+      ['Index', 'decisions/index'],
+      ['DEC-001 — Build vs buy', 'decisions/dec-001-build-vs-buy'],
+      ['DEC-002 — Drizzle over Prisma', 'decisions/dec-002-drizzle-over-prisma'],
+      ['DEC-003 — Row-Level Security', 'decisions/dec-003-row-level-security'],
+      ['DEC-004 — Claude as primary AI', 'decisions/dec-004-claude-primary'],
+      ['DEC-005 — Local storage + Garage', 'decisions/dec-005-storage'],
+      ['DEC-006 — Auth.js over Clerk', 'decisions/dec-006-authjs-over-clerk'],
+      ['DEC-007 — Manual transcript upload', 'decisions/dec-007-manual-transcript-upload'],
+      ['DEC-008 — Manual archive on expiry', 'decisions/dec-008-manual-archive'],
+      ['DEC-009 — Soft budget signal', 'decisions/dec-009-soft-budget-signal'],
+      ['DEC-010 — Internal bench model', 'decisions/dec-010-internal-bench'],
+      ['DEC-011 — GDPR erasure pattern', 'decisions/dec-011-gdpr-erasure'],
+    ],
+  },
+  { label: 'Roadmap', page: 'roadmap' },
+]
+
+const ASIDE_LABEL = {
+  note: 'ℹ️ Note',
+  tip: '💡 Tip',
+  caution: '⚠️ Caution',
+  danger: '🚨 Danger',
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function walk(dir) {
+  const out = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) out.push(...walk(full))
+    else if (/\.(md|mdx)$/.test(entry)) out.push(full)
+  }
+  return out
+}
+
+function parseFrontmatter(raw) {
+  if (!raw.startsWith('---')) return { data: {}, body: raw }
+  const end = raw.indexOf('\n---', 3)
+  if (end === -1) return { data: {}, body: raw }
+  const fm = raw.slice(3, end).trim()
+  const body = raw.slice(end + 4).replace(/^\s*\n/, '')
+  const data = {}
+  // Minimal YAML — front-matter here is only flat `key: value` scalars.
+  for (const line of fm.split('\n')) {
+    const m = line.match(/^(\w[\w-]*):\s*(.*)$/)
+    if (m) data[m[1]] = m[2].replace(/^["']|["']$/g, '').trim()
+  }
+  return { data, body }
+}
+
+// The set of all output slugs (paths without extension), populated by main()
+// before any transform runs, so links can be resolved against real files.
+let SLUGS = new Set()
+
+// Map a source content path to its TechDocs-relative slug (no extension).
+function slugFor(absSrc) {
+  return relative(SRC_DIR, absSrc).replace(/\\/g, '/').replace(/\.(md|mdx)$/, '')
+}
+
+// Resolve a /SkillAi/<target> site link to a relative .md link from `fromSlug`,
+// or to an absolute GitHub Pages URL when no matching doc page exists.
+function rewriteLink(fromSlug, target) {
+  const clean = target.replace(/^\/+|\/+$/g, '')
+  let toSlug = null
+  if (clean === '') toSlug = 'index'
+  else if (SLUGS.has(clean)) toSlug = clean
+  else if (SLUGS.has(`${clean}/index`)) toSlug = `${clean}/index`
+  else {
+    // Section directory with no index page -> link to its first child.
+    const kids = [...SLUGS].filter((s) => s.startsWith(`${clean}/`)).sort()
+    if (kids.length) toSlug = kids[0]
+  }
+  if (toSlug === null) {
+    // Unknown target (e.g. a static asset like openapi.json) -> keep it working
+    // as an absolute link to the published GitHub Pages site.
+    return { external: `https://olafkfreund.github.io/SkillAi/${clean}` }
+  }
+  const fromDir = fromSlug.includes('/') ? fromSlug.replace(/\/[^/]*$/, '') : ''
+  let rel = relative(fromDir, `${toSlug}.md`).replace(/\\/g, '/')
+  if (!rel.startsWith('.')) rel = `./${rel}`
+  return { rel }
+}
+
+function transformLinks(body, fromSlug) {
+  // [text](/SkillAi/foo/bar/#anchor)  and bare /SkillAi/foo/bar
+  return body.replace(
+    /\]\(\s*\/SkillAi(\/[^)\s#]*)?(#[^)\s]*)?\s*\)/g,
+    (_m, path = '', anchor = '') => {
+      const r = rewriteLink(fromSlug, path || '')
+      const href = r.rel ?? r.external
+      // Anchors are only meaningful on internal pages we generated.
+      return `](${href}${r.rel ? anchor || '' : ''})`
+    },
+  )
+}
+
+// Remove the common leading indentation shared by all non-empty lines of a
+// block. MDX indents component children (often 2-4 spaces); left untouched that
+// would render as Markdown code blocks. Dedenting by the shared minimum keeps
+// any *intentional* relative indentation (nested lists, fenced code) intact.
+function dedent(block) {
+  const lines = block.replace(/^\n+|\n+$/g, '').split('\n')
+  let min = Infinity
+  for (const l of lines) {
+    if (l.trim() === '') continue
+    const m = l.match(/^[ \t]*/)
+    min = Math.min(min, m[0].length)
+  }
+  if (!isFinite(min) || min === 0) return lines.join('\n')
+  return lines.map((l) => l.slice(min)).join('\n')
+}
+
+function stripMdxComponents(body) {
+  let out = body.replace(/^import\s.+$/gm, '')
+
+  // Block transforms first — they dedent inner content so it renders as prose.
+  // Aside -> labelled blockquote
+  out = out.replace(
+    /<Aside\s+type="([^"]+)"(?:\s+title="([^"]+)")?[^>]*>([\s\S]*?)<\/Aside>/g,
+    (_m, type, title, inner) => {
+      const label = ASIDE_LABEL[type] || 'ℹ️ Note'
+      const head = title ? `${label} — ${title}` : label
+      const quoted = dedent(inner)
+        .split('\n')
+        .map((l) => (l.length ? `> ${l}` : '>'))
+        .join('\n')
+      return `\n> **${head}**\n>\n${quoted}\n`
+    },
+  )
+  out = out.replace(
+    /<Aside[^>]*>([\s\S]*?)<\/Aside>/g,
+    (_m, inner) => {
+      const quoted = dedent(inner)
+        .split('\n')
+        .map((l) => (l.length ? `> ${l}` : '>'))
+        .join('\n')
+      return `\n> **ℹ️ Note**\n>\n${quoted}\n`
+    },
+  )
+  // Card -> H3 with dedented body
+  out = out.replace(
+    /<Card\s+[^>]*title="([^"]+)"[^>]*>([\s\S]*?)<\/Card>/g,
+    (_m, title, inner) => `\n### ${title}\n\n${dedent(inner)}\n`,
+  )
+  // TabItem -> bold label with dedented body
+  out = out.replace(
+    /<TabItem\s+label="([^"]+)"[^>]*>([\s\S]*?)<\/TabItem>/g,
+    (_m, label, inner) => `\n**${label}**\n\n${dedent(inner)}\n`,
+  )
+
+  return (
+    out
+      // structural wrappers that just vanish
+      .replace(/<\/?Steps>/g, '')
+      .replace(/<\/?CardGrid[^>]*>/g, '')
+      .replace(/<\/?Tabs[^>]*>/g, '')
+      // any unmatched stragglers
+      .replace(/<\/?(Card|Aside|TabItem)[^>]*>/g, '')
+      // Badge -> inline code
+      .replace(/<Badge\s+[^>]*text="([^"]+)"[^>]*\/>/g, '`$1`')
+      // Image -> drop (sources are JS imports, not portable URLs)
+      .replace(/<Image\s+[^>]*\/>/g, '')
+      // Any stray self-closing Starlight tag left over
+      .replace(/<\/?(LinkCard|LinkButton|FileTree|Code)[^>]*>/g, '')
+  )
+}
+
+function ensureHeading(body, data) {
+  const hasH1 = /^#\s+/m.test(body.split('\n').slice(0, 8).join('\n'))
+  let head = ''
+  if (!hasH1 && data.title) head += `# ${data.title}\n\n`
+  if (data.description) head += `_${data.description}_\n\n`
+  return head + body
+}
+
+function tidy(body) {
+  return body.replace(/\n{3,}/g, '\n\n').replace(/[ \t]+$/gm, '').trim() + '\n'
+}
+
+// ---------------------------------------------------------------------------
+// Special-case: the one data-driven page (mcp-server/tools) is rendered from
+// the same JSON catalogue the website uses, so the TechDocs table stays in
+// lock-step with the live MCP tool registry.
+// ---------------------------------------------------------------------------
+function renderMcpToolsPage() {
+  const jsonPath = resolve(DATA_DIR, 'mcp-catalogue.json')
+  if (!existsSync(jsonPath)) {
+    return '# Tool catalogue\n\n_MCP catalogue not generated. Run `npm run docs:gen` in `docs-site/` first._\n'
+  }
+  const cat = JSON.parse(readFileSync(jsonPath, 'utf8'))
+  const s = cat.summary
+  let out = '# Tool catalogue\n\n'
+  out += `_Every tool the SkillAI MCP server exposes — auto-generated from the live tool registry on ${cat.generatedAt}._\n\n`
+  out += `> **ℹ️ Note** — This page is generated from \`docs-site/src/data/mcp-catalogue.json\` by \`scripts/sync-techdocs.mjs\`. Do not edit it by hand; re-run \`npm run techdocs:sync\`.\n\n`
+  out += '## Summary\n\n'
+  out += '| Metric | Count |\n|---|---|\n'
+  out += `| Tools total | ${s.totalTools} |\n`
+  out += `| Read tools | ${s.readTools} |\n`
+  out += `| Write tools | ${s.writeTools} |\n`
+  out += `| Modules | ${s.modules} |\n`
+  out += `| Resources | ${s.resources} |\n`
+  out += `| Prompts | ${s.prompts} |\n\n`
+  for (const mod of cat.modules) {
+    out += `## ${mod.name} (${mod.count})\n\n`
+    out += '| Tool | Scope | Description |\n|---|---|---|\n'
+    for (const t of mod.tools) {
+      const desc = t.description.replace(/\|/g, '\\|').replace(/\n+/g, ' ')
+      out += `| \`${t.name}\` | ${t.scope} | ${desc} |\n`
+    }
+    out += '\n'
+  }
+  if (cat.resources?.length) {
+    out += '## Resources\n\n| URI | Name | Description |\n|---|---|---|\n'
+    for (const r of cat.resources) {
+      out += `| \`${r.uri}\` | ${r.name} | ${r.description.replace(/\|/g, '\\|')} |\n`
+    }
+    out += '\n'
+  }
+  if (cat.prompts?.length) {
+    out += '## Prompts\n\n| Name | Description |\n|---|---|\n'
+    for (const p of cat.prompts) {
+      out += `| \`${p.name}\` | ${p.description.replace(/\|/g, '\\|')} |\n`
+    }
+    out += '\n'
+  }
+  return tidy(out)
+}
+
+// ---------------------------------------------------------------------------
+// Transform one source file -> markdown string
+// ---------------------------------------------------------------------------
+function transform(absSrc) {
+  const slug = slugFor(absSrc)
+  if (slug === 'mcp-server/tools') return renderMcpToolsPage()
+  const raw = readFileSync(absSrc, 'utf8')
+  const { data, body } = parseFrontmatter(raw)
+  let out = stripMdxComponents(body)
+  out = transformLinks(out, slug)
+  out = ensureHeading(out, data)
+  return tidy(out)
+}
+
+// ---------------------------------------------------------------------------
+// mkdocs.yml nav generation
+// ---------------------------------------------------------------------------
+function navToYaml(writtenSlugs) {
+  const lines = ['nav:']
+  const pageRef = (slug) => `${slug}.md`
+  const has = (slug) => writtenSlugs.has(slug)
+
+  for (const section of NAV) {
+    if (section.page !== undefined) {
+      if (has(section.page)) lines.push(`  - ${section.label}: ${pageRef(section.page)}`)
+      continue
+    }
+    lines.push(`  - ${section.label}:`)
+    const items = []
+    if (section.dir) {
+      // top-level autogenerate section
+      for (const slug of [...writtenSlugs].filter((s) => s.startsWith(`${section.dir}/`)).sort()) {
+        const title = slug.split('/').pop().replace(/-/g, ' ').replace(/^\w/, (c) => c.toUpperCase())
+        items.push([title, slug])
+      }
+    } else {
+      for (const item of section.items) {
+        if (Array.isArray(item)) {
+          if (has(item[1])) items.push(item)
+        } else if (item.dir) {
+          // nested autogenerate (e.g. database/tables)
+          lines.push(`    - ${item.label}:`)
+          for (const slug of [...writtenSlugs].filter((s) => s.startsWith(`${item.dir}/`)).sort()) {
+            const title = slug.split('/').pop().replace(/-/g, ' ')
+            lines.push(`      - ${title}: ${pageRef(slug)}`)
+          }
+        }
+      }
+    }
+    for (const [title, slug] of items) {
+      lines.push(`    - ${title.replace(/:/g, ' -')}: ${pageRef(slug)}`)
+    }
+  }
+  return lines.join('\n')
+}
+
+function writeMkdocs(writtenSlugs) {
+  const header = `# mkdocs.yml — Backstage TechDocs configuration for SkillAI.
+#
+# GENERATED FILE — do not edit by hand. Regenerate with: npm run techdocs:sync
+# The nav + page content mirror the public GitHub Pages site (docs-site/).
+# Backstage builds this via the TechDocs generator (techdocs-ref: dir:. in
+# catalog-info.yaml), which runs \`mkdocs build\` against this repo.
+
+site_name: SkillAI
+site_description: Internal AI-powered recruiting portal — ranks candidates fast, archives them forever, integrates with Claude.
+docs_dir: techdocs
+repo_url: https://github.com/olafkfreund/SkillAi
+edit_uri: edit/core-mvp-foundation/docs-site/src/content/docs/
+
+theme:
+  name: material
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - tables
+  - toc:
+      permalink: true
+
+plugins:
+  - techdocs-core
+
+`
+  writeFileSync(MKDOCS_YML, header + navToYaml(writtenSlugs) + '\n', 'utf8')
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+function main() {
+  if (!existsSync(SRC_DIR)) {
+    console.error(`✗ Source docs not found: ${SRC_DIR}`)
+    process.exit(1)
+  }
+  // Clean slate so deleted source pages don't linger in TechDocs.
+  if (existsSync(OUT_DIR)) rmSync(OUT_DIR, { recursive: true, force: true })
+  mkdirSync(OUT_DIR, { recursive: true })
+
+  const files = walk(SRC_DIR)
+  // Pass 1: know every output slug up front so link resolution can target real
+  // files (X.md vs X/index.md vs section dir) deterministically.
+  SLUGS = new Set(files.map(slugFor))
+
+  const writtenSlugs = new Set()
+  for (const abs of files) {
+    const slug = slugFor(abs)
+    const outPath = resolve(OUT_DIR, `${slug}.md`)
+    mkdirSync(dirname(outPath), { recursive: true })
+    writeFileSync(outPath, transform(abs), 'utf8')
+    writtenSlugs.add(slug)
+  }
+
+  if (!writtenSlugs.has('index')) {
+    writeFileSync(
+      resolve(OUT_DIR, 'index.md'),
+      '# SkillAI\n\nInternal AI-powered recruiting portal documentation.\n',
+      'utf8',
+    )
+    writtenSlugs.add('index')
+  }
+
+  writeMkdocs(writtenSlugs)
+  console.log(
+    `✓ TechDocs synced: ${writtenSlugs.size} pages -> ${relative(REPO_ROOT, OUT_DIR)}${sep}, mkdocs.yml regenerated`,
+  )
+}
+
+main()

--- a/techdocs/architecture/ai-scoring-pipeline.md
+++ b/techdocs/architecture/ai-scoring-pipeline.md
@@ -1,0 +1,158 @@
+# AI scoring pipeline
+
+_End-to-end flow from CV upload to ranked list — structured outputs, the auto-match orchestrator, and the soft budget signal._
+
+When a candidate is uploaded and scored against a role, SkillAI takes a CV through parsing, AI scoring with a structured-output schema, persistence, and presentation. The whole flow is built around one invariant: **AI responses are always validated against a Zod schema before they hit the database.** Never parse unstructured text for fields that need to be stored.
+
+## End-to-end flow
+
+```mermaid
+sequenceDiagram
+  actor Recruiter
+  participant UI as Browser (Next.js)
+  participant Action as createCandidate<br/>(server action)
+  participant DB as Postgres (RLS)
+  participant After as after() background
+  participant AI as Claude /<br/>Gemini
+
+  Recruiter->>UI: Upload CV + select role
+  UI->>Action: FormData (multipart)
+  Action->>Action: validateCvFile<br/>parseCvBuffer
+  Action->>DB: insert candidate + score (status=pending)
+  Action-->>UI: 200 OK (immediate)
+  UI->>UI: Poll /api/scores/{id}/status
+
+  Action->>After: triggerScoring(candidateId, roleId)
+  After->>DB: SET app.tenant_id<br/>UPDATE scores SET status=processing
+  After->>AI: structured-output call
+  AI-->>After: tool_use / JSON response
+  After->>After: CandidateScoreSchema.safeParse
+  After->>DB: UPDATE scores SET status=complete + dimensions
+
+  UI->>DB: GET /api/scores/{id}/status
+  DB-->>UI: complete
+  UI->>Recruiter: Render ranked card
+```
+
+## Stage 1 — CV parsing
+
+The recruiter uploads a CV via a Server Action. Validation and parsing both live in `src/lib/cv/store.ts`:
+
+- **`validateCvFile()`** — checks size (≤10 MB), MIME type, and runs magic-byte detection via the `file-type` package to reject renamed binaries. Supported formats: PDF, DOCX, ODT, RTF, TXT, MD.
+- **`parseCvBuffer()`** — extracts plain text using `pdf-parse` (PDF), `mammoth` (DOCX), or the appropriate parser for other formats. Strips null bytes and non-printable control characters that PostgreSQL rejects.
+- **`persistCvFile()`** — writes the buffer to `/uploads/{tenantId}/{uuid}.{ext}`. The DB-relative path is computed first, then the absolute filesystem path is derived from it — guaranteeing write and read sides agree. See [File storage](./file-storage.md) for the symmetry rule.
+
+The parsed text lands in `candidates.cv_text` and a `scores` row is inserted with `score_status = 'pending'`.
+
+## Stage 2 — Background scoring with `after()`
+
+The Server Action returns immediately so the UI doesn't block on the AI call. A Next.js `after()` callback then runs the actual scoring via `triggerScoring()` in `src/lib/ai/scoring.ts:26`:
+
+1. Mark the `scores` row as `processing`.
+2. Fetch the candidate + role + (if applicable) customer hiring framework.
+3. Resolve the tenant's AI model preference from `tenant_settings.default_ai_model` — Claude unless explicitly set to `gemini`.
+4. Build the soft budget context (see [below](#the-soft-budget-signal)).
+5. Call `scoreCandidateWithClaude()` or `scoreCandidateWithGemini()`.
+6. Validate the response against `CandidateScoreSchema`.
+7. Write the four dimension scores + reasoning + summary back to the `scores` row, set `status = 'complete'`.
+8. Fire-and-forget: notify Slack/Teams if the score crosses the tenant's high-score threshold; emit a `score.completed` audit row.
+
+Errors anywhere in this chain land as `score_status = 'failed'` with the error message in `error_message`. A `score.failed` audit row records the failure with the role ID and the error.
+
+## Stage 3 — The structured-output schema
+
+Both providers return the same shape, validated by `CandidateScoreSchema` in `src/lib/ai/schema.ts`:
+
+```typescript
+export const CandidateScoreSchema = z.object({
+  overall_score: z.number().int().min(0).max(100),
+  dimensions: z.object({
+    technical_skills: DimensionSchema,
+    experience_level: DimensionSchema,
+    cultural_fit: DimensionSchema,
+    communication: DimensionSchema,
+  }),
+  summary: z.string().default('No summary provided'),
+})
+```
+
+Where each dimension is `{ score: 0-100, reasoning: string }`.
+
+**Claude** uses tool-use with a `submit_candidate_score` tool definition (see `src/lib/ai/claude.ts:18`). The tool's `input_schema` matches the Zod schema field-for-field. `tool_choice: { type: 'any' }` forces Claude to emit a tool call rather than free text.
+
+**Gemini** uses `responseSchema` JSON mode (see `src/lib/ai/gemini.ts:19`). Same shape, different encoding — the `SCORE_RESPONSE_SCHEMA` constant is the equivalent of Claude's tool schema in Gemini's `Schema` type.
+
+Both clients are configured with retries and timeouts (`maxRetries: 3`, `timeout: 120_000` on the Claude SDK; Gemini's retry behaviour ships in the SDK). A failure to validate against the Zod schema is treated as an error — no defensive coercion, no "try to parse it anyway."
+
+## Stage 4 — Polling and rendering
+
+The browser polls `/api/scores/{id}/status` every three seconds via TanStack Query. When the status flips to `complete`, the UI invalidates the role detail query and re-renders the ranked candidate cards. The four dimension scores are shown as horizontal bars; the AI reasoning is in an expandable section under each dimension.
+
+## Auto-match — the orchestrator
+
+Auto-match is a separate pipeline triggered when a recruiter creates or updates a role. It surfaces the top candidates from the archive without manually scoring all of them. The pipeline lives in `src/lib/auto-match/`:
+
+```mermaid
+flowchart LR
+  Role[Role text<br/>title + description + requirements] --> Embed[Generate embedding<br/>Gemini embedding-001]
+  Embed --> Vec[pgvector cosine top-30<br/>candidates.embedding]
+  Vec --> Filter[Hard filters<br/>availability • not rejected by customer<br/>rate ≤ 125% of budget]
+  Filter --> Top3[Take top 3<br/>by similarity]
+  Top3 --> Cap{Daily cost cap<br/>≥ $50 USD?}
+  Cap -->|yes| Skip[Skip scoring]
+  Cap -->|no| Score[Claude scoring<br/>tag operation=auto_match_scoring]
+  Score --> Persist[Persist scores +<br/>ArchiveMatchesPanel]
+```
+
+Key constants (in `src/lib/auto-match/prefilter.ts` and `src/lib/auto-match/scoring.ts`):
+
+- **`VECTOR_TOP_N = 30`** — pgvector candidates pulled before hard filters.
+- **`PREFILTER_CAP = 20`** — max survivors of hard filters that proceed to scoring consideration.
+- **`BUDGET_OVERAGE_MAX = 1.25`** — candidates whose rate exceeds 125% of the role's `customerDayRate` are excluded (when currencies match).
+- **`DEFAULT_DAILY_COST_CAP_USD = 50`** — per-tenant daily auto-match Claude spend cap. Configurable via `tenant_settings.auto_match_daily_cost_cap_usd`.
+
+The cap is checked against today's sum of `cost_usd` in the `ai_usage` ledger filtered to `operation = 'auto_match_scoring'`. When the cap is hit, auto-match returns `skipped: true, reason: 'daily_cost_cap_exceeded'` and writes nothing — the recruiter can still trigger manual scoring on individual candidates.
+
+## The soft budget signal
+
+When a role has a `customerDayRate` (budget) and a candidate has a `candidateRate` in the same currency, the scoring prompt receives a textual budget signal — not a fifth scored dimension. The signal is built by `buildBudgetContext()` in `src/lib/ai/scoring.ts:210`:
+
+```text
+BUDGET SIGNAL (soft):
+Role budget (what client will pay): GBP 600/day
+Candidate asking rate:               GBP 700/day
+Implied margin:                      GBP -100/day (17% over budget)
+
+GUIDANCE: Rates are commonly negotiable. Do NOT heavily penalise score for being over budget.
+- Within budget or ~10% over: no impact on scores.
+- 10-25% over: mention in the summary as "slightly above budget, may require negotiation."
+- >25% over: mention in the summary as "significantly above budget — likely needs negotiation."
+Never lower technical_skills, experience_level, cultural_fit, or communication scores on budget grounds alone.
+```
+
+When currencies mismatch (role in EUR, candidate in GBP), the budget context is suppressed entirely — the AI is never asked to reason across currencies. The UI still shows the margin with a warning pill.
+
+The full rationale for "soft signal, not scored dimension" is in [DEC-009](../decisions/dec-009-soft-budget-signal.md).
+
+## Embeddings for semantic search
+
+A separate path: every candidate's CV text is embedded once at upload time using **`models/gemini-embedding-001`** at 768 dimensions, stored in `candidates.embedding` (vector(768)) with an HNSW index. The same embedding model powers:
+
+- The candidate search page — paste a query, get nearest neighbours by cosine similarity.
+- The auto-match prefilter — embed the role text, query the candidate vector index.
+- The "matching roles" panel on a candidate page — embed candidate profile, query against role text.
+
+The model is called via `generateEmbedding()` in `src/lib/ai/embeddings.ts`. There is no defensive fallback to another embedding provider — if Gemini is down, semantic search returns an error.
+
+## Where the AI calls cost money
+
+All AI calls — scoring, interview pack generation, transcript analysis, welcome letter, auto-match — log a row to the `ai_usage` table via `logAiUsage()` in `src/lib/ai/usage-logger.ts`. Fields include `tenant_id`, `operation`, `model`, input/output tokens, estimated `cost_usd`, and `duration_ms`.
+
+The `/dashboard/reports` page aggregates this into a spend trend with month-over-month delta and a per-operation breakdown. Per-tenant cost caps (like the auto-match daily cap) read from this ledger.
+
+## Related
+
+- [System overview](./system-overview.md) — how scoring fits into the request lifecycle.
+- [Multi-tenancy & RLS](./multi-tenancy-rls.md) — the `withTenant()` wrapper used throughout the scoring path.
+- [DEC-004 — Claude as primary AI](../decisions/dec-004-claude-primary.md).
+- [DEC-009 — Soft budget signal](../decisions/dec-009-soft-budget-signal.md).

--- a/techdocs/architecture/file-storage.md
+++ b/techdocs/architecture/file-storage.md
@@ -1,0 +1,124 @@
+# File storage
+
+_Where uploaded CVs and branding logos live, how paths are laid out, and the path-traversal guard._
+
+SkillAI stores two kinds of binary files on disk: candidate CVs and tenant branding logos (agency + customer). Both live under the same uploads root, partitioned per tenant. For dev and small production deployments the uploads root is a Docker volume; for larger production deployments it is a Garage-backed S3 bucket.
+
+## Layout
+
+The on-disk layout under `UPLOAD_DIR` (default `/app/uploads`):
+
+```
+{UPLOAD_DIR}/
+└── {tenantId}/
+    ├── {uuid}.pdf          # CV files (PDF/DOCX/ODT/RTF/TXT/MD)
+    ├── {uuid}.docx
+    └── logos/
+        ├── {uuid}.png      # PNG/JPEG/WebP only — no SVG
+        └── {uuid}.webp
+```
+
+The DB stores **web-relative paths** with a leading slash:
+
+- CVs: `/uploads/{tenantId}/{uuid}.{ext}` (in `candidates.cv_file_path`)
+- Logos: `/uploads/{tenantId}/logos/{uuid}.{ext}` (in `agencies.logo_path` and `customers.logo_path`)
+
+The leading slash is significant — these are the URLs the frontend uses to fetch the file, *and* the source of truth from which the absolute filesystem path is derived.
+
+## The symmetry rule
+
+> **⚠️ Caution**
+>
+> **The DB-stored path must be the canonical source for both write and read.** Compute it first, derive the absolute filesystem path from it. Never compute write and read paths independently from the same inputs.
+
+Both `persistCvFile()` in `src/lib/cv/store.ts:150` and `persistLogo()` in `src/lib/branding/store.ts:88` follow this rule:
+
+```typescript
+// CORRECT — DB path first, absolute derived from it
+const filePath = `/uploads/${tenantId}/${fileName}`
+const absolutePath = join(process.cwd(), filePath.slice(1))
+await mkdir(join(absolutePath, '..'), { recursive: true })
+await writeFile(absolutePath, buffer)
+return { filePath, fileId }
+```
+
+The matching reader (`deleteCvFile()`, `getLogoAbsolutePath()`) uses the same `process.cwd() + filePath.slice(1)` derivation. This is enforced by code review, not by the type system — adding a new write path is the moment to recheck.
+
+The pattern exists because of issue #98, which broke logo serving when the write side used `UPLOAD_DIR` directly (an absolute path like `/app/app/uploads`) while the read side stripped the leading slash and joined with `cwd`. The two paths diverged silently; logos uploaded successfully but never served.
+
+## CV files
+
+Defined in `src/lib/cv/store.ts`. Key constraints:
+
+- **Max size:** 10 MB (`MAX_FILE_SIZE`).
+- **Accepted MIME types:** `application/pdf`, `application/vnd.openxmlformats-officedocument.wordprocessingml.document`, `application/vnd.oasis.opendocument.text`, `application/rtf`, `text/rtf`, `text/plain`, `text/markdown`.
+- **Accepted extensions** (fallback when MIME is wrong/missing): `.pdf`, `.docx`, `.odt`, `.rtf`, `.txt`, `.md`.
+- **Magic-byte check** via the `file-type` package — rejects executables or images renamed to a supported extension. Plain text and markdown have no reliable magic bytes, so `undefined` from `file-type` is allowed for those.
+- **Storage path:** `/uploads/{tenantId}/{uuid}.{ext}` — UUID v4 filename, original filename is discarded (recorded in `candidates.original_filename` for download UX only).
+
+`parseCvBuffer()` extracts plain text from the buffer using the format-specific parser, then strips null bytes and non-printable control characters that PostgreSQL rejects in `text` columns.
+
+## Branding logos
+
+Defined in `src/lib/branding/store.ts`. Tighter constraints than CVs:
+
+- **Max size:** 2 MB (`MAX_LOGO_SIZE`).
+- **Accepted MIME types:** `image/png`, `image/jpeg`, `image/webp` only. **SVG is rejected** because inline `<svg>` rendering has an XSS surface (`<script>` blocks, `onload=`, etc.). Use PNG/WebP for the same use case.
+- **Accepted extensions:** `.png`, `.jpg`, `.jpeg`, `.webp`.
+- **Storage path:** `/uploads/{tenantId}/logos/{uuid}.{ext}`.
+
+**Render sizing** (enforced by the components):
+
+- 20 px — candidate list rows, role detail cards
+- 24 px — candidate detail headers
+- 32 px — agency/customer list rows, PDF exports
+- 64 px — agency/customer detail headers
+
+When the logo path is null, components render an initials avatar derived from the entity name.
+
+## Path-traversal defence-in-depth
+
+The tenant export ZIP builder (`src/lib/export/tenant-export-builder.ts`) and the backup tooling both touch arbitrary stored paths — a malicious or buggy DB row could in principle hold a `..` segment that escapes the tenant directory. The guard:
+
+```typescript
+const tenantUploadRoot = `${UPLOAD_DIR}/${tenantId}/`
+const resolved = path.resolve(absolutePath)
+if (!resolved.startsWith(tenantUploadRoot)) {
+  // skip this file, record in manifest.skippedFiles
+  // reason: 'path-outside-tenant'
+  continue
+}
+const stats = await fs.stat(resolved)
+```
+
+The `startsWith` check runs **before** `fs.stat` — `stat` is never invoked on a path outside the tenant root. The skipped entries land in the export's `manifest.json` with a reason so the operator can audit them.
+
+This same defence applies to any future feature that reads stored paths in bulk (GDPR export, backup runbook integrity check, etc.). When adding a new such surface, copy the pattern — do not skip the prefix check.
+
+## ENOENT and EACCES handling
+
+For both CV deletion (`deleteCvFile`) and logo deletion (`deleteLogo`), `ENOENT` is silently swallowed — the file may already be gone. Other errors are re-thrown by `deleteCvFile` but swallowed by `deleteLogo` (logo deletion is always best-effort).
+
+The tenant export builder records `ENOENT` and `EACCES` as skipped files in the export manifest rather than failing the whole export. A single bad file should never block an export.
+
+## Production — moving to Garage
+
+For deployments larger than a single host, the local Docker volume becomes the bottleneck (no replication, no concurrent access from multiple app pods). The supported upgrade path is **Garage**, a self-hosted S3-compatible object store:
+
+- Drop-in replacement for the local volume — the application uses the AWS S3 SDK against Garage's S3 endpoint.
+- Multi-node deployment for replication.
+- No public cloud dependency (data stays on your infrastructure).
+
+The migration is a one-time copy: `aws s3 sync ./uploads/ s3://skillai-uploads/` against the Garage endpoint, then swap the storage adapter via the `STORAGE_ENDPOINT` / `STORAGE_ACCESS_KEY` / `STORAGE_SECRET_KEY` / `STORAGE_BUCKET` environment variables. The DB-stored paths stay the same — Garage uses the same `{tenantId}/{uuid}.{ext}` key shape as the on-disk layout.
+
+The rationale for Garage over MinIO (which moved to AGPL) and over public cloud S3 (data sovereignty) is in [DEC-005](../decisions/dec-005-storage.md).
+
+## AWS deployment — EFS instead
+
+On AWS EKS, the standard layout is RDS for the database + EFS for uploads. EFS appears as a normal POSIX filesystem mounted at `/app/uploads`, so no application-level changes are needed compared to the Docker volume layout. See [AWS deployment](../operations/aws-deploy.md) for the full layout.
+
+## Related
+
+- [System overview](./system-overview.md) — where storage sits in the request lifecycle.
+- [Backup & recovery](../operations/backup-runbook.md) — how the uploads volume is backed up alongside the database dump.
+- [DEC-005 — Local storage + Garage](../decisions/dec-005-storage.md) — the full decision record.

--- a/techdocs/architecture/multi-tenancy-rls.md
+++ b/techdocs/architecture/multi-tenancy-rls.md
@@ -1,0 +1,125 @@
+# Multi-tenancy & RLS
+
+_Two-layer tenant isolation — the withTenant wrapper plus PostgreSQL Row-Level Security policies, working in tandem._
+
+SkillAI runs every tenant in the same Postgres schema, isolated by a `tenant_id` column on every table and a Row-Level Security policy on every table. The policies key off a session variable that the application sets at the start of each request. This is the load-bearing pattern of the entire codebase.
+
+> **⚠️ Caution**
+>
+> Never query the database without `withTenant()` (except for truly global tables like `tenants` itself). The first layer of isolation is application-enforced; the second is the database-enforced policy that prevents a buggy query from leaking rows across tenants.
+
+## The two layers
+
+**Layer 1 — application.** Every server action, server component, and API route call sits inside a `withTenant(tenantId, fn)` block. The wrapper opens a transaction and sets `app.tenant_id` as a session variable before running `fn`.
+
+**Layer 2 — database.** Every tenant-scoped table has Row-Level Security enabled. The policy filters every read and write to rows where `tenant_id = current_setting('app.tenant_id', true)::uuid`. If the application forgets to set the session variable, the policy returns zero rows — fail-closed.
+
+The application-layer check is convention; the database-layer check is enforced by Postgres. Together they form defence-in-depth: a buggy query, a missing `withTenant`, or a hand-written SQL string cannot read across tenant boundaries.
+
+## The wrapper
+
+The whole pattern is 10 lines of code, in `src/db/index.ts:28`:
+
+```typescript
+export async function withTenant<T>(
+  tenantId: string,
+  fn: (tx: Database) => Promise<T>
+): Promise<T> {
+  return db.transaction(async (tx) => {
+    // SET LOCAL scopes the variable to the current transaction only
+    await tx.execute(sql`SELECT set_tenant_context(${tenantId}::uuid)`)
+    return fn(tx as unknown as Database)
+  })
+}
+```
+
+Two things to notice:
+
+- The session variable is set via `set_tenant_context()`, a Postgres function that wraps `SET LOCAL app.tenant_id`. `SET LOCAL` scopes the variable to the current transaction — it's automatically cleared when the transaction commits or rolls back.
+- The wrapper opens a transaction even for read-only queries. This is the cost of the isolation guarantee; in practice it adds ~1 ms of latency. The bigger pages amortise this by batching multiple queries inside one `Promise.all` inside one `withTenant`. See [Performance baselines](./performance.md) for the batching pattern.
+
+## A sample RLS policy
+
+Every schema file in `src/db/schema/` follows the same template. Here's the one for `agencies` (from `src/db/schema/agencies.ts:5`):
+
+```typescript
+export const agencies = pgTable(
+  'agencies',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tenantId: uuid('tenant_id')
+      .notNull()
+      .references(() => tenants.id, { onDelete: 'cascade' }),
+    name: varchar('name', { length: 150 }).notNull(),
+    // ...
+    isInternal: boolean('is_internal').notNull().default(false),
+    isSystem: boolean('is_system').notNull().default(false),
+  },
+  (t) => [
+    uniqueIndex('uniq_agencies_tenant_internal')
+      .on(t.tenantId)
+      .where(sql`is_internal`),
+    pgPolicy('agencies_tenant_isolation', {
+      as: 'permissive',
+      for: 'all',
+      to: 'public',
+      using: sql`${t.tenantId} = current_setting('app.tenant_id', true)::uuid`,
+    }),
+  ]
+).enableRLS()
+```
+
+Three things to call out:
+
+1. **`tenant_id UUID NOT NULL`** with a cascade-delete FK to `tenants.id`. When a tenant is deleted, all child rows go with it.
+2. **`pgPolicy(..., for: 'all', ...)`** applies to SELECT, INSERT, UPDATE, and DELETE. The `using` clause is the filter expression.
+3. **`.enableRLS()`** on the table — without this, the policy exists but isn't enforced. Easy to forget; review checklist item.
+
+Every new schema file in `src/db/schema/` must include these three. Copy from an existing file rather than writing from scratch.
+
+## Why this beats schema-per-tenant
+
+Two common approaches to multi-tenancy: schema-per-tenant (each tenant gets an isolated PostgreSQL schema) or shared schema with RLS.
+
+For an internal tool with tens of tenants, RLS wins:
+
+- **No schema migration complexity** — one set of tables to migrate, not N.
+- **Single connection pool** — schema-per-tenant either requires N pools or N reconnects per tenant switch.
+- **Isolation enforced at the DB layer** — schema-per-tenant relies on the application setting the right `search_path`; RLS enforces it via policies that fail closed.
+- **Easier ops** — `pg_dump` produces one file, not N. Backups, monitoring, and EXPLAIN ANALYZE all work the same way as a single-tenant app.
+
+The tradeoff: every query carries a `tenant_id = ...` filter via the RLS policy, which costs an index lookup. Every tenant-scoped table has a leading `tenant_id` column in its compound indexes (`idx_candidates_tenant_active_created`, `idx_roles_tenant_active_created`, etc.) to keep this cheap.
+
+The full rationale is in [DEC-003](../decisions/dec-003-row-level-security.md).
+
+## Worked example — the Internal agency uniqueness constraint
+
+Every tenant gets exactly one auto-provisioned "Internal" agency to hold internal employees / bench candidates. Enforcing "exactly one" across tenants is the canonical use case for a tenant-scoped partial unique index.
+
+Look at the index in the snippet above:
+
+```typescript
+uniqueIndex('uniq_agencies_tenant_internal')
+  .on(t.tenantId)
+  .where(sql`is_internal`)
+```
+
+This creates a partial unique index where the index entry only exists when `is_internal = true`. The result: each `(tenant_id)` value can appear at most once with `is_internal = true`, but can appear many times with `is_internal = false`. The constraint is tenant-scoped without being cross-tenant.
+
+This same pattern works for any "exactly one per tenant" or "exactly one of these per tenant" invariant — primary manager assignments, default settings rows, the auto-provisioned admin user. Use a partial unique index keyed on `tenant_id` with a `WHERE` clause matching the predicate.
+
+## What the wrapper does NOT do
+
+`withTenant()` only sets the tenant context. It does not:
+
+- Check the user's role — use `requireRole()` from `src/lib/auth/require-role.ts` for that.
+- Validate that the tenant exists — if you pass a UUID that no tenant has, queries return zero rows.
+- Audit-log the access — separate concern, lives in `src/lib/audit-middleware.ts`.
+
+These are intentional separations. A single helper that did all four would be impossible to compose with the auto-match orchestrator (which needs to switch tenants in the middle of a cron run) or with admin-only operations (which need to bypass certain checks). Keep `withTenant()` small.
+
+## Related
+
+- [System overview](./system-overview.md) — where `withTenant()` sits in the request lifecycle.
+- [Performance baselines](./performance.md) — the batching pattern that amortises the transaction overhead.
+- [DEC-003 — Row-Level Security](../decisions/dec-003-row-level-security.md) — the full decision record.

--- a/techdocs/architecture/performance.md
+++ b/techdocs/architecture/performance.md
@@ -1,0 +1,135 @@
+# Performance baselines
+
+_Where SkillAI is fast today, where it will hurt at scale, and what to flip when._
+
+This page is the forward-looking sizing exercise — not a current pain point. The working dataset as of the last performance audit (issue #83) is small; everything below is what to do when it grows.
+
+## Current baseline
+
+As of the most recent measurement:
+
+| Table | Rows |
+|---|---:|
+| `audit_logs` | 732 |
+| `interview_questions` | 270 |
+| `candidates` | 118 |
+| `ai_usage` | 49 |
+| `scores` | 43 |
+| `interview_packs` | 31 |
+| `roles` | 11 |
+
+## Hot pages
+
+### `/dashboard` — main dashboard
+
+**Today (~100 candidates):** server time ~50–80 ms cold, ~5–15 ms cached.
+
+**Target at 10k candidates:** &lt;500 ms p95 (issue #83 acceptance criterion — verified locally).
+
+The dashboard issues three top-level fetches in parallel, each inside a single `withTenant()` call:
+
+1. **`getForYouFeed`** — five sub-queries (interviews today/tomorrow, awaiting score, stale priorities, expired roles, manager approvals) inside one `withTenant` + `Promise.all`.
+2. **`getDashboardStats`** — five `count()` queries inside one `withTenant`, wrapped in `unstable_cache` with `revalidate: 60`. First load is one batch round-trip; subsequent loads within 60 s are zero round-trips.
+3. **List queries** — four queries (recent roles, top candidates, recent uploads, upcoming interviews) inside one `withTenant` + `Promise.all`.
+
+That's **three `withTenant` calls instead of eight sequential ones** — the change shipped in PR #173 closing issue #83. Each `withTenant` opens a transaction and runs `set_tenant_context()` for RLS; batching collapses that fixed cost.
+
+The 60 s stat cache is the highest-impact lever. After the first hit per tenant per minute, the stat-card row is effectively free.
+
+### `/dashboard/candidates` — candidates list
+
+**Today (~100 candidates):** ~30–60 ms.
+
+**Target at 10k candidates:** &lt;800 ms p95 (issue #83 acceptance criterion).
+
+Already structured as one `withTenant` + `Promise.all` across four sub-queries: rows, total count, agency list, bench count. The compound `(tenant_id, is_active, created_at DESC)` index covers the main row fetch.
+
+**Known weak spots that don't bite yet:**
+
+- **`LIMIT/OFFSET` pagination.** At page 400 of a 10 000-row table, Postgres scans 9 999 rows just to skip them. Switch to keyset (`(created_at, id)` cursor) once page 50+ becomes a common entry point. URL shape changes when this lands.
+- **`count()` on every page load.** Stays cheap up to ~50k rows with the compound index. Past that, swap for `pg_class.reltuples` and show "50k+" rather than an exact count.
+- **`ilike '%q%'` substring search.** No btree support. Cheap until ~10k candidates; install `pg_trgm` and add a GIN trigram index past that threshold.
+
+## Indexes
+
+Added in `src/db/migrations/0028_perf_indexes.sql` (PR #173):
+
+| Index | Table | Columns | Covers |
+|---|---|---|---|
+| `idx_candidates_tenant_active_created` | candidates | `(tenant_id, is_active, created_at DESC)` | Main candidates list, dashboard "Recent uploads" |
+| `idx_candidates_tenant_status_active` | candidates | `(tenant_id, status, is_active)` | Status-filtered candidate views |
+| `idx_scores_status_updated` | scores | `(score_status, updated_at DESC)` | Top candidates this week, scored this week |
+| `idx_roles_tenant_active_created` | roles | `(tenant_id, is_active, created_at DESC)` | Dashboard "Recent roles" |
+| `idx_interview_slots_scheduled_status` | interview_slots | `(scheduled_at, status)` | Dashboard "Upcoming interviews" |
+| `idx_interview_packs_status` | interview_packs | `(generation_status)` | Dashboard "Packs ready" stat |
+
+Pre-existing indexes that remain load-bearing: `idx_candidates_tenant`, `idx_candidates_agency`, `idx_candidates_agency_availability`, `idx_scores_role_overall`, `idx_scores_candidate`, `idx_audit_logs_tenant_created`, `idx_audit_logs_entity`.
+
+### Applying indexes in production
+
+The migration uses plain `CREATE INDEX IF NOT EXISTS` because Drizzle wraps each migration file in an implicit transaction, and `CREATE INDEX CONCURRENTLY` cannot run inside a transaction. For a busy production table, run manually outside the migration tool:
+
+```sql
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_candidates_tenant_active_created
+  ON candidates (tenant_id, is_active, created_at DESC);
+-- repeat per index
+```
+
+Then mark the migration as applied in `drizzle.__drizzle_migrations` so the migrator skips it. At current dev volumes the lock window is microseconds and the in-transaction approach is fine.
+
+## The AI cost cap as backpressure
+
+The auto-match orchestrator (`src/lib/auto-match/scoring.ts`) caps daily Claude spend at **$50 USD per tenant** by default. The cap is checked against today's sum of `cost_usd` in the `ai_usage` ledger filtered to `operation = 'auto_match_scoring'`. When hit, the orchestrator returns `skipped: true, reason: 'daily_cost_cap_exceeded'` and writes nothing.
+
+This is the only backpressure mechanism in the codebase — no rate limiter on the AI provider itself, no circuit breaker. Tenants override the default via `tenant_settings.auto_match_daily_cost_cap_usd`. The cap protects against runaway scoring loops and bug-induced retry storms.
+
+Per-tenant API rate limits exist separately (`src/lib/api/rate-limit.ts`) and apply at the REST + MCP entry points.
+
+## When to flip the next switch
+
+| Threshold | What to do | Why |
+|---|---|---|
+| Any table &gt; **5 000 rows** | Install `pg_stat_statements` (requires `shared_preload_libraries` + Postgres restart). Capture for 1 week. | Operational visibility into actual slow queries — until you have real data, optimisation is guesswork. |
+| Any table &gt; **5 000 rows** | Run `ANALYZE` after bulk imports + nightly via cron. | Planner stats get stale fast on growing tables; bad stats produce bad plans. |
+| candidates &gt; **10 000** | Install `pg_trgm`; add `CREATE INDEX … USING GIN (lower(first_name \|\| ' ' \|\| last_name) gin_trgm_ops)`. | `ilike '%q%'` becomes index-backed. |
+| Common entry past **page 50** of candidates | Switch from `LIMIT/OFFSET` to keyset using `(created_at DESC, id DESC)`. | Offset cost is linear with page number; keyset is O(log n). |
+| candidates &gt; **50 000** | Replace `count()` with `pg_class.reltuples` estimate. | Exact count becomes the dominant page cost; estimate is microseconds. |
+| audit_logs &gt; **1 000 000** | Partition `audit_logs` by month; expire after 24 months unless legal-hold flag set. | Single-table audit log starts to dominate vacuum + index-rebuild times. |
+| dashboard p95 &gt; **500 ms** with the current cache | Lower `revalidate: 60` to `30` or move stats to a materialised view refreshed by cron. | The 60 s cache is the load-bearing performance feature; if you're missing target, the underlying queries got expensive — investigate before extending the TTL. |
+
+## What was explicitly NOT done in #83
+
+- **`pg_stat_statements`** — operational lift outweighs value at &lt;1 000 rows per table. Defer to 5 000+.
+- **`pg_trgm` for search** — unnecessary at current scale. Defer to candidates &gt; 10 000.
+- **Keyset pagination** — page 50 is unreachable today; URL shape change isn't worth it yet.
+- **Background snapshot for stats** — `unstable_cache` with a 60 s TTL gives the same effective behaviour without scheduler infrastructure.
+- **Synthetic bulk-loading benchmarks** — ran the math against the indexed query plans; defer load tests until production has real data to compare against.
+
+## How to verify a query plan is index-backed
+
+Inside the running container:
+
+```bash
+docker exec -it skillai-db-1 psql -U skillai -d skillai
+```
+
+Then in `psql`, set the tenant variable so RLS doesn't filter you out, and `EXPLAIN ANALYZE` the query:
+
+```sql
+SET app.tenant_id = '<your-tenant-uuid>';
+
+EXPLAIN ANALYZE
+SELECT id, first_name, last_name FROM candidates
+WHERE tenant_id = '<tenant>'::uuid AND is_active = true
+ORDER BY created_at DESC
+LIMIT 25;
+```
+
+You want `Index Scan using idx_candidates_tenant_active_created` (or `Index Only Scan`) in the plan, not `Seq Scan`.
+
+## Related
+
+- Issue #83 — performance audit + caching layer (closed by PR #173).
+- Migration `0028_perf_indexes.sql` — the index additions documented above.
+- `src/app/(dashboard)/dashboard/page.tsx` — the parallel-fetch + cache pattern.
+- [Multi-tenancy & RLS](./multi-tenancy-rls.md) — why batching inside one `withTenant` matters.

--- a/techdocs/architecture/system-overview.md
+++ b/techdocs/architecture/system-overview.md
@@ -1,0 +1,101 @@
+# System overview
+
+_How SkillAI is wired together — the high-level boxes, the request lifecycle, and where AI fits in._
+
+SkillAI is a single Next.js 16 application backed by a single PostgreSQL 17 database. Everything else — file uploads, AI scoring, MCP integration — is either an in-process module or a thin transport adapter. There is no message queue, no worker fleet, no auxiliary service.
+
+The whole system runs on one Docker host for dev and small production deployments; on AWS EKS for larger ones (see [AWS deployment](../operations/aws-deploy.md)).
+
+## The boxes
+
+```mermaid
+flowchart LR
+  Browser([Browser])
+  MCP([claude-desktop or<br/>Claude Code])
+
+  subgraph Host[Docker host]
+    App[Next.js 16<br/>App Router]
+    DB[(PostgreSQL 17<br/>+ pgvector)]
+    Uploads[/uploads volume<br/>CVs + logos/]
+  end
+
+  AI[(Anthropic Claude<br/>Google Gemini)]
+
+  Browser -->|HTTPS| App
+  MCP -->|stdio bridge<br/>then HTTPS| App
+  App -->|withTenant + RLS| DB
+  App -->|read/write| Uploads
+  App -->|structured outputs| AI
+```
+
+Five things deserve attention:
+
+- **Next.js does everything serverside** — pages render as Server Components, mutations run as Server Actions, polling and exports run as API routes. No separate API tier.
+- **Postgres is the only stateful service.** All entities (tenants, users, candidates, roles, scores, audit logs, AI usage, calendar tokens) live here.
+- **pgvector ships in the same database image** (`pgvector/pgvector:pg17`). Embeddings live in `candidates.embedding` as a `vector(768)` column with an HNSW index. No separate vector store.
+- **Uploads live on a Docker volume** at `/app/uploads`. Production deployments swap this for an S3-compatible store (Garage). Details on [File storage](./file-storage.md).
+- **AI providers are the only external dependencies.** Anthropic Claude is the primary provider; Gemini is a per-tenant toggle. Both are called with structured-output schemas so responses never need defensive parsing.
+
+## The request lifecycle
+
+Every request — web UI, REST API, or MCP tool call — follows the same four-stage shape:
+
+```mermaid
+flowchart LR
+  Req([Request]) --> Auth[1\. Auth.js<br/>or bearer token]
+  Auth --> Mw[2\. Middleware<br/>injects x-tenant-id +<br/>x-user-role headers]
+  Mw --> Handler[3\. Server component /<br/>action / route handler]
+  Handler --> WT[4\. withTenant tx<br/>SET app.tenant_id]
+  WT --> DB[(Postgres + RLS)]
+```
+
+1. **Authenticate.** Web requests use Auth.js v5 JWTs stored in httpOnly cookies. API and MCP calls use bearer tokens (`skl_<env>_<24-base62>`) verified via argon2 in `src/lib/api/auth-middleware.ts`.
+2. **Inject tenant + role.** Middleware reads the JWT or token, forwards `x-tenant-id`, `x-user-id`, and `x-user-role` headers to the handler. Server components and actions read these via `headers()`.
+3. **Run the handler.** Server components fetch data; Server Actions mutate. Both validate input with Zod schemas before touching the database.
+4. **Wrap every query in `withTenant`.** The helper in `src/db/index.ts:28` opens a transaction and calls `set_tenant_context()` so PostgreSQL Row-Level Security policies filter rows to the correct tenant. See [Multi-tenancy & RLS](./multi-tenancy-rls.md) for the full pattern.
+
+Background work — AI scoring, interview pack generation, calendar sync diffing — runs via Next.js `after()`. There is no external queue.
+
+## Multi-tenancy at 10 000 ft
+
+One Postgres schema. Every table has `tenant_id UUID NOT NULL`. Every table enables RLS with a policy filtering on `current_setting('app.tenant_id', true)::uuid`. The `withTenant()` wrapper sets that session variable inside a transaction before any query runs.
+
+This means it is architecturally impossible for application code to read across tenant boundaries, even if a query is written incorrectly. The full rationale lives in [DEC-003](../decisions/dec-003-row-level-security.md).
+
+Hiring managers, recruiters, admins, and viewers all live in the same `users` table with a `role` column; role-based gates use the `requireRole()` helper. The `hiring_manager` rank sits between `viewer` and `recruiter` so existing `requireRole(_, 'recruiter')` guards continue to block managers without any call-site changes.
+
+## AI scoring at 10 000 ft
+
+When a CV is scored against a role:
+
+1. **Parse** the uploaded PDF/DOCX/etc. to plain text. Helpers in `src/lib/cv/store.ts`.
+2. **Insert** a `scores` row with `score_status = 'pending'`.
+3. **Return** immediately. The UI shows a "Scoring..." state.
+4. **Fan out** in `after()` to either `scoreCandidateWithClaude()` or `scoreCandidateWithGemini()` depending on the tenant's `default_ai_model` setting.
+5. **Validate** the structured-output response against the `CandidateScoreSchema` Zod schema. Failures land as `score_status='failed'` rows with the error message.
+6. **Update** the row to `score_status='complete'` with the four dimension scores, reasoning text, and the AI summary.
+7. **Poll** — the UI polls `/api/scores/<id>/status` every three seconds until the row reports complete or failed.
+
+Full detail on the pipeline, the structured-output schema, and the auto-match top-3 scoring loop lives in [AI scoring pipeline](./ai-scoring-pipeline.md).
+
+## Where to next
+
+
+### Multi-tenancy & RLS
+
+The `withTenant()` wrapper, the RLS policy template, and why this beats schema-per-tenant. [Read more](./multi-tenancy-rls.md).
+
+
+### AI scoring pipeline
+
+End-to-end flow from CV upload to ranked list. Includes the structured-output schema and auto-match. [Read more](./ai-scoring-pipeline.md).
+
+
+### File storage
+
+Docker volume layout, the logo upload pattern, path-traversal defence. [Read more](./file-storage.md).
+
+
+### Tech stack
+
+Every chosen library with versions and a one-sentence "why". [Read more](./tech-stack.md).

--- a/techdocs/architecture/tech-stack.md
+++ b/techdocs/architecture/tech-stack.md
@@ -1,0 +1,96 @@
+# Tech stack
+
+_Every chosen library with its version and a one-sentence rationale._
+
+Canonical source is `.agent-os/product/tech-stack.md` in the repo. This page is the documentation-site version of the same list.
+
+> **ℹ️ Note**
+>
+> For *why* a given technology was chosen over the obvious alternative, see the [design decisions](../decisions/index.md) — each major pick has its own decision record (Drizzle over Prisma, RLS over schema-per-tenant, Auth.js over Clerk, etc.).
+
+## Application framework
+
+| Item | Choice | Why |
+|---|---|---|
+| Framework | **Next.js 16.2+** (App Router, standalone output) | Server Components + Server Actions + `after()` cover pages, mutations, and background work without a separate API tier. |
+| Language | **TypeScript 5.x**, strict mode | No `any` except where the third-party SDK forces it. |
+| Runtime | **Node.js 22 LTS** | Matches the `node:22-alpine` image used in Docker. |
+| Rendering | Server Components for data-heavy views; Client Components for interactive UI; Server Actions for mutations | One framework, one execution model. |
+
+## Database
+
+| Item | Choice | Why |
+|---|---|---|
+| Engine | **PostgreSQL 17** | Latest stable; same image used in dev and prod. |
+| Extension | **pgvector** (HNSW indexing) | Native vector type + cosine distance for candidate semantic search — no separate vector store. |
+| Multi-tenancy | **Row-Level Security** with `SET app.tenant_id` per request | Isolation enforced at the DB layer; see [DEC-003](../decisions/dec-003-row-level-security.md). |
+| ORM | **Drizzle ORM** | First-class pgvector support, type-safe SQL-like query builder, no query-engine binary; see [DEC-002](../decisions/dec-002-drizzle-over-prisma.md). |
+
+## AI / ML
+
+**What we picked**
+
+| Item | Choice |
+|---|---|
+| Primary scoring | **Anthropic Claude** (`claude-sonnet-4-6`) with tool-use structured outputs |
+| Secondary scoring | **Google Gemini** (`gemini-2.0-flash`) with `responseSchema` JSON mode |
+| Embeddings | **Gemini `models/gemini-embedding-001`** (768 dimensions) |
+| CV parsing | **`pdf-parse`** (PDF) + **`mammoth`** (DOCX); plus ODT/RTF/TXT/MD parsers |
+| Scoring schema | `CandidateScoreSchema` in `src/lib/ai/schema.ts` — Zod-validated, identical shape for both providers |
+
+**What we considered**
+
+- **OpenAI GPT-4 for scoring** — comparable quality, but Claude's structured outputs (tool_use) gave a stronger contract than JSON-mode at the time of the decision. See [DEC-004](../decisions/dec-004-claude-primary.md).
+- **OpenAI `text-embedding-3-small`** for embeddings — viable, but the Gemini embedding model is already in the stack for scoring keys and is cheap enough that adding a second provider for embeddings wasn't worth it.
+- **A vendor LLM gateway** (LangChain, LiteLLM) — rejected; the two-provider abstraction in `src/lib/ai/scoring.ts` is ~30 lines and zero dependencies.
+
+## Frontend
+
+| Item | Choice | Why |
+|---|---|---|
+| UI components | **shadcn/ui** | Best-in-class tables, forms, dialogs for data-heavy internal tools. |
+| Styling | **TailwindCSS 4.0+** | CSS-var token system lives in `src/app/globals.css` for light/dark theme. |
+| Icons | **Lucide React** | Tree-shakable, consistent. |
+| Server state | **TanStack Query v5** | Polling for AI generation progress; cache invalidation for lists. |
+| Local UI state | **Zustand** | Selected candidates, comparison tray, active filters. |
+| File uploads | **`react-dropzone`** + Server Action handlers | Native FormData handling, no extra API surface. |
+| Data tables | **TanStack Table v8** | Virtualised, sortable, filterable candidate lists. |
+
+## Authentication
+
+| Item | Choice | Why |
+|---|---|---|
+| Library | **Auth.js v5 (NextAuth v5)** | Self-hosted; no candidate or session data leaves the host. See [DEC-006](../decisions/dec-006-authjs-over-clerk.md). |
+| Strategy | Credentials provider (email + password) | Internal tool; no SSO requirement in v1. |
+| Session | **JWT** in httpOnly cookies | Tenant ID + role embedded in the token. |
+| Roles | `admin` &gt; `recruiter` &gt; `hiring_manager` &gt; `viewer` | Ranked so `requireRole(_, 'recruiter')` blocks managers without call-site changes. |
+| API auth | Bearer tokens (`skl_<env>_<24-base62>`), argon2-hashed | Per-token scope (`read` / `write` / `admin`) enforced by `withApiAuth`. |
+
+## File storage
+
+| Item | Choice | Why |
+|---|---|---|
+| Dev / small prod | **Local Docker volume** at `/app/uploads` | Zero dependencies; data stays on the host. See [DEC-005](../decisions/dec-005-storage.md). |
+| Larger prod | **Garage** (self-hosted S3-compatible) | Drop-in S3 SDK compatibility; no public cloud dependency. |
+| Max CV size | **10 MB** per file (PDF/DOCX/ODT/TXT/RTF/MD) | Enforced in `src/lib/cv/store.ts:18`. |
+| Max logo size | **2 MB** (PNG/JPEG/WebP only — no SVG) | Enforced in `src/lib/branding/store.ts:16`. SVG rejected for XSS surface. |
+
+Full layout, path-traversal guards, and the symmetric DB-path/disk-path resolution pattern live in [File storage](./file-storage.md).
+
+## Infrastructure & deployment
+
+| Item | Choice | Why |
+|---|---|---|
+| Orchestration | **Docker Compose** for dev/single-host; **AWS EKS** for cloud | Same Dockerfile in both. See [AWS deployment](../operations/aws-deploy.md). |
+| App image | `node:22-alpine` (multi-arch — arm64 on Graviton) | Small surface, fast cold start. |
+| DB image | **`pgvector/pgvector:pg17`** | pgvector pre-installed; no manual extension setup. |
+| Reverse proxy | **Caddy** (single-host with automatic HTTPS) or **NGINX Ingress + cert-manager** (Kubernetes) | Operator choice. |
+| Migrations | **Drizzle Kit** — `db:push` for dev, `db:migrate` for prod | Migrations live in `src/db/migrations/`. |
+| CI/CD | **GitHub Actions** | Build + push to ECR; `kubectl apply -k` for the rolling deploy. |
+
+## Code repository
+
+- **Platform:** GitHub
+- **URL:** [github.com/olafkfreund/SkillAi](https://github.com/olafkfreund/SkillAi)
+- **Main branch:** `core-mvp-foundation`
+- **Branching:** every PR branches off `core-mvp-foundation` explicitly

--- a/techdocs/code-patterns/agency-logo.md
+++ b/techdocs/code-patterns/agency-logo.md
@@ -1,0 +1,81 @@
+# Agency logo on candidate displays
+
+_How an agency logo is shown alongside candidate identity across lists, role cards, candidate detail headers, and PDF exports — with an initials fallback when no logo is set._
+
+Every candidate surface that shows the candidate's name also shows the originating agency's logo (or an initials avatar fallback) so the source of every candidate is visible at a glance. The visual treatment is consistent across web and PDF: a small rounded-full image with explicit width/height, `object-contain`, and a tinted-background placeholder when the image is unavailable.
+
+## Sizes by surface
+
+| Surface | Size | File |
+|---|---|---|
+| Candidate list | 20 × 20 | [`src/components/candidates/selectable-candidate-list.tsx`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/components/candidates/selectable-candidate-list.tsx) |
+| Role-detail candidate card | 20 × 20 | [`src/components/roles/role-candidate-card.tsx`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/components/roles/role-candidate-card.tsx) |
+| Candidate detail header | 24 × 24 | candidate detail page |
+| Candidate PDF export | 32 × 32 | [`src/app/api/export/candidate/[candidateId]/route.ts`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/app/api/export/candidate/%5BcandidateId%5D/route.ts) |
+
+The agency-logo-on-candidate surfaces are deliberately smaller than the logos on the agency list or detail pages (32 / 64 px) — at candidate scale the logo is identification, not branding.
+
+## Web pattern — conditional render with initials fallback
+
+The canonical snippet appears in `selectable-candidate-list.tsx:20` and `role-candidate-card.tsx:168`. Both components do exactly the same thing:
+
+```tsx
+{agencyLogoPath ? (
+  <img
+    src={`/api/agencies/${agencyId}/logo`}
+    alt=""
+    width={20}
+    height={20}
+    style={{ width: 20, height: 20 }}
+    className="rounded-full border border-[var(--color-border)]
+               bg-[var(--color-bg-input)] object-contain shrink-0"
+  />
+) : (
+  <div
+    className="flex items-center justify-center rounded-full
+               bg-[var(--color-bg-input)] text-[var(--color-fg-muted)]
+               text-xs font-semibold shrink-0"
+    style={{ width: 20, height: 20 }}
+    aria-hidden="true"
+  >
+    {agencyName?.charAt(0).toUpperCase() ?? '?'}
+  </div>
+)}
+```
+
+A few rules baked in:
+
+- **`alt=""`** on the image — the agency name is rendered as a sibling `<span>`, so the logo is decorative and screen readers don't need to repeat it. The initials fallback is `aria-hidden="true"` for the same reason.
+- **Both `width`/`height` attributes and inline `style`** — the attributes prevent layout shift before CSS loads; the inline style locks the size against any inherited `img { max-width: 100% }` rules.
+- **`object-contain`** so a non-square logo letterboxes inside the circle rather than stretching.
+- **`shrink-0`** so a long candidate name in the adjacent flex item doesn't compress the logo.
+- **`bg-[var(--color-bg-input)]` placeholder** — gives the rounded shape mass before the image loads and serves as the tinted background for both states.
+
+The image source is `/api/agencies/{agencyId}/logo`, which is auth-gated and tenant-scoped. Files are served with a 5-minute private cache header.
+
+## PDF pattern — base64 data URI
+
+`react-pdf` runs server-side without browser networking, so PDFs can't fetch the logo over HTTP. The candidate PDF route reads the file from disk once via `getLogoAbsolutePath`, encodes it as a base64 data URI, and hands the string to react-pdf's `<Image>` component. Implementation at `route.ts:205`:
+
+```ts
+let agencyLogoBase64: string | undefined
+if (audience === 'internal' && agency?.logoPath) {
+  try {
+    const absPath = getLogoAbsolutePath(agency.logoPath)
+    const logoBuffer = await fs.readFile(absPath)
+    const ext = agency.logoPath.split('.').pop()?.toLowerCase() ?? 'png'
+    const mime = ext === 'jpg' || ext === 'jpeg' ? 'image/jpeg'
+      : ext === 'webp' ? 'image/webp'
+      : 'image/png'
+    agencyLogoBase64 = `data:${mime};base64,${logoBuffer.toString('base64')}`
+  } catch {
+    // File unreadable — render the PDF without the logo
+  }
+}
+```
+
+The `audience === 'internal'` gate matters: customer-facing PDF variants never embed the agency logo because the originating agency is one of the fields stripped for the customer audience.
+
+> **💡 Tip**
+>
+> The full storage + serving pipeline (validation, path symmetry, the storage helper) is documented on the [logo upload page](./logo-upload.md). This page covers only the candidate-side rendering surfaces.

--- a/techdocs/code-patterns/audience-sanitisation.md
+++ b/techdocs/code-patterns/audience-sanitisation.md
@@ -1,0 +1,61 @@
+# Audience-based view sanitisation
+
+_How the audience prop strips commercially-sensitive and internal data per persona without forking the underlying components._
+
+SkillAI renders the same role and candidate components for three personas. Each page and shared component takes an `audience: 'recruiter' | 'customer' | 'manager'` prop and conditionally strips fields rather than duplicating the component tree. Recruiters see everything. Customers see no internal notes, day rates, margin, or originating agency. Managers see the score breakdown, AI reasoning, and the interview pack — but no rates, margin, or agency — and every edit control becomes read-only.
+
+## Surfaces that thread `audience`
+
+The prop is threaded end-to-end from the page server component into each child:
+
+- Role detail page and candidate detail page (top-level entry points)
+- [`src/components/roles/role-candidate-card.tsx`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/components/roles/role-candidate-card.tsx)
+- `EditDetailsForm` (edit controls disabled when not `recruiter`)
+- `NotesPanel` (also filters by `note.is_shareable`)
+- `RoleTagsPanel`, `PriorityKeywordsPanel` (read-only for managers)
+
+## Worked example — the margin pill
+
+`RoleCandidateCard` shows day-rate margin to recruiters but hides it from managers. The component aliases the audience check once at the top of the render body:
+
+```tsx
+const isManagerView = audience === 'manager'
+
+// …later, inside the score row:
+{!isManagerView && (
+  <MarginPill
+    roleRate={roleDayRate}
+    roleCurrency={roleCurrency}
+    candRate={candidateRate}
+    candCurrency={candidateCurrency}
+  />
+)}
+```
+
+The same flag also hides the destructive "Remove from role" button so managers can read but never mutate (`role-candidate-card.tsx:220`). Customers never reach this component at all — the customer share page renders a different sanitised tree.
+
+## Notes panel — the extra `is_shareable` rule
+
+Notes have a second layer on top of `audience`. Each `notes` row carries an `is_shareable` boolean that defaults to `false`. For the manager audience the panel filters to `audience === 'manager' ? notes.filter(n => n.is_shareable) : notes`. Recruiters opt-in per note when they want a manager to see it; nothing leaks by accident.
+
+## Adding a new field
+
+When you add a field that contains commercial or internal data, gate it on `audience === 'recruiter'` **explicitly**. Default-visible-and-then-hidden is the wrong direction — a missing audience check on a new field is the failure mode this pattern exists to prevent.
+
+```tsx
+type Props = {
+  audience?: 'recruiter' | 'customer' | 'manager'
+  internalNotes: string | null
+  // …
+}
+
+export function Panel({ audience = 'recruiter', internalNotes }: Props) {
+  if (audience !== 'recruiter') return null
+  if (!internalNotes) return null
+  return <section className="text-[var(--color-fg-muted)]">{internalNotes}</section>
+}
+```
+
+> **⚠️ Caution**
+>
+> Day rates and margin are the canonical example of internal-only data — see [DEC-009](../decisions/dec-009-soft-budget-signal.md) for why budget context is rendered as a margin pill for recruiters while being deliberately invisible to customers and managers.

--- a/techdocs/code-patterns/force-dynamic.md
+++ b/techdocs/code-patterns/force-dynamic.md
@@ -1,0 +1,45 @@
+# force-dynamic on public routes
+
+_Why two routes are pinned to force-dynamic, what bug it works around, and the rule for adding new App Router routes._
+
+`next build` fails on Next 16.2 + React 19 with `Cannot read properties of null (reading 'useContext')` whenever the build tries to statically prerender a route whose layout transitively renders a client component that reads React context at module scope. The `<ThemeProvider>` from `next-themes` in the root layout is the trigger in this codebase — React's context machinery is null during static prerender, so the `useContext` call inside `next-themes` throws.
+
+The workaround is one line per affected route:
+
+```ts
+export const dynamic = 'force-dynamic'
+```
+
+This skips static prerender entirely and the build stays green.
+
+## Where it's applied
+
+Two routes in the tree currently carry the directive:
+
+- [`src/app/page.tsx`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/app/page.tsx) — the home page, which only redirects to `/dashboard`. Zero cost; nothing visible to cache.
+- [`src/app/(dashboard)/layout.tsx`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/app/(dashboard)/layout.tsx) — the dashboard layout. Session-gated anyway, so static caching would never apply to real traffic.
+
+Both files carry a multi-line "DO NOT REMOVE" banner above the export so the directive isn't innocently deleted by a future contributor. PR [#171](https://github.com/olafkfreund/SkillAi/pull/171) strengthened that banner specifically because the failure mode is silent in dev and only surfaces during a production build.
+
+## Rule for new routes
+
+When you add a public route under `src/app/`, default to `force-dynamic`:
+
+```ts
+// src/app/(marketing)/about/page.tsx
+export const dynamic = 'force-dynamic'
+
+export default function AboutPage() {
+  // …
+}
+```
+
+The only routes that are safe to omit it on are `[param]`-style **dynamic segments without static params** — those don't get prerendered, so they don't hit the bug. Static collected routes (anything that could be selected for prerender) need the directive.
+
+## Why not fix the root cause?
+
+The fix lives upstream in either Next.js or React, not in this repo. Tracked in issue [#41](https://github.com/olafkfreund/SkillAi/issues/41) as "closed by workaround" — the issue stays open as the canonical reference until an upstream patch lands. Until then:
+
+> **⚠️ Caution**
+>
+> If you're tempted to remove `force-dynamic` from `page.tsx` or `(dashboard)/layout.tsx`, run `next build` first. The error surfaces immediately and the message is the one quoted above. Re-read [#41](https://github.com/olafkfreund/SkillAi/issues/41) before removing the directive.

--- a/techdocs/code-patterns/help-content.md
+++ b/techdocs/code-patterns/help-content.md
@@ -1,0 +1,71 @@
+# In-app help content
+
+_How the /dashboard/help articles are authored as flat markdown files, validated by Zod at load time, and filtered by user role._
+
+The in-app help hub at `/dashboard/help` is a flat-file system: every article is a `.md` file in `src/content/help/` with YAML front-matter. Authoring a new article means dropping a file in that directory — no code change, no migration, no rebuild step beyond the next deploy. The loader is [`src/lib/help/loader.ts`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/lib/help/loader.ts) and is marked `'server-only'` so it never leaks into a client bundle.
+
+## Front-matter shape
+
+Every article declares these fields. The schema is enforced by Zod at load time so a malformed file fails loudly with a console warning and is skipped — it never reaches the UI:
+
+```yaml
+---
+title: "GDPR right-to-erasure (deleting a candidate)"
+category: "Settings & Admin"
+audience: ["admin"]
+order: 55
+lastUpdated: "2026-04-28"
+tags: ["gdpr", "privacy", "compliance"]
+---
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `title` | string | Required, non-empty |
+| `category` | enum | One of the 8 fixed categories below |
+| `audience` | string[] | Defaults to `['all']` |
+| `order` | number | Sort key, defaults to `100` |
+| `lastUpdated` | `YYYY-MM-DD` | Validated by regex |
+| `tags` | string[] | Free-form, defaults to `[]` |
+
+The 8 categories are fixed in code (`CATEGORIES` const): Getting Started, Roles & Candidates, AI Scoring & Interviews, Hiring Manager Workflow, Agencies & Customers, Settings & Admin, Tips & Best Practice, Troubleshooting. Adding a new category is a one-line code change.
+
+## Audience filter
+
+`audience` accepts `'all' | 'admin' | 'recruiter' | 'hiring_manager' | 'viewer'`. The loader's public API takes the current user's `UserRole` and filters before returning:
+
+```ts
+function isVisibleTo(article: HelpArticle, role: UserRole): boolean {
+  return article.audience.includes('all') || (article.audience as string[]).includes(role)
+}
+```
+
+So a hiring manager browsing `/dashboard/help` sees only `audience: ["all"]` and `audience: ["hiring_manager"]` articles — recruiter-only operational guides simply aren't in their navigation tree.
+
+## Validation failure mode
+
+`parseFile` wraps the whole parse in `try/catch`. If `matter()` chokes on bad YAML, or Zod rejects the parsed object (missing `title`, wrong category, malformed date), the failure logs a warning and returns `null`. The article is skipped, the loader keeps going, the rest of the help hub renders normally. Failing loud-but-isolated is deliberate: one broken article doesn't take down the whole page, but the warning ensures the breakage isn't silent.
+
+```ts
+} catch (err) {
+  console.warn(`[help/loader] Skipping ${filePath}: ${(err as Error).message}`)
+  return null
+}
+```
+
+## Module-scope cache
+
+Articles are read from disk once per Node.js process and cached in a module-scope `Map`. Files don't change at runtime in production, so the filesystem cost is paid once on the first request and never again. In dev, restart the server to pick up new articles.
+
+## Adding an article
+
+1. Create `src/content/help/your-slug.md`
+2. Add the front-matter block above (pick the right category and audience)
+3. Write markdown body
+4. Done — it appears in `/dashboard/help` after the next request
+
+No registration step, no index update.
+
+> **ℹ️ Note**
+>
+> This is **distinct** from the docs site you're reading now. In-app help is recruiter-facing operational quick-reference loaded inside the SkillAI app and gated by the logged-in user's role. This docs site is the engineering and integration reference — public, no auth, MDX with Starlight components, deployed separately. Don't mix concerns: a new "how does the manager approval flow work" article belongs in `src/content/help/`; a new "how does the audience-sanitisation pattern work" page belongs here under `code-patterns/`.

--- a/techdocs/code-patterns/logo-upload.md
+++ b/techdocs/code-patterns/logo-upload.md
@@ -1,0 +1,85 @@
+# Logo upload (agency & customer)
+
+_How agency and customer logos are uploaded, stored, served over HTTP, and embedded into PDFs without write-vs-read path drift._
+
+Agency and customer logos share one storage pipeline implemented in [`src/lib/branding/store.ts`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/lib/branding/store.ts). It enforces validation, computes the canonical path, persists to disk, and exposes a single helper for converting the stored web-relative path back to an absolute filesystem path. The strict invariant: **the absolute filesystem path is always derived from the DB-stored path** via the same helper, so write and read can never drift apart.
+
+## Validation
+
+`validateLogoFile` checks three things and returns a discriminated union (`{ ok: true } | { ok: false; error }`) so callers handle errors without `try/catch`:
+
+- Buffer is non-empty and under the 2 MB cap (`MAX_LOGO_SIZE`)
+- Extension is one of `.png`, `.jpg`, `.jpeg`, `.webp` — no SVG
+- Magic-byte MIME detected by `file-type` matches the same allow-list
+
+```ts
+const buf = Buffer.from(await file.arrayBuffer())
+const validation = await validateLogoFile(buf, extname(file.name))
+if (!validation.ok) return { success: false, error: validation.error }
+```
+
+The magic-byte check exists specifically to reject SVGs or other formats that someone has renamed to a permitted extension.
+
+## Path shape
+
+The DB stores a web-relative path with a leading slash:
+
+```
+/uploads/{tenantId}/logos/{uuid}.{ext}
+```
+
+The filesystem write path is **derived from that exact DB path** by stripping the leading slash and joining with `process.cwd()`:
+
+```ts
+// inside persistLogo
+const dbPath = `/uploads/${tenantId}/logos/${randomUUID()}${normExt}`
+const absolutePath = getLogoAbsolutePath(dbPath) // strips leading "/", joins cwd
+await mkdir(join(absolutePath, '..'), { recursive: true })
+await writeFile(absolutePath, buf)
+return dbPath
+```
+
+`tenantId` is always supplied by the server from the authenticated session — never accepted from client `FormData`. Regression risk on this symmetry was issue [#98](https://github.com/olafkfreund/SkillAi/issues/98): an earlier implementation computed the write path independently of the DB path, and one rename to the storage root broke reads while leaving writes happy.
+
+## Serving over HTTP
+
+The web reads logos through `/api/agencies/{agencyId}/logo` (and the matching customer route). The route auths the session, validates the UUID, fetches the agency under RLS with an explicit `tenantId` filter (belt-and-suspenders), resolves the absolute path via `getLogoAbsolutePath`, and streams the file back with a 5-minute private cache. ENOENT becomes `410 file_missing`; cross-tenant lookups are `403`. Implementation in [`src/app/api/agencies/[agencyId]/logo/route.ts`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/app/api/agencies/%5BagencyId%5D/logo/route.ts).
+
+## Embedding in PDFs
+
+PDFs can't hit an authenticated HTTP endpoint, so they read the file directly and inline it as a base64 data URI. The pattern lives in [`src/app/api/export/candidate/[candidateId]/route.ts`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/app/api/export/candidate/%5BcandidateId%5D/route.ts) around line 207:
+
+```ts
+if (audience === 'internal' && agency?.logoPath) {
+  try {
+    const absPath = getLogoAbsolutePath(agency.logoPath)
+    const logoBuffer = await fs.readFile(absPath)
+    const ext = agency.logoPath.split('.').pop()?.toLowerCase() ?? 'png'
+    const mime = ext === 'jpg' || ext === 'jpeg' ? 'image/jpeg'
+      : ext === 'webp' ? 'image/webp'
+      : 'image/png'
+    agencyLogoBase64 = `data:${mime};base64,${logoBuffer.toString('base64')}`
+  } catch {
+    // File unreadable — render without the logo
+  }
+}
+```
+
+The encoded string is handed to `react-pdf`'s `<Image>` component. Customer-facing PDF variants skip this block entirely because agency identity is one of the fields stripped for the customer audience.
+
+## Rendered sizes
+
+| Surface | Size | File |
+|---|---|---|
+| Candidate list row | 20 × 20 | `selectable-candidate-list.tsx` |
+| Role-detail candidate card | 20 × 20 | `role-candidate-card.tsx` |
+| Candidate detail header | 24 × 24 | candidate detail page |
+| Agency / customer list | 32 × 32 | list pages |
+| Agency / customer detail header | 64 × 64 | detail pages |
+| Internal candidate PDF | 32 × 32 | `CandidatePDF` component |
+
+When `agencyLogoPath` is null, the same surfaces render an initials avatar — `bg-[var(--color-bg-input)]` circle with the agency's first letter uppercased. Always set explicit `width` and `height` (both as attributes and inline `style`) plus `object-contain` so a non-square logo never stretches.
+
+> **ℹ️ Note**
+>
+> For the broader storage architecture — why the local Docker volume rather than S3, and the planned Garage upgrade path — see [DEC-005](../decisions/dec-005-storage.md).

--- a/techdocs/code-patterns/theme-tokens.md
+++ b/techdocs/code-patterns/theme-tokens.md
@@ -1,0 +1,52 @@
+# Theme tokens (light & dark)
+
+_The CSS-variable token system in globals.css, the rules for when to use a token vs a direct Tailwind colour, and the status-pill dark-prefix pattern._
+
+SkillAI ships both a dark theme (default) and a light theme via `next-themes`. The colour system is a small set of CSS variables declared in [`src/app/globals.css`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/app/globals.css) and consumed through Tailwind's `bg-[var(--token)]` arbitrary-value syntax. The dark palette lives under `:root`; the light palette lives under `.light` and is activated by toggling that class on `<html>`.
+
+## Surface tokens
+
+These six tokens cover every chrome surface in the app:
+
+| Token | Dark value | Light value | Use for |
+|---|---|---|---|
+| `--color-bg-app` | `#09090b` zinc-950 | `#f4f4f5` zinc-100 | Page background |
+| `--color-bg-elevated` | `#18181b` zinc-900 | `#ffffff` | Cards, panels, sidebar |
+| `--color-bg-input` | `#27272a` zinc-800 | `#f9fafb` gray-50 | Form inputs, hover states |
+| `--color-fg` | `#f4f4f5` zinc-100 | `#18181b` zinc-900 | Primary text |
+| `--color-fg-muted` | `#a1a1aa` zinc-400 | `#52525b` zinc-600 | Secondary text |
+| `--color-fg-subtle` | `#71717a` zinc-500 | `#6b7280` gray-500 | Tertiary text, captions |
+| `--color-border` | `#3f3f46` zinc-700 | `#d1d5db` gray-300 | All borders |
+
+Every pair has been measured for WCAG AA contrast in both modes — the comments alongside each token in `globals.css` show the measured ratio.
+
+```tsx
+<div className="bg-[var(--color-bg-elevated)] border border-[var(--color-border)] text-[var(--color-fg)]">
+  <h2 className="text-[var(--color-fg)]">Title</h2>
+  <p className="text-[var(--color-fg-muted)]">Body copy</p>
+  <small className="text-[var(--color-fg-subtle)]">Timestamp</small>
+</div>
+```
+
+## Saturated accents stay as direct Tailwind
+
+Solid action buttons and brand-coloured pills (`bg-blue-600`, `bg-emerald-700`, `bg-violet-600`, `bg-amber-500`, `bg-red-600`) are theme-invariant — they read correctly on both light and dark surfaces without re-tinting. Leave these as plain Tailwind utilities; do not convert them to tokens. The token system is for surfaces and text, not accent colour.
+
+## Status pills — the `dark:` prefix pattern
+
+Status pills (Scoring, Submitted, INTERNAL, score buckets) carry their own per-status colour pair and need to read in both themes. The convention is `bg-X-100 dark:bg-X-950 text-X-700 dark:text-X-300 border-X-300 dark:border-X-800`. Pale tint + saturated text in light mode flips to dark tint + lighter text in dark mode, and contrast holds either way.
+
+```tsx
+<span className="inline-flex items-center gap-1 text-xs border rounded-full px-2 py-0.5
+                 bg-emerald-100 dark:bg-emerald-950
+                 text-emerald-700 dark:text-emerald-300
+                 border-emerald-300 dark:border-emerald-800">
+  Submitted
+</span>
+```
+
+The six pipeline statuses (new / shortlisted / interviewing / offered / hired / rejected) additionally have dedicated tokens (`--color-status-{state}-bg`, `--color-status-{state}-fg`) so the candidate-list status badge can use a single class lookup — see `STATUS_BADGE` in [`selectable-candidate-list.tsx:43`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/components/candidates/selectable-candidate-list.tsx#L43).
+
+> **⚠️ Caution**
+>
+> Never reintroduce hardcoded `bg-zinc-{700,800,900,950}`, `text-zinc-{100,300,400,500,600}`, or `border-zinc-{600,700,800}` for surfaces. Those classes were the v1 dark-only palette and don't flip under `.light`. The full migration was Epic [#103](https://github.com/olafkfreund/SkillAi/issues/103), shipped across PRs [#161](https://github.com/olafkfreund/SkillAi/pull/161)–[#165](https://github.com/olafkfreund/SkillAi/pull/165). See [DEC-001](../decisions/dec-001-build-vs-buy.md) for the broader self-hosted, theme-controlled product stance.

--- a/techdocs/database/overview.md
+++ b/techdocs/database/overview.md
@@ -1,0 +1,65 @@
+# Schema overview
+
+_Logical grouping of the 29 tables in the SkillAI database._
+
+> **💡 Tip**
+>
+> **28 tables**, all multi-tenant via PostgreSQL Row-Level Security. Every tenant-scoped table includes `tenant_id UUID NOT NULL` and is filtered by an RLS policy that reads `app.tenant_id` from the session. See [DEC-003](../decisions/dec-003-row-level-security.md) for the rationale.
+
+## Identity & tenancy
+
+| Table | Columns | Source |
+|---|---|---|
+| [`tenants`](./tables/tenants.md) | 5 | `src/db/schema/tenants.ts` |
+| [`users`](./tables/users.md) | 12 | `src/db/schema/users.ts` |
+| [`user_invitations`](./tables/user-invitations.md) | 9 | `src/db/schema/user-invitations.ts` |
+| [`tenant_settings`](./tables/tenant-settings.md) | 6 | `src/db/schema/tenant-settings.ts` |
+| [`api_tokens`](./tables/api-tokens.md) | 11 | `src/db/schema/api-tokens.ts` |
+
+## Roles & candidates
+
+| Table | Columns | Source |
+|---|---|---|
+| [`roles`](./tables/roles.md) | 27 | `src/db/schema/roles.ts` |
+| [`candidates`](./tables/candidates.md) | 41 | `src/db/schema/candidates.ts` |
+| [`cv_profiles`](./tables/cv-profiles.md) | 13 | `src/db/schema/cv-profiles.ts` |
+| [`candidate_enrichments`](./tables/candidate-enrichments.md) | 11 | `src/db/schema/candidate-enrichments.ts` |
+| [`role_managers`](./tables/role-managers.md) | 7 | `src/db/schema/role-managers.ts` |
+| [`role_submissions`](./tables/role-submissions.md) | 13 | `src/db/schema/role-submissions.ts` |
+
+## Scoring & matching
+
+| Table | Columns | Source |
+|---|---|---|
+| [`scores`](./tables/scores.md) | 18 | `src/db/schema/scores.ts` |
+| [`ai_usage`](./tables/ai-usage.md) | 13 | `src/db/schema/ai-usage.ts` |
+
+## Interviews & approvals
+
+| Table | Columns | Source |
+|---|---|---|
+| [`interview_slots`](./tables/interview-slots.md) | 17 | `src/db/schema/interview-slots.ts` |
+| [`interview_packs`](./tables/interview-packs.md) | 15 | `src/db/schema/interview-packs.ts` |
+| [`interview_questions`](./tables/interview-questions.md) | 13 | `src/db/schema/interview-questions.ts` |
+| [`code_challenges`](./tables/code-challenges.md) | 9 | `src/db/schema/code-challenges.ts` |
+| [`interview_transcripts`](./tables/interview-transcripts.md) | 14 | `src/db/schema/interview-transcripts.ts` |
+| [`transcript_analyses`](./tables/transcript-analyses.md) | 19 | `src/db/schema/transcript-analyses.ts` |
+| [`candidate_role_approvals`](./tables/candidate-role-approvals.md) | 9 | `src/db/schema/candidate-role-approvals.ts` |
+
+## Agencies, customers, notes
+
+| Table | Columns | Source |
+|---|---|---|
+| [`agencies`](./tables/agencies.md) | 11 | `src/db/schema/agencies.ts` |
+| [`customers`](./tables/customers.md) | 13 | `src/db/schema/customers.ts` |
+| [`customer_frameworks`](./tables/customer-frameworks.md) | 9 | `src/db/schema/customer-frameworks.ts` |
+| [`notes`](./tables/notes.md) | 9 | `src/db/schema/notes.ts` |
+| [`sent_emails`](./tables/sent-emails.md) | 15 | `src/db/schema/sent-emails.ts` |
+| [`email_templates`](./tables/email-templates.md) | 9 | `src/db/schema/email-templates.ts` |
+
+## Calendars & audit
+
+| Table | Columns | Source |
+|---|---|---|
+| [`calendar_connections`](./tables/calendar-connections.md) | 9 | `src/db/schema/calendar-connections.ts` |
+| [`audit_logs`](./tables/audit-logs.md) | 10 | `src/db/schema/audit-logs.ts` |

--- a/techdocs/database/tables/agencies.md
+++ b/techdocs/database/tables/agencies.md
@@ -1,0 +1,27 @@
+# agencies
+
+_Schema reference for the agencies table._
+
+> **ℹ️ Note**
+>
+> Auto-generated from `src/db/schema/agencies.ts`. **11** columns. To regenerate locally, run `npm run docs:gen:db` from `docs-site/`.
+
+**Tenant-scoped.** This table includes `tenant_id` and is enforced by Row-Level Security. All queries must run inside `withTenant(tenantId, ...)`. See [Multi-tenancy & RLS](../../architecture/multi-tenancy-rls.md).
+
+## Columns
+
+| Column | Type | Constraints | Default | References |
+|---|---|---|---|---|
+| `id` | `uuid` | `PRIMARY KEY` | `gen_random_uuid()` | — |
+| `tenant_id` | `uuid` | `NOT NULL` | — | `tenants.id` |
+| `name` | `varchar(150)` | `NOT NULL` | — | — |
+| `contact_email` | `varchar(255)` | — | — | — |
+| `contact_phone` | `varchar(50)` | — | — | — |
+| `notes` | `text` | — | — | — |
+| `logo_path` | `varchar(500)` | — | — | — |
+| `is_active` | `boolean` | `NOT NULL` | `true` | — |
+| `is_internal` | `boolean` | `NOT NULL` | `false` | — |
+| `is_system` | `boolean` | `NOT NULL` | `false` | — |
+| `created_at` | `timestamp` | `NOT NULL` | `now()` | — |
+
+**Drizzle name:** `agencies` (imported as `import { agencies } from '@/db/schema'`).

--- a/techdocs/database/tables/ai-usage.md
+++ b/techdocs/database/tables/ai-usage.md
@@ -1,0 +1,29 @@
+# ai_usage
+
+_Schema reference for the ai_usage table._
+
+> **ℹ️ Note**
+>
+> Auto-generated from `src/db/schema/ai-usage.ts`. **13** columns. To regenerate locally, run `npm run docs:gen:db` from `docs-site/`.
+
+**Tenant-scoped.** This table includes `tenant_id` and is enforced by Row-Level Security. All queries must run inside `withTenant(tenantId, ...)`. See [Multi-tenancy & RLS](../../architecture/multi-tenancy-rls.md).
+
+## Columns
+
+| Column | Type | Constraints | Default | References |
+|---|---|---|---|---|
+| `id` | `uuid` | `PRIMARY KEY` | `gen_random_uuid()` | — |
+| `tenant_id` | `uuid` | `NOT NULL` | — | `tenants.id` |
+| `user_id` | `uuid` | — | — | — |
+| `operation` | `varchar(64)` | `NOT NULL` | — | — |
+| `model` | `varchar(100)` | `NOT NULL` | — | — |
+| `input_tokens` | `integer` | `NOT NULL` | — | — |
+| `output_tokens` | `integer` | `NOT NULL` | — | — |
+| `cache_creation_tokens` | `integer` | — | — | — |
+| `cache_read_tokens` | `integer` | — | — | — |
+| `cost_usd` | `decimal` | `NOT NULL` | — | — |
+| `duration_ms` | `integer` | — | — | — |
+| `metadata` | `jsonb` | — | — | — |
+| `created_at` | `timestamp` | `NOT NULL` | `now()` | — |
+
+**Drizzle name:** `aiUsage` (imported as `import { aiUsage } from '@/db/schema'`).

--- a/techdocs/database/tables/api-tokens.md
+++ b/techdocs/database/tables/api-tokens.md
@@ -1,0 +1,27 @@
+# api_tokens
+
+_Schema reference for the api_tokens table._
+
+> **ℹ️ Note**
+>
+> Auto-generated from `src/db/schema/api-tokens.ts`. **11** columns. To regenerate locally, run `npm run docs:gen:db` from `docs-site/`.
+
+**Tenant-scoped.** This table includes `tenant_id` and is enforced by Row-Level Security. All queries must run inside `withTenant(tenantId, ...)`. See [Multi-tenancy & RLS](../../architecture/multi-tenancy-rls.md).
+
+## Columns
+
+| Column | Type | Constraints | Default | References |
+|---|---|---|---|---|
+| `id` | `uuid` | `PRIMARY KEY` | `gen_random_uuid()` | — |
+| `tenant_id` | `uuid` | `NOT NULL` | — | `tenants.id` |
+| `user_id` | `uuid` | `NOT NULL` | — | `users.id` |
+| `name` | `varchar(100)` | `NOT NULL` | — | — |
+| `prefix` | `varchar(20)` | `NOT NULL` `UNIQUE` | — | — |
+| `hash` | `varchar(500)` | `NOT NULL` | — | — |
+| `scopes` | `text` | `NOT NULL` | `sql`'{}'::text[]`` | — |
+| `expires_at` | `timestamp` | — | — | — |
+| `last_used_at` | `timestamp` | — | — | — |
+| `revoked_at` | `timestamp` | — | — | — |
+| `created_at` | `timestamp` | `NOT NULL` | `now()` | — |
+
+**Drizzle name:** `apiTokens` (imported as `import { apiTokens } from '@/db/schema'`).

--- a/techdocs/database/tables/audit-logs.md
+++ b/techdocs/database/tables/audit-logs.md
@@ -1,0 +1,26 @@
+# audit_logs
+
+_Schema reference for the audit_logs table._
+
+> **ℹ️ Note**
+>
+> Auto-generated from `src/db/schema/audit-logs.ts`. **10** columns. To regenerate locally, run `npm run docs:gen:db` from `docs-site/`.
+
+**Tenant-scoped.** This table includes `tenant_id` and is enforced by Row-Level Security. All queries must run inside `withTenant(tenantId, ...)`. See [Multi-tenancy & RLS](../../architecture/multi-tenancy-rls.md).
+
+## Columns
+
+| Column | Type | Constraints | Default | References |
+|---|---|---|---|---|
+| `id` | `uuid` | `PRIMARY KEY` | `gen_random_uuid()` | — |
+| `tenant_id` | `uuid` | `NOT NULL` | — | `tenants.id` |
+| `user_id` | `uuid` | — | — | — |
+| `user_email` | `varchar(200)` | — | — | — |
+| `action` | `varchar(100)` | `NOT NULL` | — | — |
+| `entity_type` | `varchar(50)` | `NOT NULL` | — | — |
+| `entity_id` | `uuid` | — | — | — |
+| `entity_label` | `varchar(200)` | — | — | — |
+| `metadata` | `jsonb` | — | — | — |
+| `created_at` | `timestamp` | `NOT NULL` | `now()` | — |
+
+**Drizzle name:** `auditLogs` (imported as `import { auditLogs } from '@/db/schema'`).

--- a/techdocs/database/tables/calendar-connections.md
+++ b/techdocs/database/tables/calendar-connections.md
@@ -1,0 +1,23 @@
+# calendar_connections
+
+_Schema reference for the calendar_connections table._
+
+> **ℹ️ Note**
+>
+> Auto-generated from `src/db/schema/calendar-connections.ts`. **9** columns. To regenerate locally, run `npm run docs:gen:db` from `docs-site/`.
+
+## Columns
+
+| Column | Type | Constraints | Default | References |
+|---|---|---|---|---|
+| `id` | `uuid` | `PRIMARY KEY` | `gen_random_uuid()` | — |
+| `user_id` | `uuid` | `NOT NULL` | — | `users.id` |
+| `provider` | `varchar(20)` | `NOT NULL` | — | — |
+| `access_token` | `text` | `NOT NULL` | — | — |
+| `refresh_token` | `text` | — | — | — |
+| `token_expiry` | `timestamp` | — | — | — |
+| `calendar_id` | `varchar(500)` | — | `'primary'` | — |
+| `created_at` | `timestamp` | `NOT NULL` | `now()` | — |
+| `updated_at` | `timestamp` | `NOT NULL` | `now()` | — |
+
+**Drizzle name:** `calendarConnections` (imported as `import { calendarConnections } from '@/db/schema'`).

--- a/techdocs/database/tables/candidate-enrichments.md
+++ b/techdocs/database/tables/candidate-enrichments.md
@@ -1,0 +1,27 @@
+# candidate_enrichments
+
+_Schema reference for the candidate_enrichments table._
+
+> **ℹ️ Note**
+>
+> Auto-generated from `src/db/schema/candidate-enrichments.ts`. **11** columns. To regenerate locally, run `npm run docs:gen:db` from `docs-site/`.
+
+**Tenant-scoped.** This table includes `tenant_id` and is enforced by Row-Level Security. All queries must run inside `withTenant(tenantId, ...)`. See [Multi-tenancy & RLS](../../architecture/multi-tenancy-rls.md).
+
+## Columns
+
+| Column | Type | Constraints | Default | References |
+|---|---|---|---|---|
+| `id` | `uuid` | `PRIMARY KEY` | `gen_random_uuid()` | — |
+| `tenant_id` | `uuid` | `NOT NULL` | — | `tenants.id` |
+| `candidate_id` | `uuid` | `NOT NULL` `UNIQUE` | — | `candidates.id` |
+| `web_hits` | `jsonb` | — | `[]` | — |
+| `github_profile` | `jsonb` | — | — | — |
+| `verified_profiles` | `jsonb` | `NOT NULL` | `sql`'[]'::jsonb`` | — |
+| `rejected_urls` | `jsonb` | `NOT NULL` | `sql`'[]'::jsonb`` | — |
+| `stack_overflow_profile` | `jsonb` | — | — | — |
+| `devto_profile` | `jsonb` | — | — | — |
+| `personal_site_summary` | `jsonb` | — | — | — |
+| `searched_at` | `timestamp` | `NOT NULL` | `now()` | — |
+
+**Drizzle name:** `candidateEnrichments` (imported as `import { candidateEnrichments } from '@/db/schema'`).

--- a/techdocs/database/tables/candidate-role-approvals.md
+++ b/techdocs/database/tables/candidate-role-approvals.md
@@ -1,0 +1,25 @@
+# candidate_role_approvals
+
+_Schema reference for the candidate_role_approvals table._
+
+> **ℹ️ Note**
+>
+> Auto-generated from `src/db/schema/candidate-role-approvals.ts`. **9** columns. To regenerate locally, run `npm run docs:gen:db` from `docs-site/`.
+
+**Tenant-scoped.** This table includes `tenant_id` and is enforced by Row-Level Security. All queries must run inside `withTenant(tenantId, ...)`. See [Multi-tenancy & RLS](../../architecture/multi-tenancy-rls.md).
+
+## Columns
+
+| Column | Type | Constraints | Default | References |
+|---|---|---|---|---|
+| `id` | `uuid` | `PRIMARY KEY` | `gen_random_uuid()` | — |
+| `tenant_id` | `uuid` | `NOT NULL` | — | `tenants.id` |
+| `role_id` | `uuid` | `NOT NULL` | — | `roles.id` |
+| `candidate_id` | `uuid` | `NOT NULL` | — | `candidates.id` |
+| `manager_id` | `uuid` | `NOT NULL` | — | `users.id` |
+| `decision` | `varchar(20)` | `NOT NULL` | `'pending'` | — |
+| `comment` | `text` | — | — | — |
+| `decided_at` | `timestamp` | — | — | — |
+| `created_at` | `timestamp` | `NOT NULL` | `now()` | — |
+
+**Drizzle name:** `candidateRoleApprovals` (imported as `import { candidateRoleApprovals } from '@/db/schema'`).

--- a/techdocs/database/tables/candidates.md
+++ b/techdocs/database/tables/candidates.md
@@ -1,0 +1,57 @@
+# candidates
+
+_Schema reference for the candidates table._
+
+> **ℹ️ Note**
+>
+> Auto-generated from `src/db/schema/candidates.ts`. **41** columns. To regenerate locally, run `npm run docs:gen:db` from `docs-site/`.
+
+**Tenant-scoped.** This table includes `tenant_id` and is enforced by Row-Level Security. All queries must run inside `withTenant(tenantId, ...)`. See [Multi-tenancy & RLS](../../architecture/multi-tenancy-rls.md).
+
+## Columns
+
+| Column | Type | Constraints | Default | References |
+|---|---|---|---|---|
+| `id` | `uuid` | `PRIMARY KEY` | `gen_random_uuid()` | — |
+| `tenant_id` | `uuid` | `NOT NULL` | — | `tenants.id` |
+| `agency_id` | `uuid` | — | — | `agencies.id` |
+| `first_name` | `varchar(100)` | `NOT NULL` | — | — |
+| `last_name` | `varchar(100)` | `NOT NULL` | — | — |
+| `email` | `varchar(255)` | — | — | — |
+| `phone` | `varchar(50)` | — | — | — |
+| `cv_text` | `text` | `NOT NULL` | — | — |
+| `cv_text_formatted` | `text` | — | — | — |
+| `file_path` | `varchar(500)` | — | — | — |
+| `file_type` | `fileTypeEnum` | `NOT NULL` | — | — |
+| `linkedin_url` | `varchar(500)` | — | — | — |
+| `github_username` | `varchar(100)` | — | — | — |
+| `embedding` | `text` | — | — | — |
+| `status` | `candidateStatusEnum` | `NOT NULL` | `'new'` | — |
+| `status_confirmed_by` | `uuid` | — | — | `users.id` |
+| `status_confirmed_at` | `timestamp` | — | — | — |
+| `country` | `varchar(100)` | — | — | — |
+| `city` | `varchar(100)` | — | — | — |
+| `languages_spoken` | `text` | `NOT NULL` | `sql`'{}'::text[]`` | — |
+| `willing_to_relocate` | `boolean` | — | — | — |
+| `candidate_rate` | `numeric` | — | — | — |
+| `customer_rate` | `numeric` | — | — | — |
+| `rate_currency` | `varchar(3)` | — | — | — |
+| `availability_status` | `availabilityStatusEnum` | `NOT NULL` | `'available'` | — |
+| `available_from` | `date` | — | — | — |
+| `is_active` | `boolean` | `NOT NULL` | `true` | — |
+| `synechron_cv_data` | `jsonb` | — | — | — |
+| `synechron_candidate_id` | `varchar(64)` | — | — | — |
+| `created_at` | `timestamp` | `NOT NULL` | `now()` | — |
+| `right_to_work_status` | `rightToWorkStatusEnum` | — | — | — |
+| `right_to_work_document_type` | `rightToWorkDocumentTypeEnum` | — | — | — |
+| `right_to_work_expiry` | `date` | — | — | — |
+| `right_to_work_checked_at` | `timestamp` | — | — | — |
+| `right_to_work_checked_by` | `uuid` | — | — | `users.id` |
+| `share_code` | `varchar(20)` | — | — | — |
+| `sponsorship_required` | `boolean` | `NOT NULL` | `false` | — |
+| `nationality` | `varchar(100)` | — | — | — |
+| `notice_period_days` | `integer` | — | — | — |
+| `gdpr_processing_consent_at` | `timestamp` | — | — | — |
+| `gdpr_processing_consent_by` | `gdprProcessingConsentByEnum` | — | — | — |
+
+**Drizzle name:** `candidates` (imported as `import { candidates } from '@/db/schema'`).

--- a/techdocs/database/tables/code-challenges.md
+++ b/techdocs/database/tables/code-challenges.md
@@ -1,0 +1,23 @@
+# code_challenges
+
+_Schema reference for the code_challenges table._
+
+> **ℹ️ Note**
+>
+> Auto-generated from `src/db/schema/code-challenges.ts`. **9** columns. To regenerate locally, run `npm run docs:gen:db` from `docs-site/`.
+
+## Columns
+
+| Column | Type | Constraints | Default | References |
+|---|---|---|---|---|
+| `id` | `uuid` | `PRIMARY KEY` | `gen_random_uuid()` | — |
+| `pack_id` | `uuid` | `NOT NULL` `UNIQUE` | — | `interviewPacks.id` |
+| `title` | `varchar(200)` | `NOT NULL` | — | — |
+| `problem_description` | `text` | `NOT NULL` | — | — |
+| `starter_code` | `text` | `NOT NULL` | — | — |
+| `language` | `varchar(50)` | `NOT NULL` | `'typescript'` | — |
+| `unit_tests` | `text` | — | — | — |
+| `evaluation_criteria` | `text` | — | — | — |
+| `estimated_minutes` | `integer` | — | — | — |
+
+**Drizzle name:** `codeChallenges` (imported as `import { codeChallenges } from '@/db/schema'`).

--- a/techdocs/database/tables/customer-frameworks.md
+++ b/techdocs/database/tables/customer-frameworks.md
@@ -1,0 +1,25 @@
+# customer_frameworks
+
+_Schema reference for the customer_frameworks table._
+
+> **ℹ️ Note**
+>
+> Auto-generated from `src/db/schema/customer-frameworks.ts`. **9** columns. To regenerate locally, run `npm run docs:gen:db` from `docs-site/`.
+
+**Tenant-scoped.** This table includes `tenant_id` and is enforced by Row-Level Security. All queries must run inside `withTenant(tenantId, ...)`. See [Multi-tenancy & RLS](../../architecture/multi-tenancy-rls.md).
+
+## Columns
+
+| Column | Type | Constraints | Default | References |
+|---|---|---|---|---|
+| `id` | `uuid` | `PRIMARY KEY` | `gen_random_uuid()` | — |
+| `tenant_id` | `uuid` | `NOT NULL` | — | `tenants.id` |
+| `customer_id` | `uuid` | `NOT NULL` | — | `customers.id` |
+| `name` | `varchar(200)` | `NOT NULL` | — | — |
+| `description` | `text` | — | — | — |
+| `levels` | `jsonb` | `NOT NULL` | `[]` | — |
+| `is_active` | `boolean` | `NOT NULL` | `true` | — |
+| `created_at` | `timestamp` | `NOT NULL` | `now()` | — |
+| `updated_at` | `timestamp` | `NOT NULL` | `now()` | — |
+
+**Drizzle name:** `customerFrameworks` (imported as `import { customerFrameworks } from '@/db/schema'`).

--- a/techdocs/database/tables/customers.md
+++ b/techdocs/database/tables/customers.md
@@ -1,0 +1,29 @@
+# customers
+
+_Schema reference for the customers table._
+
+> **ℹ️ Note**
+>
+> Auto-generated from `src/db/schema/customers.ts`. **13** columns. To regenerate locally, run `npm run docs:gen:db` from `docs-site/`.
+
+**Tenant-scoped.** This table includes `tenant_id` and is enforced by Row-Level Security. All queries must run inside `withTenant(tenantId, ...)`. See [Multi-tenancy & RLS](../../architecture/multi-tenancy-rls.md).
+
+## Columns
+
+| Column | Type | Constraints | Default | References |
+|---|---|---|---|---|
+| `id` | `uuid` | `PRIMARY KEY` | `gen_random_uuid()` | — |
+| `tenant_id` | `uuid` | `NOT NULL` | — | `tenants.id` |
+| `name` | `varchar(200)` | `NOT NULL` | — | — |
+| `contact_name` | `varchar(100)` | — | — | — |
+| `contact_email` | `varchar(255)` | — | — | — |
+| `contact_phone` | `varchar(50)` | — | — | — |
+| `website` | `varchar(500)` | — | — | — |
+| `portal_base_url` | `varchar(500)` | — | — | — |
+| `logo_path` | `varchar(500)` | — | — | — |
+| `role_id_label` | `varchar(60)` | — | — | — |
+| `notes` | `text` | — | — | — |
+| `is_active` | `boolean` | `NOT NULL` | `true` | — |
+| `created_at` | `timestamp` | `NOT NULL` | `now()` | — |
+
+**Drizzle name:** `customers` (imported as `import { customers } from '@/db/schema'`).

--- a/techdocs/database/tables/cv-profiles.md
+++ b/techdocs/database/tables/cv-profiles.md
@@ -1,0 +1,29 @@
+# cv_profiles
+
+_Schema reference for the cv_profiles table._
+
+> **ℹ️ Note**
+>
+> Auto-generated from `src/db/schema/cv-profiles.ts`. **13** columns. To regenerate locally, run `npm run docs:gen:db` from `docs-site/`.
+
+**Tenant-scoped.** This table includes `tenant_id` and is enforced by Row-Level Security. All queries must run inside `withTenant(tenantId, ...)`. See [Multi-tenancy & RLS](../../architecture/multi-tenancy-rls.md).
+
+## Columns
+
+| Column | Type | Constraints | Default | References |
+|---|---|---|---|---|
+| `id` | `uuid` | `PRIMARY KEY` | `gen_random_uuid()` | — |
+| `tenant_id` | `uuid` | `NOT NULL` | — | `tenants.id` |
+| `candidate_id` | `uuid` | `NOT NULL` `UNIQUE` | — | `candidates.id` |
+| `experience_level` | `text` | — | — | — |
+| `summary` | `text` | — | — | — |
+| `technical_skills` | `jsonb` | — | `[]` | — |
+| `companies` | `jsonb` | — | `[]` | — |
+| `personalizable_moments` | `jsonb` | — | `[]` | — |
+| `extraction_status` | `text` | `NOT NULL` | `'pending'` | — |
+| `error_message` | `text` | — | — | — |
+| `ai_model` | `text` | — | — | — |
+| `extracted_at` | `timestamp` | — | — | — |
+| `created_at` | `timestamp` | `NOT NULL` | `now()` | — |
+
+**Drizzle name:** `cvProfiles` (imported as `import { cvProfiles } from '@/db/schema'`).

--- a/techdocs/database/tables/email-templates.md
+++ b/techdocs/database/tables/email-templates.md
@@ -1,0 +1,25 @@
+# email_templates
+
+_Schema reference for the email_templates table._
+
+> **ℹ️ Note**
+>
+> Auto-generated from `src/db/schema/email-templates.ts`. **9** columns. To regenerate locally, run `npm run docs:gen:db` from `docs-site/`.
+
+**Tenant-scoped.** This table includes `tenant_id` and is enforced by Row-Level Security. All queries must run inside `withTenant(tenantId, ...)`. See [Multi-tenancy & RLS](../../architecture/multi-tenancy-rls.md).
+
+## Columns
+
+| Column | Type | Constraints | Default | References |
+|---|---|---|---|---|
+| `id` | `uuid` | `PRIMARY KEY` | `gen_random_uuid()` | — |
+| `tenant_id` | `uuid` | `NOT NULL` | — | `tenants.id` |
+| `name` | `varchar(80)` | `NOT NULL` | — | — |
+| `category` | `varchar(40)` | `NOT NULL` | — | — |
+| `subject` | `varchar(200)` | `NOT NULL` | — | — |
+| `body` | `text` | `NOT NULL` | — | — |
+| `is_default` | `boolean` | `NOT NULL` | `false` | — |
+| `created_at` | `timestamp` | `NOT NULL` | `now()` | — |
+| `updated_at` | `timestamp` | `NOT NULL` | `now()` | — |
+
+**Drizzle name:** `emailTemplates` (imported as `import { emailTemplates } from '@/db/schema'`).

--- a/techdocs/database/tables/interview-packs.md
+++ b/techdocs/database/tables/interview-packs.md
@@ -1,0 +1,31 @@
+# interview_packs
+
+_Schema reference for the interview_packs table._
+
+> **ℹ️ Note**
+>
+> Auto-generated from `src/db/schema/interview-packs.ts`. **15** columns. To regenerate locally, run `npm run docs:gen:db` from `docs-site/`.
+
+**Tenant-scoped.** This table includes `tenant_id` and is enforced by Row-Level Security. All queries must run inside `withTenant(tenantId, ...)`. See [Multi-tenancy & RLS](../../architecture/multi-tenancy-rls.md).
+
+## Columns
+
+| Column | Type | Constraints | Default | References |
+|---|---|---|---|---|
+| `id` | `uuid` | `PRIMARY KEY` | `gen_random_uuid()` | — |
+| `tenant_id` | `uuid` | `NOT NULL` | — | `tenants.id` |
+| `candidate_id` | `uuid` | `NOT NULL` | — | `candidates.id` |
+| `role_id` | `uuid` | `NOT NULL` | — | `roles.id` |
+| `generation_status` | `generationStatusEnum` | `NOT NULL` | `'pending'` | — |
+| `generation_stage` | `text` | — | — | — |
+| `experience_level` | `experienceLevelEnum` | — | — | — |
+| `recommended_duration_minutes` | `integer` | — | — | — |
+| `includes_code_challenge` | `boolean` | `NOT NULL` | `false` | — |
+| `pack_type` | `packTypeEnum` | `NOT NULL` | `'full'` | — |
+| `language` | `varchar(10)` | `NOT NULL` | `'en'` | — |
+| `error_message` | `text` | — | — | — |
+| `created_by` | `uuid` | `NOT NULL` | — | `users.id` |
+| `created_at` | `timestamp` | `NOT NULL` | `now()` | — |
+| `updated_at` | `timestamp` | `NOT NULL` | `now()` | — |
+
+**Drizzle name:** `interviewPacks` (imported as `import { interviewPacks } from '@/db/schema'`).

--- a/techdocs/database/tables/interview-questions.md
+++ b/techdocs/database/tables/interview-questions.md
@@ -1,0 +1,27 @@
+# interview_questions
+
+_Schema reference for the interview_questions table._
+
+> **ℹ️ Note**
+>
+> Auto-generated from `src/db/schema/interview-questions.ts`. **13** columns. To regenerate locally, run `npm run docs:gen:db` from `docs-site/`.
+
+## Columns
+
+| Column | Type | Constraints | Default | References |
+|---|---|---|---|---|
+| `id` | `uuid` | `PRIMARY KEY` | `gen_random_uuid()` | — |
+| `pack_id` | `uuid` | `NOT NULL` | — | `interviewPacks.id` |
+| `question_type` | `questionTypeEnum` | `NOT NULL` | — | — |
+| `difficulty` | `difficultyEnum` | `NOT NULL` | — | — |
+| `question_text` | `text` | `NOT NULL` | — | — |
+| `rationale` | `text` | — | — | — |
+| `follow_ups` | `jsonb` | — | — | — |
+| `strong_answer_signals` | `text` | — | — | — |
+| `acceptable_answer_signals` | `text` | — | — | — |
+| `weak_answer_signals` | `text` | — | — | — |
+| `cv_references` | `text` | — | — | — |
+| `order_index` | `integer` | `NOT NULL` | `0` | — |
+| `notes` | `text` | — | — | — |
+
+**Drizzle name:** `interviewQuestions` (imported as `import { interviewQuestions } from '@/db/schema'`).

--- a/techdocs/database/tables/interview-slots.md
+++ b/techdocs/database/tables/interview-slots.md
@@ -1,0 +1,33 @@
+# interview_slots
+
+_Schema reference for the interview_slots table._
+
+> **ℹ️ Note**
+>
+> Auto-generated from `src/db/schema/interview-slots.ts`. **17** columns. To regenerate locally, run `npm run docs:gen:db` from `docs-site/`.
+
+**Tenant-scoped.** This table includes `tenant_id` and is enforced by Row-Level Security. All queries must run inside `withTenant(tenantId, ...)`. See [Multi-tenancy & RLS](../../architecture/multi-tenancy-rls.md).
+
+## Columns
+
+| Column | Type | Constraints | Default | References |
+|---|---|---|---|---|
+| `id` | `uuid` | `PRIMARY KEY` | `gen_random_uuid()` | — |
+| `tenant_id` | `uuid` | `NOT NULL` | — | `tenants.id` |
+| `candidate_id` | `uuid` | `NOT NULL` | — | `candidates.id` |
+| `role_id` | `uuid` | — | — | `roles.id` |
+| `interviewer_id` | `uuid` | — | — | `users.id` |
+| `title` | `varchar(300)` | `NOT NULL` | — | — |
+| `scheduled_at` | `timestamp` | `NOT NULL` | — | — |
+| `duration_minutes` | `integer` | `NOT NULL` | `60` | — |
+| `location` | `varchar(500)` | — | — | — |
+| `meeting_url` | `varchar(1000)` | — | — | — |
+| `status` | `varchar(30)` | `NOT NULL` | `'scheduled'` | — |
+| `slot_notes` | `text` | — | — | — |
+| `google_event_id` | `varchar(500)` | — | — | — |
+| `microsoft_event_id` | `varchar(500)` | — | — | — |
+| `created_by` | `uuid` | `NOT NULL` | — | `users.id` |
+| `created_at` | `timestamp` | `NOT NULL` | `now()` | — |
+| `updated_at` | `timestamp` | `NOT NULL` | `now()` | — |
+
+**Drizzle name:** `interviewSlots` (imported as `import { interviewSlots } from '@/db/schema'`).

--- a/techdocs/database/tables/interview-transcripts.md
+++ b/techdocs/database/tables/interview-transcripts.md
@@ -1,0 +1,30 @@
+# interview_transcripts
+
+_Schema reference for the interview_transcripts table._
+
+> **ℹ️ Note**
+>
+> Auto-generated from `src/db/schema/interview-transcripts.ts`. **14** columns. To regenerate locally, run `npm run docs:gen:db` from `docs-site/`.
+
+**Tenant-scoped.** This table includes `tenant_id` and is enforced by Row-Level Security. All queries must run inside `withTenant(tenantId, ...)`. See [Multi-tenancy & RLS](../../architecture/multi-tenancy-rls.md).
+
+## Columns
+
+| Column | Type | Constraints | Default | References |
+|---|---|---|---|---|
+| `id` | `uuid` | `PRIMARY KEY` | `gen_random_uuid()` | — |
+| `tenant_id` | `uuid` | `NOT NULL` | — | `tenants.id` |
+| `candidate_id` | `uuid` | `NOT NULL` | — | `candidates.id` |
+| `role_id` | `uuid` | `NOT NULL` | — | `roles.id` |
+| `pack_id` | `uuid` | — | — | `interviewPacks.id` |
+| `raw_transcript_text` | `text` | `NOT NULL` | — | — |
+| `parsed_transcript` | `jsonb` | — | — | — |
+| `source_platform` | `transcriptPlatformEnum` | `NOT NULL` | `'other'` | — |
+| `source_format` | `transcriptFormatEnum` | `NOT NULL` | — | — |
+| `interview_date` | `timestamp` | — | — | — |
+| `analysis_status` | `transcriptAnalysisStatusEnum` | `NOT NULL` | `'pending'` | — |
+| `error_message` | `text` | — | — | — |
+| `created_at` | `timestamp` | `NOT NULL` | `now()` | — |
+| `updated_at` | `timestamp` | `NOT NULL` | `now()` | — |
+
+**Drizzle name:** `interviewTranscripts` (imported as `import { interviewTranscripts } from '@/db/schema'`).

--- a/techdocs/database/tables/notes.md
+++ b/techdocs/database/tables/notes.md
@@ -1,0 +1,25 @@
+# notes
+
+_Schema reference for the notes table._
+
+> **ℹ️ Note**
+>
+> Auto-generated from `src/db/schema/notes.ts`. **9** columns. To regenerate locally, run `npm run docs:gen:db` from `docs-site/`.
+
+**Tenant-scoped.** This table includes `tenant_id` and is enforced by Row-Level Security. All queries must run inside `withTenant(tenantId, ...)`. See [Multi-tenancy & RLS](../../architecture/multi-tenancy-rls.md).
+
+## Columns
+
+| Column | Type | Constraints | Default | References |
+|---|---|---|---|---|
+| `id` | `uuid` | `PRIMARY KEY` | `gen_random_uuid()` | — |
+| `tenant_id` | `uuid` | `NOT NULL` | — | `tenants.id` |
+| `candidate_id` | `uuid` | `NOT NULL` | — | `candidates.id` |
+| `author_id` | `uuid` | `NOT NULL` | — | `users.id` |
+| `body` | `text` | `NOT NULL` | — | — |
+| `is_shareable` | `boolean` | `NOT NULL` | `false` | — |
+| `created_at` | `timestamp` | `NOT NULL` | `now()` | — |
+| `updated_at` | `timestamp` | — | — | — |
+| `is_edited` | `boolean` | `NOT NULL` | `false` | — |
+
+**Drizzle name:** `notes` (imported as `import { notes } from '@/db/schema'`).

--- a/techdocs/database/tables/role-managers.md
+++ b/techdocs/database/tables/role-managers.md
@@ -1,0 +1,23 @@
+# role_managers
+
+_Schema reference for the role_managers table._
+
+> **ℹ️ Note**
+>
+> Auto-generated from `src/db/schema/role-managers.ts`. **7** columns. To regenerate locally, run `npm run docs:gen:db` from `docs-site/`.
+
+**Tenant-scoped.** This table includes `tenant_id` and is enforced by Row-Level Security. All queries must run inside `withTenant(tenantId, ...)`. See [Multi-tenancy & RLS](../../architecture/multi-tenancy-rls.md).
+
+## Columns
+
+| Column | Type | Constraints | Default | References |
+|---|---|---|---|---|
+| `id` | `uuid` | `PRIMARY KEY` | `gen_random_uuid()` | — |
+| `tenant_id` | `uuid` | `NOT NULL` | — | `tenants.id` |
+| `role_id` | `uuid` | `NOT NULL` | — | `roles.id` |
+| `user_id` | `uuid` | `NOT NULL` | — | `users.id` |
+| `is_primary` | `boolean` | `NOT NULL` | `false` | — |
+| `added_by` | `uuid` | — | — | `users.id` |
+| `added_at` | `timestamp` | `NOT NULL` | `now()` | — |
+
+**Drizzle name:** `roleManagers` (imported as `import { roleManagers } from '@/db/schema'`).

--- a/techdocs/database/tables/role-submissions.md
+++ b/techdocs/database/tables/role-submissions.md
@@ -1,0 +1,29 @@
+# role_submissions
+
+_Schema reference for the role_submissions table._
+
+> **ℹ️ Note**
+>
+> Auto-generated from `src/db/schema/role-submissions.ts`. **13** columns. To regenerate locally, run `npm run docs:gen:db` from `docs-site/`.
+
+**Tenant-scoped.** This table includes `tenant_id` and is enforced by Row-Level Security. All queries must run inside `withTenant(tenantId, ...)`. See [Multi-tenancy & RLS](../../architecture/multi-tenancy-rls.md).
+
+## Columns
+
+| Column | Type | Constraints | Default | References |
+|---|---|---|---|---|
+| `id` | `uuid` | `PRIMARY KEY` | `gen_random_uuid()` | — |
+| `tenant_id` | `uuid` | `NOT NULL` | — | `tenants.id` |
+| `role_id` | `uuid` | `NOT NULL` | — | `roles.id` |
+| `candidate_id` | `uuid` | `NOT NULL` | — | `candidates.id` |
+| `sent_at` | `timestamp` | `NOT NULL` | `now()` | — |
+| `sent_by_user_id` | `uuid` | — | — | `users.id` |
+| `status` | `submissionStatusEnum` | `NOT NULL` | `'submitted'` | — |
+| `status_updated_at` | `timestamp` | `NOT NULL` | `now()` | — |
+| `notes` | `text` | — | — | — |
+| `share_token` | `varchar(64)` | — | — | — |
+| `share_token_created_at` | `timestamp` | — | — | — |
+| `created_at` | `timestamp` | `NOT NULL` | `now()` | — |
+| `updated_at` | `timestamp` | `NOT NULL` | `now()` | — |
+
+**Drizzle name:** `roleSubmissions` (imported as `import { roleSubmissions } from '@/db/schema'`).

--- a/techdocs/database/tables/roles.md
+++ b/techdocs/database/tables/roles.md
@@ -1,0 +1,43 @@
+# roles
+
+_Schema reference for the roles table._
+
+> **ℹ️ Note**
+>
+> Auto-generated from `src/db/schema/roles.ts`. **27** columns. To regenerate locally, run `npm run docs:gen:db` from `docs-site/`.
+
+**Tenant-scoped.** This table includes `tenant_id` and is enforced by Row-Level Security. All queries must run inside `withTenant(tenantId, ...)`. See [Multi-tenancy & RLS](../../architecture/multi-tenancy-rls.md).
+
+## Columns
+
+| Column | Type | Constraints | Default | References |
+|---|---|---|---|---|
+| `id` | `uuid` | `PRIMARY KEY` | `gen_random_uuid()` | — |
+| `tenant_id` | `uuid` | `NOT NULL` | — | `tenants.id` |
+| `title` | `varchar(200)` | `NOT NULL` | — | — |
+| `description` | `text` | `NOT NULL` | — | — |
+| `requirements` | `text` | `NOT NULL` | — | — |
+| `file_path` | `varchar(500)` | — | — | — |
+| `created_by` | `uuid` | `NOT NULL` | — | `users.id` |
+| `customer_id` | `uuid` | — | — | `customers.id` |
+| `customer_role_id` | `varchar(100)` | — | — | — |
+| `is_active` | `boolean` | `NOT NULL` | `true` | — |
+| `framework_level_id` | `varchar(50)` | — | — | — |
+| `framework_level_label` | `varchar(200)` | — | — | — |
+| `country` | `varchar(100)` | — | — | — |
+| `city` | `varchar(100)` | — | — | — |
+| `work_mode` | `workModeEnum` | — | — | — |
+| `language_requirements` | `text` | `NOT NULL` | `sql`'{}'::text[]`` | — |
+| `key_skills` | `text` | `NOT NULL` | `sql`'{}'::text[]`` | — |
+| `top_requirements` | `text` | `NOT NULL` | `sql`'{}'::text[]`` | — |
+| `priority_keywords` | `text` | `NOT NULL` | `sql`'{}'::text[]`` | — |
+| `priority_keywords_updated_at` | `timestamp` | — | — | — |
+| `target_fill_date` | `date` | — | — | — |
+| `cutoff_date` | `date` | — | — | — |
+| `customer_portal_path` | `varchar(500)` | — | — | — |
+| `customer_day_rate` | `numeric` | — | — | — |
+| `rate_currency` | `varchar(3)` | — | — | — |
+| `shortlist_sent_at` | `timestamp` | — | — | — |
+| `created_at` | `timestamp` | `NOT NULL` | `now()` | — |
+
+**Drizzle name:** `roles` (imported as `import { roles } from '@/db/schema'`).

--- a/techdocs/database/tables/scores.md
+++ b/techdocs/database/tables/scores.md
@@ -1,0 +1,34 @@
+# scores
+
+_Schema reference for the scores table._
+
+> **ℹ️ Note**
+>
+> Auto-generated from `src/db/schema/scores.ts`. **18** columns. To regenerate locally, run `npm run docs:gen:db` from `docs-site/`.
+
+**Tenant-scoped.** This table includes `tenant_id` and is enforced by Row-Level Security. All queries must run inside `withTenant(tenantId, ...)`. See [Multi-tenancy & RLS](../../architecture/multi-tenancy-rls.md).
+
+## Columns
+
+| Column | Type | Constraints | Default | References |
+|---|---|---|---|---|
+| `id` | `uuid` | `PRIMARY KEY` | `gen_random_uuid()` | — |
+| `tenant_id` | `uuid` | `NOT NULL` | — | `tenants.id` |
+| `candidate_id` | `uuid` | `NOT NULL` | — | `candidates.id` |
+| `role_id` | `uuid` | `NOT NULL` | — | `roles.id` |
+| `score_status` | `scoreStatusEnum` | `NOT NULL` | `'pending'` | — |
+| `overall_score` | `integer` | — | — | — |
+| `technical_score` | `integer` | — | — | — |
+| `experience_score` | `integer` | — | — | — |
+| `cultural_fit_score` | `integer` | — | — | — |
+| `communication_score` | `integer` | — | — | — |
+| `technical_reasoning` | `text` | — | — | — |
+| `experience_reasoning` | `text` | — | — | — |
+| `cultural_fit_reasoning` | `text` | — | — | — |
+| `communication_reasoning` | `text` | — | — | — |
+| `ai_summary` | `text` | — | — | — |
+| `error_message` | `text` | — | — | — |
+| `created_at` | `timestamp` | `NOT NULL` | `now()` | — |
+| `updated_at` | `timestamp` | `NOT NULL` | `now()` | — |
+
+**Drizzle name:** `scores` (imported as `import { scores } from '@/db/schema'`).

--- a/techdocs/database/tables/sent-emails.md
+++ b/techdocs/database/tables/sent-emails.md
@@ -1,0 +1,31 @@
+# sent_emails
+
+_Schema reference for the sent_emails table._
+
+> **ℹ️ Note**
+>
+> Auto-generated from `src/db/schema/sent-emails.ts`. **15** columns. To regenerate locally, run `npm run docs:gen:db` from `docs-site/`.
+
+**Tenant-scoped.** This table includes `tenant_id` and is enforced by Row-Level Security. All queries must run inside `withTenant(tenantId, ...)`. See [Multi-tenancy & RLS](../../architecture/multi-tenancy-rls.md).
+
+## Columns
+
+| Column | Type | Constraints | Default | References |
+|---|---|---|---|---|
+| `id` | `uuid` | `PRIMARY KEY` | `gen_random_uuid()` | — |
+| `tenant_id` | `uuid` | `NOT NULL` | — | `tenants.id` |
+| `candidate_id` | `uuid` | `NOT NULL` | — | `candidates.id` |
+| `template_id` | `uuid` | — | — | `emailTemplates.id` |
+| `template_name` | `varchar(80)` | `NOT NULL` | — | — |
+| `recipient_email` | `varchar(255)` | `NOT NULL` | — | — |
+| `recipient_name` | `varchar(200)` | — | — | — |
+| `sender_user_id` | `uuid` | — | — | `users.id` |
+| `sender_email` | `varchar(255)` | `NOT NULL` | — | — |
+| `sender_name` | `varchar(200)` | `NOT NULL` | — | — |
+| `subject` | `varchar(200)` | `NOT NULL` | — | — |
+| `body` | `text` | `NOT NULL` | — | — |
+| `send_status` | `varchar(20)` | `NOT NULL` | `'sent'` | — |
+| `error_message` | `text` | — | — | — |
+| `sent_at` | `timestamp` | `NOT NULL` | `now()` | — |
+
+**Drizzle name:** `sentEmails` (imported as `import { sentEmails } from '@/db/schema'`).

--- a/techdocs/database/tables/tenant-settings.md
+++ b/techdocs/database/tables/tenant-settings.md
@@ -1,0 +1,22 @@
+# tenant_settings
+
+_Schema reference for the tenant_settings table._
+
+> **ℹ️ Note**
+>
+> Auto-generated from `src/db/schema/tenant-settings.ts`. **6** columns. To regenerate locally, run `npm run docs:gen:db` from `docs-site/`.
+
+**Tenant-scoped.** This table includes `tenant_id` and is enforced by Row-Level Security. All queries must run inside `withTenant(tenantId, ...)`. See [Multi-tenancy & RLS](../../architecture/multi-tenancy-rls.md).
+
+## Columns
+
+| Column | Type | Constraints | Default | References |
+|---|---|---|---|---|
+| `id` | `uuid` | `PRIMARY KEY` | `gen_random_uuid()` | — |
+| `tenant_id` | `uuid` | `NOT NULL` | — | `tenants.id` |
+| `key` | `varchar(100)` | `NOT NULL` | — | — |
+| `value` | `text` | `NOT NULL` | — | — |
+| `updated_by` | `uuid` | `NOT NULL` | — | `users.id` |
+| `updated_at` | `timestamp` | `NOT NULL` | `now()` | — |
+
+**Drizzle name:** `tenantSettings` (imported as `import { tenantSettings } from '@/db/schema'`).

--- a/techdocs/database/tables/tenants.md
+++ b/techdocs/database/tables/tenants.md
@@ -1,0 +1,19 @@
+# tenants
+
+_Schema reference for the tenants table._
+
+> **ℹ️ Note**
+>
+> Auto-generated from `src/db/schema/tenants.ts`. **5** columns. To regenerate locally, run `npm run docs:gen:db` from `docs-site/`.
+
+## Columns
+
+| Column | Type | Constraints | Default | References |
+|---|---|---|---|---|
+| `id` | `uuid` | `PRIMARY KEY` | `gen_random_uuid()` | — |
+| `name` | `varchar(100)` | `NOT NULL` | — | — |
+| `slug` | `varchar(100)` | `NOT NULL` `UNIQUE` | — | — |
+| `plan` | `varchar(20)` | `NOT NULL` | `'free'` | — |
+| `created_at` | `timestamp` | `NOT NULL` | `now()` | — |
+
+**Drizzle name:** `tenants` (imported as `import { tenants } from '@/db/schema'`).

--- a/techdocs/database/tables/transcript-analyses.md
+++ b/techdocs/database/tables/transcript-analyses.md
@@ -1,0 +1,35 @@
+# transcript_analyses
+
+_Schema reference for the transcript_analyses table._
+
+> **ℹ️ Note**
+>
+> Auto-generated from `src/db/schema/transcript-analyses.ts`. **19** columns. To regenerate locally, run `npm run docs:gen:db` from `docs-site/`.
+
+**Tenant-scoped.** This table includes `tenant_id` and is enforced by Row-Level Security. All queries must run inside `withTenant(tenantId, ...)`. See [Multi-tenancy & RLS](../../architecture/multi-tenancy-rls.md).
+
+## Columns
+
+| Column | Type | Constraints | Default | References |
+|---|---|---|---|---|
+| `id` | `uuid` | `PRIMARY KEY` | `gen_random_uuid()` | — |
+| `tenant_id` | `uuid` | `NOT NULL` | — | `tenants.id` |
+| `transcript_id` | `uuid` | `NOT NULL` | — | `interviewTranscripts.id` |
+| `overall_score` | `integer` | — | — | — |
+| `communication_score` | `integer` | — | — | — |
+| `technical_depth_score` | `integer` | — | — | — |
+| `problem_solving_score` | `integer` | — | — | — |
+| `social_fit_score` | `integer` | — | — | — |
+| `communication_reasoning` | `text` | — | — | — |
+| `technical_depth_reasoning` | `text` | — | — | — |
+| `problem_solving_reasoning` | `text` | — | — | — |
+| `social_fit_reasoning` | `text` | — | — | — |
+| `summary` | `text` | — | — | — |
+| `strengths` | `text` | — | — | — |
+| `red_flags` | `text` | — | — | — |
+| `recommended_decision` | `recommendedDecisionEnum` | — | — | — |
+| `question_responses` | `jsonb` | — | — | — |
+| `detected_language` | `varchar(10)` | `NOT NULL` | `'en'` | — |
+| `created_at` | `timestamp` | `NOT NULL` | `now()` | — |
+
+**Drizzle name:** `transcriptAnalyses` (imported as `import { transcriptAnalyses } from '@/db/schema'`).

--- a/techdocs/database/tables/user-invitations.md
+++ b/techdocs/database/tables/user-invitations.md
@@ -1,0 +1,25 @@
+# user_invitations
+
+_Schema reference for the user_invitations table._
+
+> **ℹ️ Note**
+>
+> Auto-generated from `src/db/schema/user-invitations.ts`. **9** columns. To regenerate locally, run `npm run docs:gen:db` from `docs-site/`.
+
+**Tenant-scoped.** This table includes `tenant_id` and is enforced by Row-Level Security. All queries must run inside `withTenant(tenantId, ...)`. See [Multi-tenancy & RLS](../../architecture/multi-tenancy-rls.md).
+
+## Columns
+
+| Column | Type | Constraints | Default | References |
+|---|---|---|---|---|
+| `id` | `uuid` | `PRIMARY KEY` | `gen_random_uuid()` | — |
+| `tenant_id` | `uuid` | `NOT NULL` | — | `tenants.id` |
+| `token` | `varchar(64)` | `NOT NULL` `UNIQUE` | — | — |
+| `email` | `varchar(255)` | — | — | — |
+| `role` | `varchar(20)` | `NOT NULL` | `'recruiter'` | — |
+| `created_by` | `uuid` | `NOT NULL` | — | — |
+| `expires_at` | `timestamp` | `NOT NULL` | — | — |
+| `used_at` | `timestamp` | — | — | — |
+| `created_at` | `timestamp` | `NOT NULL` | `now()` | — |
+
+**Drizzle name:** `userInvitations` (imported as `import { userInvitations } from '@/db/schema'`).

--- a/techdocs/database/tables/users.md
+++ b/techdocs/database/tables/users.md
@@ -1,0 +1,28 @@
+# users
+
+_Schema reference for the users table._
+
+> **ℹ️ Note**
+>
+> Auto-generated from `src/db/schema/users.ts`. **12** columns. To regenerate locally, run `npm run docs:gen:db` from `docs-site/`.
+
+**Tenant-scoped.** This table includes `tenant_id` and is enforced by Row-Level Security. All queries must run inside `withTenant(tenantId, ...)`. See [Multi-tenancy & RLS](../../architecture/multi-tenancy-rls.md).
+
+## Columns
+
+| Column | Type | Constraints | Default | References |
+|---|---|---|---|---|
+| `id` | `uuid` | `PRIMARY KEY` | `gen_random_uuid()` | — |
+| `tenant_id` | `uuid` | `NOT NULL` | — | `tenants.id` |
+| `email` | `varchar(255)` | `NOT NULL` | — | — |
+| `name` | `varchar(100)` | `NOT NULL` | — | — |
+| `role` | `userRoleEnum` | `NOT NULL` | `'recruiter'` | — |
+| `password_hash` | `varchar(255)` | `NOT NULL` | — | — |
+| `is_active` | `boolean` | `NOT NULL` | `true` | — |
+| `password_reset_required` | `boolean` | `NOT NULL` | `false` | — |
+| `last_password_change_at` | `timestamp` | — | — | — |
+| `password_reset_token_hash` | `varchar(64)` | — | — | — |
+| `password_reset_token_expires_at` | `timestamp` | — | — | — |
+| `created_at` | `timestamp` | `NOT NULL` | `now()` | — |
+
+**Drizzle name:** `users` (imported as `import { users } from '@/db/schema'`).

--- a/techdocs/decisions/dec-001-build-vs-buy.md
+++ b/techdocs/decisions/dec-001-build-vs-buy.md
@@ -1,0 +1,49 @@
+# DEC-001 — Build vs buy
+
+_Build SkillAI as a focused internal recruiting tool rather than buying or forking a full ATS, to keep candidate data on-premise and ship in 6–8 weeks._
+
+> **ℹ️ Note**
+>
+> **Status:** Accepted · **Category:** Product · **Date:** 2026-04-09 · **Stakeholders:** Product Owner, Tech Lead
+
+## Decision
+
+Build SkillAI as a focused internal recruiting tool — not a full ATS — that uses AI (Claude + Gemini) to rank and archive candidates against job role descriptions, with multi-tenant support, agency management, and a persistent candidate archive.
+
+## Context
+
+The recruiter team is drowning in unstructured CV volume from multiple agencies across multiple open roles. Existing approaches (spreadsheets, email threads) create no searchable history and produce inconsistent evaluation. Full ATS platforms (Greenhouse, Lever, Workday) are too heavy and expensive for what is fundamentally a ranking and navigation problem. An internal, self-hosted tool is preferred because candidate data is sensitive and should not leave company infrastructure.
+
+## Alternatives Considered
+
+1. **Buy a full ATS (Greenhouse/Lever)**
+   - Pros: Feature-complete, well-supported, mobile apps
+   - Cons: $10k-$50k/year, requires IT procurement, data leaves company, massive scope beyond our needs
+
+2. **Fork an open-source ATS (OpenCATS, iKrut)**
+   - Pros: Free, some features pre-built
+   - Cons: No AI ranking, legacy codebases, PHP/outdated stacks, not built for CV-to-role scoring
+
+3. **Build a spreadsheet + GPT workflow**
+   - Pros: Zero infrastructure
+   - Cons: No archive, no multi-user, no structured scoring, brittle
+
+## Rationale
+
+The core value we need is: fast AI-powered ranking + a reusable candidate archive. Nothing off-the-shelf provides both. Building a focused tool in 6-8 weeks is feasible, delivers exactly what we need, and keeps data internal.
+
+## Consequences
+
+**Positive:**
+- Full control over data and features
+- No recurring SaaS costs beyond AI API usage
+- Can extend as needs evolve
+
+**Negative:**
+- Requires development time and ongoing maintenance
+- No mobile app initially
+- Team must manage infrastructure (Docker, backups)
+
+## Related
+
+- The data-sovereignty principle established here is invoked directly by [DEC-006 — Auth.js v5 over Clerk](./dec-006-authjs-over-clerk.md) and [DEC-007 — Manual transcript upload](./dec-007-manual-transcript-upload.md).

--- a/techdocs/decisions/dec-002-drizzle-over-prisma.md
+++ b/techdocs/decisions/dec-002-drizzle-over-prisma.md
@@ -1,0 +1,24 @@
+# DEC-002 — Drizzle ORM over Prisma
+
+_Drizzle was chosen for native first-class pgvector support, a lighter footprint with no query-engine binary, and a type-safe SQL-like query builder that suits our schema._
+
+> **ℹ️ Note**
+>
+> **Status:** Accepted · **Category:** Technical · **Date:** 2026-04-09 · **Stakeholders:** Tech Lead
+
+## Decision
+
+Use Drizzle ORM instead of Prisma for database access.
+
+## Context
+
+Both ORMs are viable for Next.js + PostgreSQL. Drizzle was chosen because it has native, first-class pgvector support built into its schema types (`vector()` column type, `cosineDistance`, `l2Distance` helpers). Prisma only added pgvector support in v6.13 (early 2026) and the DX is still maturing. Drizzle is also significantly lighter (no query engine binary) which simplifies Docker images.
+
+## Consequences
+
+**Positive:** Native pgvector, lighter Docker images, type-safe SQL-like query builder
+**Negative:** Smaller ecosystem, fewer examples online vs Prisma
+
+## Related
+
+- The pgvector advantage here is what makes semantic candidate search practical — see [DEC-003 — Row-Level Security](./dec-003-row-level-security.md) for how RLS interacts with the schema choices.

--- a/techdocs/decisions/dec-003-row-level-security.md
+++ b/techdocs/decisions/dec-003-row-level-security.md
@@ -1,0 +1,25 @@
+# DEC-003 — Row-Level Security for multi-tenancy
+
+_PostgreSQL RLS with a tenant_id column on every table and a per-request session variable enforces isolation at the database layer, simpler than schema-per-tenant._
+
+> **ℹ️ Note**
+>
+> **Status:** Accepted · **Category:** Technical · **Date:** 2026-04-09 · **Stakeholders:** Tech Lead
+
+## Decision
+
+Implement multi-tenancy using PostgreSQL Row-Level Security (RLS) with a `tenant_id` column on all tables and a session variable (`SET app.tenant_id = '...'`) set at the start of each request.
+
+## Context
+
+Two common approaches: (1) schema-per-tenant (each tenant gets isolated schema) and (2) shared schema + RLS. For an internal tool with fewer than 50 tenants, RLS is simpler to operate: no schema migration complexity, single connection pool, and isolation is enforced at the database layer — impossible to bypass in application code.
+
+## Consequences
+
+**Positive:** Simple ops, single schema, isolation enforced at DB level
+**Negative:** All queries must include tenant context; RLS policies must be audited carefully
+
+## Related
+
+- [DEC-002 — Drizzle ORM over Prisma](./dec-002-drizzle-over-prisma.md) — the ORM choice that made writing RLS-aware queries straightforward via the `withTenant()` helper.
+- [DEC-011 — GDPR erasure](./dec-011-gdpr-erasure.md) — every explicit delete runs inside the same `withTenant()` transaction this decision establishes.

--- a/techdocs/decisions/dec-004-claude-primary.md
+++ b/techdocs/decisions/dec-004-claude-primary.md
@@ -1,0 +1,24 @@
+# DEC-004 — Claude as primary AI, Gemini as secondary
+
+_Claude's structured-output reliability and reasoning quality make it the default scoring model; Gemini is retained as a per-tenant toggle for cost-sensitive bulk processing._
+
+> **ℹ️ Note**
+>
+> **Status:** Accepted · **Category:** Technical · **Date:** 2026-04-09 · **Stakeholders:** Product Owner, Tech Lead
+
+## Decision
+
+Use Claude (`claude-sonnet-4-6`) as the primary AI for CV parsing and candidate scoring, with Gemini (`gemini-2.0-flash`) available as an alternative per-role toggle.
+
+## Context
+
+Claude's structured output support guarantees valid JSON schema responses, which eliminates defensive parsing code and improves reliability of the scoring pipeline. Claude's reasoning quality for nuanced assessment tasks (experience-level judgment, role-fit) is superior in benchmarks. Gemini is retained as an option for cost-sensitive bulk processing and as a comparison baseline.
+
+## Consequences
+
+**Positive:** Reliable structured scoring, high quality reasoning, explainable scores
+**Negative:** Claude API costs can add up on large batches; Gemini option adds integration complexity
+
+## Related
+
+- [DEC-009 — Soft AI signal for day-rate budget](./dec-009-soft-budget-signal.md) — the soft budget signal applies to both Claude and Gemini scoring prompts.

--- a/techdocs/decisions/dec-005-storage.md
+++ b/techdocs/decisions/dec-005-storage.md
@@ -1,0 +1,25 @@
+# DEC-005 — Local Docker volume + Garage for file storage
+
+_CVs and logos live on a local Docker named volume in development and small production deployments; Garage (self-hosted S3-compatible) is the upgrade path for larger deployments._
+
+> **ℹ️ Note**
+>
+> **Status:** Accepted · **Category:** Technical · **Date:** 2026-04-09 · **Stakeholders:** Tech Lead
+
+## Decision
+
+Store uploaded CVs in a local Docker named volume for development and small production deployments. Garage (self-hosted S3-compatible) is the defined upgrade path for larger production deployments.
+
+## Context
+
+MinIO (the previously popular self-hosted S3 option) moved to AGPL in 2024 and is now effectively archived for most self-hosted use cases. Garage is a purpose-built self-hosted object store, S3-compatible, runs as a single Docker container, and is designed for modest hardware. Since all CV files are internal and sensitive, no external storage (S3, GCS) is used.
+
+## Consequences
+
+**Positive:** Zero external dependencies, data stays on-premise, simple Docker setup
+**Negative:** Volume backup must be managed manually; Garage adds complexity if adopted
+
+## Related
+
+- [DEC-001 — Build vs buy](./dec-001-build-vs-buy.md) — the data-sovereignty principle established here is what rules out S3 / GCS as defaults.
+- The Garage migration is an open roadmap item — see [Roadmap → Open work](../roadmap.md#open-work).

--- a/techdocs/decisions/dec-006-authjs-over-clerk.md
+++ b/techdocs/decisions/dec-006-authjs-over-clerk.md
@@ -1,0 +1,42 @@
+# DEC-006 — Auth.js v5 over Clerk for authentication
+
+_Clerk would have shipped faster but routes sessions through external SaaS. Auth.js v5 with credentials + JWT keeps all auth data on-premise, satisfying our data-sovereignty rule._
+
+> **ℹ️ Note**
+>
+> **Status:** Accepted · **Category:** Technical · **Date:** 2026-04-09 · **Stakeholders:** Tech Lead, Product Owner
+
+## Decision
+
+Use Auth.js v5 (NextAuth) with credentials provider and JWT sessions instead of Clerk.
+
+## Context
+
+Research flagged Clerk as the fastest-setup auth solution for Next.js with built-in RBAC. However, Clerk is a SaaS service — user sessions and auth events are processed on Clerk's infrastructure. Since SkillAI handles sensitive candidate PII and is explicitly an internal tool, all auth must remain self-hosted with no data leaving company infrastructure. Auth.js v5 is self-hosted, credentials-based, and fully on-premise.
+
+The additional setup cost (implementing RBAC manually vs Clerk's built-in) is acceptable: we need only 3 roles (admin, recruiter, viewer), which maps to a simple JWT claim + middleware check — approximately 2-4 hours of work.
+
+## Alternatives Considered
+
+1. **Clerk**
+   - Pros: 30-minute setup, RBAC built-in, managed sessions
+   - Cons: External SaaS dependency, candidate/user data transits Clerk servers, violates internal-only data policy
+
+2. **Keycloak (self-hosted)**
+   - Pros: Enterprise OIDC/SAML, full self-hosted
+   - Cons: Requires a separate service, significant ops overhead, overkill for 3 roles and 20-50 users
+
+## Rationale
+
+Data sovereignty is non-negotiable for candidate PII. Auth.js v5 with credentials + JWT + Drizzle adapter is the simplest fully self-hosted solution that integrates natively with our stack.
+
+## Consequences
+
+**Positive:** All auth data stays on-premise, no external SaaS dependency, integrates cleanly with Drizzle adapter
+**Negative:** Manual RBAC implementation (~3 hours), manual password reset flow if needed later
+
+## Related
+
+- [DEC-001 — Build vs buy](./dec-001-build-vs-buy.md) — the data-sovereignty principle this decision applies.
+- [DEC-007 — Manual transcript upload](./dec-007-manual-transcript-upload.md) — the same data-sovereignty argument rules out third-party transcript aggregators.
+- The role enum has since grown to four (`admin`, `recruiter`, `hiring_manager`, `viewer`) — see the roadmap Hiring Manager Persona section.

--- a/techdocs/decisions/dec-007-manual-transcript-upload.md
+++ b/techdocs/decisions/dec-007-manual-transcript-upload.md
@@ -1,0 +1,47 @@
+# DEC-007 — Manual file upload for interview transcripts
+
+_Transcripts are imported via manual file upload (VTT / SRT / DOCX / TXT) or paste. Zoom / Teams / Meet API adapters are deferred to avoid OAuth complexity and external SaaS dependencies._
+
+> **ℹ️ Note**
+>
+> **Status:** Accepted · **Category:** Product · **Date:** 2026-04-10 · **Stakeholders:** Tech Lead, Product Owner
+>
+> **Related spec:** `@.agent-os/specs/2026-04-10-interview-transcript-scoring/`
+
+## Decision
+
+Implement interview transcript import via manual file upload (VTT, SRT, DOCX, TXT) and text paste only. Do not integrate with Zoom, Teams, or Google Meet APIs in the initial spec.
+
+## Context
+
+All three platforms have API access to transcripts (Zoom API, Teams Graph API, Google Meet API), but each requires: OAuth app registration with corporate admin consent, platform-specific credential management, webhook/token refresh infrastructure, and significant integration testing. That is 3–6 weeks of work per platform, introducing external SaaS dependencies and ongoing maintenance. Manual file upload covers 100% of use cases immediately — every platform allows transcript export as a file, and users can upload it in seconds.
+
+## Alternatives Considered
+
+1. **Build Zoom/Teams/Google Meet API adapters first**
+   - Pros: Smoother UX (one-click import without leaving SkillAI)
+   - Cons: 3–6 weeks additional effort, requires corporate admin OAuth consent in user's org, creates external dependency per platform, significant maintenance burden
+
+2. **Use a third-party aggregator (Recall.ai)**
+   - Pros: Single API for all platforms
+   - Cons: External SaaS dependency, cost per meeting, data leaves infrastructure (violates data sovereignty principle)
+
+## Rationale
+
+Data sovereignty principle (DEC-001, DEC-006) and speed-to-value both favour manual upload. Platform API integration can be added as a Phase 2 enhancement once manual upload validates recruiter demand for the feature.
+
+## Consequences
+
+**Positive:**
+- Ships in ~1 week vs 3–6 weeks for API integration
+- Zero new external dependencies or OAuth complexity
+- Consistent with data sovereignty principle — transcript data never transits third-party services
+
+**Negative:**
+- Slightly more friction for users (download file → upload to SkillAI vs one-click)
+- Speaker attribution quality depends on platform export quality
+
+## Related
+
+- [DEC-001 — Build vs buy](./dec-001-build-vs-buy.md) — the on-premise principle invoked here.
+- [DEC-006 — Auth.js v5 over Clerk](./dec-006-authjs-over-clerk.md) — same data-sovereignty reasoning, applied to auth.

--- a/techdocs/decisions/dec-008-manual-archive.md
+++ b/techdocs/decisions/dec-008-manual-archive.md
@@ -1,0 +1,38 @@
+# DEC-008 — Manual archive on role cut-off expiry
+
+_Roles past their cut-off date are flagged visually but never auto-archived. Recruiters retain control over closing a role, because cut-off dates routinely slide._
+
+> **ℹ️ Note**
+>
+> **Status:** Accepted · **Category:** Product · **Date:** 2026-04-14
+
+## Decision
+
+When a role's `cutoffDate` passes, the role is **flagged visually** (red EXPIRED badge on the list, red banner on the detail page) but remains `isActive = true` until a recruiter explicitly archives it. No automatic lifecycle transitions.
+
+## Context
+
+Cut-off dates are set based on the customer's stated deadline but often slide — the client extends, a late strong candidate appears, or the search is paused rather than cancelled. An auto-archive policy would routinely close roles that the recruiter still wants to work, creating either silent data loss or a constant stream of "unarchive" clicks.
+
+## Alternatives Considered
+
+1. **Auto-archive on cut-off date**
+   - Pros: Zero manual overhead; list stays tidy
+   - Cons: Hides roles the recruiter still needs; forces "unarchive" dance; loses ranked shortlist state if archive triggers cleanup
+
+2. **Auto-archive after a grace period (e.g. +7 days past cut-off)**
+   - Pros: Softer version of auto-archive
+   - Cons: Still wrong for the common "client extended" case; adds a new tunable with no clear right value
+
+3. **Prompt + manual confirm (chosen)**
+   - Pros: Recruiter retains control; visibility is preserved; zero risk of accidental closure
+   - Cons: Expired roles accumulate if recruiter ignores the prompt
+
+## Rationale
+
+Recruiters are the judgement layer. The tool surfaces the signal; the human makes the call. Two clicks (Edit to extend OR Archive to close) is a trivial cost to pay for zero risk of losing in-flight search state.
+
+## Consequences
+
+**Positive:** No data loss, no surprise archival, matches how recruiters already think about deadlines.
+**Negative:** Housekeeping is manual; an inactive tenant could accumulate hundreds of silently-expired roles. Mitigated by the list-level EXPIRED badge making them visually obvious.

--- a/techdocs/decisions/dec-009-soft-budget-signal.md
+++ b/techdocs/decisions/dec-009-soft-budget-signal.md
@@ -1,0 +1,48 @@
+# DEC-009 — Soft AI signal for day-rate budget
+
+_Budget is a textual signal in the per-candidate prompt block, never a scored dimension. The four structured scores are never reduced on budget grounds alone._
+
+> **ℹ️ Note**
+>
+> **Status:** Accepted · **Category:** Technical · **Date:** 2026-04-14
+>
+> **Related feature:** Customer day rate per role + margin display
+
+## Decision
+
+When a role has a `customerDayRate` (budget) and a candidate has a `candidateRate` in the same currency, pass a **soft budget signal** to Claude / Gemini as prompt text in the per-candidate section. Guidance: rates are negotiable; candidates within ~10% over budget get no score impact; 10–25% over gets a "may require negotiation" note in the summary; >25% over gets a "may be misaligned with seniority" note. **The four structured scoring dimensions (technical_skills, experience_level, cultural_fit, communication) are never reduced on budget grounds alone.**
+
+Currency mismatch (role in EUR, candidate in GBP, etc.) **suppresses** the AI budget context entirely — the UI still displays the margin with a warning pill.
+
+## Context
+
+Adding budget as a fifth scored dimension was considered and rejected. The existing four dimensions are carefully-chosen assessment axes that aggregate into `overall_score`. Adding a "budget" dimension would:
+- Create an invisible pull on `overall_score` that recruiters have to mentally back out
+- Require a migration on the `scores` table and changes to both Claude tool schema and Gemini response schema, plus matching PDF changes
+- Be awkward to express "don't heavily penalise over-budget" — dimensions are scalar scores that can't easily carry soft-signal semantics
+
+## Alternatives Considered
+
+1. **New scored dimension `budget_fit`** — rejected as above
+2. **Hard budget filter (exclude over-budget candidates)** — rejected because rates are commonly negotiable
+3. **Soft signal in prompt only (chosen)** — zero schema migration, margin still visible in UI, AI context is optional per-candidate
+4. **Display margin only, no AI awareness** — rejected because the AI summary then contradicts the visible margin pill
+
+## Rationale
+
+Budget matters to the recruiter (margin is prominent in the UI) but the right application is textual, not numerical. The soft signal lets Claude mention budget positioning in its summary while leaving the structured scores untouched.
+
+## Technical notes
+
+- Budget context is inserted in the **per-candidate** prompt block, NOT the role/framework block. The role block has `cache_control: ephemeral` — per-candidate rate data in the cached section would bust the prompt cache on every candidate.
+- Currency mismatch detection suppresses the AI context so the model is never asked to reason across currencies.
+- Changes to a role's `customerDayRate` do NOT trigger automatic rescoring. Recruiters use the existing per-candidate rescore button if they want updated summaries after a budget change.
+
+## Consequences
+
+**Positive:** No schema migration on scoring, no risk of inadvertent score suppression for strong over-budget candidates, margin visible where recruiters need it, AI reasoning acknowledges budget when relevant.
+**Negative:** Over-budget candidates aren't "sorted to the bottom" automatically — recruiters sort themselves.
+
+## Related
+
+- [DEC-004 — Claude as primary AI](./dec-004-claude-primary.md) — the budget signal goes into both Claude and Gemini scoring prompts.

--- a/techdocs/decisions/dec-010-internal-bench.md
+++ b/techdocs/decisions/dec-010-internal-bench.md
@@ -1,0 +1,45 @@
+# DEC-010 — Internal bench: orthogonal availability, not a pipeline stage
+
+_Bench is a derived view from a per-tenant Internal system agency plus an orthogonal availability enum that applies to all candidates — not a stored flag or a pipeline-status value._
+
+> **ℹ️ Note**
+>
+> **Status:** Accepted · **Category:** Technical · **Date:** 2026-04-14
+>
+> **Related feature:** Internal bench (system Internal agency + availability status)
+
+## Decision
+
+Internal employees are modelled as candidates belonging to a per-tenant system agency named "Internal" (`is_internal = true`, `is_system = true`, protected from archival). Their **availability** is an orthogonal field (`available` / `on_project` / `unavailable`) plus an optional `available_from` date, applied to ALL candidates (internal or external). "Bench" is a derived concept: `agency.isInternal && candidate.availabilityStatus = 'available'` — no redundant column.
+
+Internal candidates get a visible **INTERNAL badge** on the candidate list and on ranked role results, but **no scoring boost**. Fit is fit.
+
+## Context
+
+Two naïve approaches were considered and rejected:
+
+1. **Extending the pipeline `status` enum with a `bench` value** — wrong because bench is orthogonal to pipeline position. An internal bench person can be `new`, `shortlisted`, or `interviewing` for a specific role while still being "on bench" from the hiring team's perspective.
+2. **A `bench`-specific boolean that only applies to internal candidates** — wrong because contractors also finish contracts. "When is this person free?" applies to any candidate.
+
+## Alternatives Considered
+
+1. **Pipeline enum extension** — rejected (orthogonality violation)
+2. **Bench-specific fields** — rejected (narrow applicability)
+3. **Placement FK (link candidate to their current role)** — rejected (we don't model placements as first-class entities, and this conflates "currently scored on a role" with "currently billing on a role")
+4. **Orthogonal availability enum + derived bench view (chosen)**
+
+## Rationale
+
+Availability as an orthogonal attribute is conceptually correct, works for both internal and external candidates, and requires no changes to existing pipeline logic. Making "bench" a derived view rather than a stored flag avoids denormalisation and keeps the model honest.
+
+## Implementation notes
+
+- Internal agency is **auto-provisioned** per tenant via migration backfill AND a seed-time helper (`ensureInternalAgency`). Idempotent via partial unique index `uniq_agencies_tenant_internal`.
+- `is_internal` (semantic) and `is_system` (operational, blocks archival) are kept as separate flags even though they happen to be the same rows today — cheap future-proofing.
+- Bulk action `bulkAssignToInternalAgency` lets recruiters convert a batch of existing candidates into internal employees.
+- Internal candidates do **not** receive an AI scoring boost. They are tagged in the UI (INTERNAL badge) and easily surfaced via filter, but scored identically to external candidates.
+
+## Consequences
+
+**Positive:** Clean separation of concerns (pipeline vs availability), reusable beyond internal employees, auto-provisioned for all existing and future tenants, protected from accidental deletion.
+**Negative:** Two flags (`is_internal`, `is_system`) instead of one — minor schema complexity; derived "bench" status requires a join in queries.

--- a/techdocs/decisions/dec-011-gdpr-erasure.md
+++ b/techdocs/decisions/dec-011-gdpr-erasure.md
@@ -1,0 +1,53 @@
+# DEC-011 — GDPR erasure: explicit transactional deletes + audit redaction
+
+_Article 17 erasure runs explicit application-level deletes across 13 child tables inside one transaction; audit rows are redacted in place rather than deleted, to satisfy competing GDPR record-keeping obligations._
+
+> **ℹ️ Note**
+>
+> **Status:** Accepted · **Category:** Technical · **Date:** 2026-04-28
+>
+> **Related feature:** GDPR right-to-erasure UI (Article 17) — Issue #75, PR #130
+
+## Decision
+
+When honouring a GDPR Article 17 erasure request, the application issues **explicit transactional deletes** in dependency order across all 13 candidate-child tables (`sent_emails`, `transcript_analyses`, `interview_transcripts`, `interview_questions`, `code_challenges`, `interview_packs`, `interview_slots`, `candidate_role_approvals`, `notes`, `cv_profiles`, `candidate_enrichments`, `scores`, `candidates`) inside a single `withTenant()` transaction. The CV file is unlinked from disk via `deleteCvFile` after the transaction commits.
+
+Existing `audit_logs` rows for the candidate are **NOT deleted**. They are **redacted in place**: `entityLabel := '[redacted-gdpr]'` and `metadata := { redacted_gdpr: true, redacted_at: <iso> }`. A tombstone `candidate.deleted_gdpr` audit row is written after the deletion succeeds.
+
+## Context
+
+Two reasonable approaches were on the table for the cascade:
+
+1. **DB-level cascade** — add `ON DELETE CASCADE` to every FK referencing `candidates.id`. This is the canonical relational answer, but it would require a migration touching ~13 tables and the cascade order would be implicit (defined by the DB engine), not auditable in code.
+
+2. **Application-level explicit deletes** (chosen) — the action enumerates each child table and issues a `DELETE WHERE candidate_id = ?` (or grandchild equivalent) in the correct order inside one transaction. The code reads as a checklist; reviewers can immediately verify nothing is missed.
+
+For the audit log, the regulatory question is "do we need to delete the audit rows under Article 17?" The answer in most legal interpretations: **no**, because Article 17 requires erasure of *personal data*, and an audit log of "user X deleted candidate Y at time Z" is required for accountability under Article 5(2) and Article 30 — a competing legal obligation. Redacting the PII (the candidate's name and metadata) while keeping the action timestamp + actor satisfies both: the personal data is gone, the audit trail survives.
+
+## Alternatives Considered
+
+1. **DB cascade with migration** — rejected on auditability grounds. A future schema change to add a new candidate-child table would silently inherit cascade behaviour without any signal to the engineer that a GDPR-relevant data path now exists.
+2. **Soft-delete (set `deleted_at`)** — rejected because Article 17 explicitly requires erasure, not anonymisation. A soft-delete row still contains the personal data.
+3. **Delete the audit rows entirely** — rejected because audit retention is a competing legal obligation; redaction satisfies both.
+4. **Hash the audit row PII** — rejected as theatre. If the audit log can be re-correlated to the deleted candidate via a secondary key, it isn't really redacted; if it can't, redacting via null/sentinel is simpler than hashing.
+
+## Rationale
+
+Explicit deletes make the data flow legible and reviewable. Audit redaction-not-deletion balances Article 17 (erasure) against Article 5(2) / Article 30 (accountability + record-keeping). Both choices favour clarity over cleverness — when a regulator or a customer asks "what exactly happens when you erase a candidate?", we can read it off the code.
+
+## Implementation notes
+
+- Deletion order is documented in `src/actions/gdpr.ts` and follows FK dependency: grandchildren of `interview_packs` and `interview_transcripts` first, then direct children of `candidates`, audit redaction, then `candidates` row last.
+- The action is admin-gated at three layers: server action (`requireRole(_, 'admin')`), API route (`session.user.role === 'admin'`), and UI panel render (`userRole === 'admin'`).
+- Confirmation: caller must type `${firstName} ${lastName}` exactly (case-sensitive) — server-side check.
+- DSAR export (Article 15) is a separate action with its own admin gate; both live in `src/actions/gdpr.ts` + `src/lib/gdpr/`.
+- This pattern should be reused for any future hard-delete features (e.g., tenant data purge, user account deletion). DB cascade should be avoided for any flow with audit / regulatory implications.
+
+## Consequences
+
+**Positive:** Auditable in code; future-proof against silent cascade changes; satisfies competing GDPR obligations; reviewable confirmation flow.
+**Negative:** New tables that reference `candidates.id` will need an explicit entry in the deletion list — a forgotten table is the failure mode. Mitigation: a future test could enumerate all FKs referencing `candidates.id` in the schema and assert they're all in the action's delete list.
+
+## Related
+
+- [DEC-003 — Row-Level Security](./dec-003-row-level-security.md) — every delete in the cascade runs inside the `withTenant()` transaction this decision establishes.

--- a/techdocs/decisions/index.md
+++ b/techdocs/decisions/index.md
@@ -1,0 +1,32 @@
+# Decisions log
+
+_Every architecturally-meaningful choice in SkillAI, with rationale, alternatives considered, and consequences. Override priority — highest._
+
+Every architecturally-meaningful choice in SkillAI is logged here with rationale, alternatives considered, and consequences. **Override priority: highest.** These decisions trump anything in `CLAUDE.md` or contributor docs — if a contributor instruction conflicts with a decision below, the decision wins until it is formally superseded.
+
+## The log
+
+| ID | Date | Title | Category | Status |
+|----|------|-------|----------|--------|
+| [DEC-001](./dec-001-build-vs-buy.md) | 2026-04-09 | Initial product planning — build vs buy | Product | `Accepted` |
+| [DEC-002](./dec-002-drizzle-over-prisma.md) | 2026-04-09 | Drizzle ORM over Prisma | Technical | `Accepted` |
+| [DEC-003](./dec-003-row-level-security.md) | 2026-04-09 | Row-Level Security for multi-tenancy | Technical | `Accepted` |
+| [DEC-004](./dec-004-claude-primary.md) | 2026-04-09 | Claude as primary AI, Gemini as secondary | Technical | `Accepted` |
+| [DEC-005](./dec-005-storage.md) | 2026-04-09 | Local Docker volume + Garage for file storage | Technical | `Accepted` |
+| [DEC-006](./dec-006-authjs-over-clerk.md) | 2026-04-09 | Auth.js v5 over Clerk for authentication | Technical | `Accepted` |
+| [DEC-007](./dec-007-manual-transcript-upload.md) | 2026-04-10 | Manual file upload for interview transcripts | Product | `Accepted` |
+| [DEC-008](./dec-008-manual-archive.md) | 2026-04-14 | Manual archive on role cut-off expiry | Product | `Accepted` |
+| [DEC-009](./dec-009-soft-budget-signal.md) | 2026-04-14 | Soft AI signal for day-rate budget | Technical | `Accepted` |
+| [DEC-010](./dec-010-internal-bench.md) | 2026-04-14 | Internal bench — orthogonal availability | Technical | `Accepted` |
+| [DEC-011](./dec-011-gdpr-erasure.md) | 2026-04-28 | GDPR erasure — explicit deletes + audit redaction | Technical | `Accepted` |
+
+> **ℹ️ Note — Proposing a new decision**
+>
+> Before opening a PR for a new decision:
+>
+> 1. **Read the existing decisions first** — many architectural questions are already answered. If a new decision contradicts an existing one, that existing one needs to be **superseded** (not silently ignored) — call it out explicitly in the PR.
+> 2. **Follow the same template** — Decision · Context · Alternatives Considered · Rationale · Consequences (plus Implementation notes / Technical notes / Related feature when relevant).
+> 3. **Use the next sequential `DEC-XXX` ID.** Stakeholders and date go in the metadata block at the top.
+> 4. **Get sign-off in PR review** from at least one other engineer plus the product owner for `Product`-category decisions.
+>
+> The canonical source is [`/.agent-os/product/decisions.md`](https://github.com/olafkfreund/SkillAi/blob/main/.agent-os/product/decisions.md). The pages in this section are lifted verbatim from that file so the rationale never drifts.

--- a/techdocs/getting-started/development.md
+++ b/techdocs/getting-started/development.md
@@ -1,0 +1,236 @@
+# Development workflow
+
+_Project layout, testing, migrations, branch conventions, and the project-specific rules that come up in code review._
+
+This page covers the conventions you'll touch every day. For first-time setup see [Quick start](./quick-start.md).
+
+## Project layout
+
+```
+SkillAi/
+├── src/
+│   ├── app/                 Next.js App Router (pages + API routes)
+│   │   ├── (dashboard)/     Authenticated dashboard pages
+│   │   ├── (auth)/          Login page
+│   │   └── api/             REST API routes, polling endpoints, MCP server
+│   ├── actions/             Server actions (mutations from forms / client components)
+│   ├── components/          React components, grouped by domain
+│   ├── db/
+│   │   ├── schema/          Drizzle schema, one file per table
+│   │   ├── migrations/      Generated migration files
+│   │   └── index.ts         db client + withTenant() wrapper
+│   ├── lib/
+│   │   ├── ai/              Claude + Gemini clients, scoring, schemas
+│   │   ├── auth/            require-role, types
+│   │   ├── cv/              CV upload helpers
+│   │   ├── branding/        Logo upload helpers
+│   │   ├── mcp/             MCP server tools, resources, prompts
+│   │   ├── notifications/   Slack + Teams webhook dispatchers
+│   │   └── ...
+│   └── content/help/        In-app help articles (markdown + Zod front-matter)
+├── tests/
+│   ├── unit/                Unit tests (Vitest)
+│   ├── integration/         DB-backed integration tests
+│   └── fixtures/            Test fixtures
+├── scripts/                 Helper scripts (seed, migrate, etc.)
+├── skillai-mcp/             Standalone stdio bridge for claude-desktop
+├── docker/                  docker-compose definitions
+├── uploads/                 Local CV/logo storage (gitignored)
+├── docs/                    Internal product + ops documentation
+├── docs-site/               This documentation site (Astro Starlight)
+└── .agent-os/               Product mission, tech-stack, roadmap, decisions
+```
+
+## Running the app
+
+```bash
+# Start the database
+docker compose up -d db
+
+# Start the dev server with hot reload
+npm run dev
+
+# Type-check without building
+npx tsc --noEmit
+
+# Push schema changes after editing src/db/schema/
+npm run db:push
+
+# Open Drizzle Studio (visual DB browser)
+npm run db:studio
+```
+
+## Running tests
+
+```bash
+# Unit tests
+npm test
+
+# Integration tests (require a running DB; flag is opt-in)
+RUN_DB_INTEGRATION_TESTS=true npm test
+```
+
+Unit tests live in `tests/unit/`, integration tests in `tests/integration/`. The integration tests apply migrations to a scratch database and exercise the full server-action path including RLS — they take longer, so they're gated behind the env flag.
+
+## Migration workflow
+
+
+**Development**
+
+After editing a file in `src/db/schema/`:
+
+```bash
+npm run db:push
+```
+
+`db:push` applies the schema directly to the local DB without generating a migration file. Fast, destructive (will drop columns), only safe for local development.
+
+
+
+
+**Production**
+
+```bash
+# 1. Generate a migration file
+npm run db:generate
+
+# 2. Review the generated SQL in src/db/migrations/
+#    Reject if it drops a column or rewrites a type — that needs a manual migration.
+
+# 3. Run pending migrations against the production database
+npm run db:migrate
+```
+
+
+
+> **⚠️ Caution**
+>
+> **Never use `db:push` against a production database.** It can destructively drop columns. Always generate a migration file, review the SQL, and run `db:migrate`.
+
+## Branch conventions
+
+Always branch off `core-mvp-foundation` explicitly. Never branch off whatever is currently checked out:
+
+```bash
+git checkout -b feat/my-feature core-mvp-foundation
+```
+
+Branch names follow `<type>/<short-description>`:
+
+- `feat/...` for new features
+- `fix/...` for bug fixes
+- `docs/...` for doc-only changes
+- `chore/...` for housekeeping
+
+PRs target `core-mvp-foundation`. Keep PRs focused on a single concern.
+
+## Server action template
+
+Every server action follows the same shape. Copy from an existing one in `src/actions/` rather than writing from scratch:
+
+```typescript
+'use server'
+
+const MySchema = z.object({ field: z.string().min(1) })
+
+export async function myAction(_prev: MyState | null, formData: FormData): Promise<MyState> {
+  const h = await headers()
+  const tenantId = h.get('x-tenant-id')
+  if (!tenantId) return { success: false, error: 'Unauthorized' }
+
+  const parsed = MySchema.safeParse({ field: formData.get('field') })
+  if (!parsed.success) return { success: false, error: 'Validation failed' }
+
+  await withTenant(tenantId, async (tx) => {
+    await tx.insert(myTable).values({ tenantId, ...parsed.data })
+  })
+
+  revalidatePath('/dashboard/my-page')
+  return { success: true }
+}
+```
+
+Five rules, in order:
+
+1. **Read tenant + user + role** from headers set by the auth middleware.
+2. **Validate** the input with a Zod schema. Never trust form data.
+3. **Wrap the DB call** in `withTenant(tenantId, ...)` — see [Multi-tenancy & RLS](../architecture/multi-tenancy-rls.md).
+4. **`revalidatePath()`** after mutations so the dashboard reflects the change.
+5. **Return a typed state** — never throw to the client.
+
+## Patterns to know about
+
+These patterns are load-bearing across many pages — follow them when extending the same surfaces. Each has its own documentation page under [Code patterns](../code-patterns/agency-logo.md):
+
+- **Audience-based view sanitisation** ([audience-sanitisation](../code-patterns/audience-sanitisation.md)) — recruiter / customer / manager get different field visibility on the same page. Always gate new commercial / internal fields on `audience === 'recruiter'` explicitly.
+- **Logo upload pattern** ([logo-upload](../code-patterns/logo-upload.md)) — DB-path-first, derive absolute path from it. The same rule applies to any new file-storage feature.
+- **Help content pattern** ([help-content](../code-patterns/help-content.md)) — markdown + Zod-validated front-matter in `src/content/help/`. Add a file, no code change.
+- **Theme tokens** ([theme-tokens](../code-patterns/theme-tokens.md)) — use `var(--color-bg-app)` etc., not hard-coded `bg-zinc-900`. Both light and dark must render correctly.
+- **`force-dynamic` workaround** ([force-dynamic](../code-patterns/force-dynamic.md)) — Next 16.2 + React 19 has a prerender bug; new public routes need `export const dynamic = 'force-dynamic'`.
+
+## Project-specific rules
+
+These are enforced by convention and by code review:
+
+- **Never query the DB without `withTenant()`** except for truly global tables like `tenants` itself.
+- **Never store AI API keys in plain text** — use the encryption helpers in `src/lib/ai/keys.ts`.
+- **Never commit `.env.local`** or any file with real credentials. The `.gitignore` already excludes all `.env*` files.
+- **Never use raw `sql\`\`` queries** except for the RLS session variable setter and `EXPLAIN ANALYZE` debugging.
+- **Always validate AI responses** with the relevant Zod schema in `src/lib/ai/` before writing the parsed data to the DB.
+- **Never commit DB writes without explicit consent** — the SkillAI portal is in continuous live use, not a sandbox. Always ask before seeding test fixtures or running migrations.
+- **Take a backup before any runtime change** — `pg_dump` + uploads tarball. See the [backup runbook](../operations/backup-runbook.md).
+
+## Debugging
+
+### Interview pack stuck in `pending` or `processing`
+
+The background `after()` task was interrupted (most likely by a hot reload in dev). Open the pack detail page; after 3 minutes a "Force retry" button appears.
+
+To reset manually:
+
+```sql
+UPDATE interview_packs
+SET generation_status = 'failed',
+    error_message = 'Manually reset for retry',
+    updated_at = now()
+WHERE id = '<pack-id>';
+```
+
+Then use the Retry button.
+
+### AI errors
+
+Errors are logged to the server console with the pack or score ID.
+
+```bash
+# Dev server
+# (errors appear in the terminal running `npm run dev`)
+
+# Docker
+docker compose logs -f app
+```
+
+### Direct DB access
+
+```bash
+# Local
+PGPASSWORD=skillai psql -h localhost -p 5433 -U skillai -d skillai
+
+# In the Docker container
+docker compose exec db psql -U skillai -d skillai
+```
+
+To run queries that need to see tenant-scoped rows, set the tenant variable first:
+
+```sql
+SET app.tenant_id = '<your-tenant-uuid>';
+SELECT id, first_name, last_name FROM candidates LIMIT 5;
+```
+
+## Pull request guidelines
+
+- Keep PRs focused on a single concern.
+- Include a short description of what changed and why.
+- Ensure `npx tsc --noEmit` passes with no errors.
+- Manually test the feature in the browser before submitting.
+- Ensure the existing test suite still passes (`npm test`).

--- a/techdocs/getting-started/quick-start.md
+++ b/techdocs/getting-started/quick-start.md
@@ -1,0 +1,161 @@
+# Quick start
+
+_Get SkillAI running locally in under five minutes._
+
+This walks you through cloning the repo, starting the database, pushing the schema, seeding a default tenant, and logging into the dashboard. Aimed at running it on your laptop for local development; for production deployment see [AWS deployment](../operations/aws-deploy.md).
+
+## Prerequisites
+
+| Tool | Version | Notes |
+|---|---|---|
+| Node.js | 22 LTS or later | matches the `node:22-alpine` image used in Docker |
+| Docker + Docker Compose | recent | Postgres 17 + pgvector ships as a container |
+| Git | any | |
+| Anthropic API key | — | required for AI scoring (`sk-ant-...`) |
+| Google AI (Gemini) API key | — | required for embeddings and Gemini scoring |
+| `psql` client | optional | for direct database access during debugging |
+
+## Setup
+
+1. **Clone the repository**
+
+   ```bash
+   git clone https://github.com/olafkfreund/SkillAi.git
+   cd SkillAi
+   ```
+
+2. **Install dependencies**
+
+   ```bash
+   npm install
+   ```
+
+3. **Create your env file**
+
+   ```bash
+   cp .env.example .env.local
+   ```
+
+   Open `.env.local` and fill in the required values:
+
+   ```bash
+   DATABASE_URL=postgresql://skillai:skillai@localhost:5433/skillai
+
+   NEXTAUTH_URL=http://localhost:3000
+   NEXTAUTH_SECRET=$(openssl rand -base64 32)
+   AUTH_SECRET=$(openssl rand -base64 32)  # same value as NEXTAUTH_SECRET
+
+   ANTHROPIC_API_KEY=sk-ant-...
+   GEMINI_API_KEY=AIza...
+
+   UPLOAD_DIR=./uploads
+   ENCRYPTION_KEY=$(openssl rand -hex 32)   # used to encrypt per-tenant API keys
+   ```
+
+
+> **⚠️ Caution**
+>
+> `ENCRYPTION_KEY` encrypts tenant API keys stored in the database. **If you deploy a different key in production, every tenant's stored API keys become unreadable** — keep it stable across environments.
+>
+
+4. **Start the database**
+
+
+
+**Linux / macOS**
+
+```bash
+docker compose up -d db
+```
+
+
+
+
+**Windows (PowerShell)**
+
+```powershell
+docker compose up -d db
+```
+
+
+
+
+
+   Starts PostgreSQL 17 with `pgvector` on **port 5433** (to avoid conflicting with any local Postgres on 5432).
+
+5. **Push the schema and seed initial data**
+
+   ```bash
+   npm run db:push
+   npm run db:seed
+   ```
+
+   The seed script creates one tenant and two users. Default credentials:
+
+   | Role | Email | Password |
+   |---|---|---|
+   | Admin | `admin@skillai.internal` | `admin1234` |
+   | Recruiter | `recruiter@skillai.internal` | `recruiter1234` |
+
+
+> **⚠️ Caution**
+>
+> Change both passwords immediately in any non-local environment.
+>
+
+6. **Start the dev server**
+
+   ```bash
+   npm run dev
+   ```
+
+   Open [http://localhost:3000](http://localhost:3000). The first visit redirects to the login page — sign in with the admin or recruiter credentials above.
+
+## Self-contained Docker deployment
+
+If you want both the app and the database in containers (useful for trying a fresh checkout without installing Node locally):
+
+```bash
+cp .env.example .env.local
+# edit .env.local — set DATABASE_URL=postgresql://skillai:skillai@db:5432/skillai
+docker compose up --build
+```
+
+The app is available at [http://localhost:3000](http://localhost:3000). Uploaded files persist in the `uploads` Docker volume.
+
+To run migrations and seed inside the container:
+
+```bash
+docker compose exec app npm run db:push
+docker compose exec app npm run db:seed
+```
+
+## Three things to try first
+
+1. **Upload a CV.** Sidebar → **Candidates** → **+ Add candidate**. Drop a PDF or DOCX onto the dropzone. Pick the demo agency. Hit save. The candidate appears in the list immediately; the AI profile extraction runs in the background.
+
+2. **Create a role.** Sidebar → **Roles** → **+ New role**. Paste a job description into the description field; copy the must-have requirements into the requirements field. Save. The role now exists and is ready to score candidates against.
+
+3. **Generate an interview pack.** From a candidate detail page, pick a role and click **Generate interview pack**. The pack appears within ~15 seconds with 8–12 personalised technical questions, scoring rubrics, and (for engineering roles) a code challenge. See the [in-app help](https://github.com/olafkfreund/SkillAi/tree/core-mvp-foundation/src/content/help) for tips on the prescreen vs full-pack mode.
+
+## Where to next
+
+
+### Architecture overview
+
+The high-level boxes, the request lifecycle, and the multi-tenant story. [Read more](../architecture/system-overview.md).
+
+
+### Development workflow
+
+Project layout, testing, migration workflow, branch conventions. [Read more](./development.md).
+
+
+### REST API
+
+Authenticate with a bearer token, hit any of the 36 endpoints, get OpenAPI 3.1 at `/api/openapi.json`. [Read more](../rest-api/overview.md).
+
+
+### MCP server
+
+Wire `claude-desktop` or Claude Code to your SkillAI instance via the stdio bridge or hosted HTTP endpoint. [Read more](../mcp-server/overview.md).

--- a/techdocs/index.md
+++ b/techdocs/index.md
@@ -1,0 +1,99 @@
+# SkillAI
+
+_Internal AI-powered recruiting portal — rank candidates in seconds, archive them forever, integrate with Claude._
+
+<div class="section-label">$ skillai --version 1.0</div>
+
+## What you get
+
+
+### Sub-second ranking
+
+Upload a job role, paste CVs, get a ranked shortlist scored across four
+dimensions (skills, experience, role-fit, communication) with explainable AI
+reasoning. Powered by **Claude claude-sonnet-4-6** with **Gemini 2.0 Flash** as
+fallback.
+
+
+### Reusable candidate archive
+
+Every candidate persists with their AI-extracted profile and full scoring
+history. Re-rank past candidates against new roles in one click. Semantic
+search via **pgvector** (HNSW + cosine similarity).
+
+
+### Multi-tenant by default
+
+Postgres **Row-Level Security** isolation enforced at the database layer.
+Tenant ID is set via `SET app.tenant_id` on every request — impossible to
+bypass from application code.
+
+
+### MCP-native
+
+Built-in **Model Context Protocol** server at `/api/mcp` exposes 48 tools,
+4 resources, and 3 prompts. Connect Claude Code or claude-desktop and drive
+the whole portal from your terminal.
+
+
+### GDPR-ready
+
+Right-to-erasure (Article 17) with audit-log redaction, DSAR export
+(Article 15) as a streamed ZIP, per-tenant audit retention. See
+[DEC-011](./decisions/dec-011-gdpr-erasure.md).
+
+
+### Self-hosted, no external SaaS
+
+Postgres + pgvector + Docker — that's the stack. No data leaves your
+infrastructure. Claude/Gemini API keys are per-tenant and stored encrypted.
+
+## Start where you are
+
+
+### 🚀 Try it locally
+
+`docker compose up` and you're running in five minutes. See
+[Quick start](./getting-started/quick-start.md).
+
+
+### 🔌 Integrate via REST
+
+77 routes, 41 documented in the OpenAPI spec. Bearer-token auth,
+sliding-window rate limits, scope-based authorization. Start at
+[REST API overview](./rest-api/overview.md).
+
+
+### 🤖 Drive it from Claude
+
+The MCP server lets Claude Code create roles, score candidates, send
+interview packs, and approve shortlists end-to-end. See
+[Connecting from Claude Code](./mcp-server/connecting.md).
+
+
+### 🏛️ Read the decisions
+
+Why Drizzle over Prisma. Why RLS over schema-per-tenant. Why manual
+transcript upload over Zoom OAuth. All 11 decisions are
+[logged with rationale](./decisions/index.md).
+
+## The numbers
+
+|  |  |
+|--|--|
+| **REST routes** | 77 (41 in OpenAPI, 36 internal/UI/auth) |
+| **MCP tools** | 48 across 12 modules (27 read · 21 write) |
+| **MCP resources** | 4 URI-addressable views |
+| **MCP prompts** | 3 prebuilt multi-step workflows |
+| **DB tables** | 29 tenant-scoped tables under RLS |
+| **Design decisions** | 11 logged with full rationale |
+| **In-app help articles** | 20+ across 8 categories (recruiter-facing) |
+
+## Quick links
+
+- [What is SkillAI](./overview/what-is-skillai.md) — the elevator pitch and the problem space
+- [Product tour](./overview/product-tour.md) — annotated screenshots of every major surface
+- [System overview](./architecture/system-overview.md) — boxes-and-arrows, request lifecycle, AI pipeline
+- [Endpoint reference](./rest-api/endpoints.md) — auto-generated from the OpenAPI spec
+- [Tool catalogue](./mcp-server/tools.md) — auto-generated from the MCP registry
+- [Roadmap](./roadmap.md) — what shipped, what's next

--- a/techdocs/mcp-server/connecting.md
+++ b/techdocs/mcp-server/connecting.md
@@ -1,0 +1,137 @@
+# Connecting from Claude Code
+
+_Wire the SkillAI MCP server into Claude Code via HTTP transport, or into claude-desktop via the skillai-mcp stdio bridge. Covers tokens, scopes, and the write-confirm flow._
+
+There are two ways to talk to the SkillAI MCP server: directly over HTTP (recommended for Claude Code) or via a small stdio bridge binary (recommended for claude-desktop, which doesn't speak HTTP transports yet). Both use the same bearer token.
+
+## Pick your transport
+
+| Client | Recommended transport | Why |
+|---|---|---|
+| **Claude Code** (`claude` CLI) | HTTP — `--transport http` | Fewer moving parts, direct connection, easy to debug with curl |
+| **claude-desktop** | stdio bridge — `skillai-mcp` binary | claude-desktop spawns MCP servers as subprocesses; HTTP isn't supported there |
+| **Custom MCP client** | HTTP | Standard `@modelcontextprotocol/sdk` clients connect over HTTP |
+
+## Mint a token first
+
+Before connecting either client, mint an API token from the SkillAI dashboard under **Settings → API Tokens**. The raw token is shown exactly once — copy it now. See [Authentication](../rest-api/authentication.md) for the full token model.
+
+## Connecting Claude Code (HTTP)
+
+This is the path from the project's `CLAUDE.md`:
+
+```bash
+claude mcp add --transport http --scope user skillai \
+  http://localhost:3000/api/mcp \
+  --header "Authorization: Bearer skl_prod_your_token_here"
+```
+
+Swap `http://localhost:3000` for your deployed host. The `--scope user` registers the server globally for your Claude Code user (not per-project) so you only do this once.
+
+After the add, restart any open Claude Code session — it picks up new MCP servers on startup. Then in chat:
+
+```
+> /mcp
+```
+
+…to see `skillai` listed with its tool / resource / prompt counts. Or just ask Claude something like `list the top 5 candidates for role <id>` and it will discover and call the right tool.
+
+## Connecting claude-desktop (stdio bridge)
+
+claude-desktop spawns each MCP server as a subprocess on launch and talks to it over stdio. SkillAI ships a small stdio bridge called `skillai-mcp` that proxies stdio JSON-RPC to the hosted HTTP endpoint, so claude-desktop can connect to the same server Claude Code uses.
+
+1. **Install the `skillai-mcp` binary.**
+
+   Standalone binaries are published on GitHub Releases for Linux (x64, arm64), macOS (x64, arm64), and Windows (x64), plus `.deb`, `.rpm`, and a Nix flake. See the project's releases page.
+
+2. **Add the entry to `claude_desktop_config.json`.**
+
+   ```json
+   {
+     "mcpServers": {
+       "skillai": {
+         "command": "skillai-mcp",
+         "env": {
+           "SKILLAI_URL": "http://localhost:3000",
+           "SKILLAI_TOKEN": "skl_prod_your_token_here"
+         }
+       }
+     }
+   }
+   ```
+
+3. **Restart claude-desktop.**
+
+   It re-reads the config on launch and spawns `skillai-mcp` as a subprocess. The bridge then proxies every JSON-RPC message to `${SKILLAI_URL}/api/mcp` with the bearer header set.
+
+You can also wire the bridge into Claude Code if you prefer stdio for any reason:
+
+```bash
+claude mcp add --transport stdio --scope user skillai skillai-mcp \
+  -e SKILLAI_URL=http://localhost:3000 \
+  -e SKILLAI_TOKEN=skl_prod_your_token_here
+```
+
+## Pick the right scope for the work
+
+The token scope governs which tools the LLM can call.
+
+| Scope | What you can do | Pick this when |
+|---|---|---|
+| `read` | List candidates, roles, agencies; read scores; read interview packs; query notes | You're plugging in a dashboard, building a report, or letting Claude *analyse* without changing data |
+| `write` | All reads, plus state changes — update candidate status, create candidates, generate interview packs, send shortlists | The most common scope; covers normal recruiter workflow from Claude |
+| `admin` | Everything in `write`, plus user / settings / tenant-level operations | Reserve for genuinely administrative integrations; rare in day-to-day use |
+
+Scope inclusion is `admin ⊃ write ⊃ read`. See [Authentication → Scope hierarchy](../rest-api/authentication.md#scope-hierarchy).
+
+> **⚠️ Caution**
+>
+> A token scoped wider than the integration needs is a needless blast radius. Pick the lowest scope that makes the work possible, and rotate to a narrower token once you're past initial exploration.
+
+## The write-confirm flow
+
+Every write tool's input schema requires `confirmed: true`. When the LLM tries to call one, the MCP client surfaces an inline confirmation prompt and won't dispatch the JSON-RPC request until you OK it.
+
+In Claude Code that looks like:
+
+```
+> Mark candidate Jane Doe as shortlisted on role "Staff SWE — HSBC"?
+
+Tool: skillai.update_candidate_status
+  candidateId: 9f1e8c4d-...
+  status:      shortlisted
+  confirmed:   true   ← I'll set this when you approve
+
+[y / n / always allow this tool]
+```
+
+Hit `y` and the call goes through. Hit `n` and the LLM is told the tool was refused and adjusts course. This gate exists *on top of* the token scope check — even a `write` token can't make changes without a per-call human approval.
+
+## Verifying the connection
+
+The fastest sanity check is to ask Claude to list resources:
+
+```
+> List all SkillAi MCP resources
+```
+
+It should return four entries: `skillai://candidates/{id}`, `skillai://roles/{id}`, `skillai://interview-packs/{id}`, and `skillai://my-shortlists`. If you get an auth error instead, the token is wrong or expired — re-mint and re-add.
+
+For a deeper test, try a curl directly against the HTTP endpoint to make sure the host is reachable:
+
+```bash
+curl -X POST http://localhost:3000/api/mcp \
+  -H "Authorization: Bearer skl_prod_your_token_here" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+You should get back a JSON-RPC response listing all 48 tools. A `401` means the token is wrong; a `429` means you've hit a rate limit (see [Rate limiting](../rest-api/rate-limiting.md)).
+
+## Troubleshooting
+
+- **`401 Unauthorized`** — token missing, malformed, expired, or revoked. Re-check the `Authorization` header and re-mint if needed.
+- **`403 Forbidden`** — token is valid but the scope doesn't cover the tool you tried to call. Mint a higher-scoped token, or pick a different tool.
+- **`429 Too Many Requests`** — sliding-window rate limit hit. Honour `Retry-After`. See [Rate limiting](../rest-api/rate-limiting.md).
+- **`skillai-mcp` exits immediately** — the bridge needs both `SKILLAI_URL` and `SKILLAI_TOKEN` in the environment. Check the env block of your client config.
+- **Claude Code doesn't see the server** — restart the CLI after `claude mcp add`. Server registrations are read at startup.

--- a/techdocs/mcp-server/overview.md
+++ b/techdocs/mcp-server/overview.md
@@ -1,0 +1,102 @@
+# MCP server overview
+
+_SkillAI ships a built-in Model Context Protocol server at /api/mcp — 48 tools, 4 resources, 3 prompts, bearer-token auth, write-confirm semantics, full audit trail._
+
+SkillAI ships a built-in **Model Context Protocol** server so Claude (and any other MCP-aware client) can drive the recruiting portal directly — list candidates, create roles, run scoring, send shortlists for approval, generate interview packs — without leaving the chat surface.
+
+## What MCP is
+
+MCP is Anthropic's open standard for exposing tools and data sources to large language models in a structured, discoverable, security-conscious way. It defines a JSON-RPC protocol for three primitives:
+
+- **Tools** — function calls the LLM can invoke (read or write).
+- **Resources** — URI-addressable read-only views the LLM can subscribe to.
+- **Prompts** — pre-authored multi-step workflows the LLM can render into a conversation.
+
+The reference SDK is published as `@modelcontextprotocol/sdk`. SkillAI uses v1.29.0 of that SDK, served over the streamable-HTTP transport.
+
+## What SkillAI exposes
+
+
+### 48 tools across 12 modules
+
+Candidates, roles, agencies, customers, scoring, interviews, approvals, managers, notes, users, settings, exports. Full table at [Tool catalogue](./tools.md).
+
+
+### 4 resources
+
+Candidate, role (with ranked shortlist), interview pack, and "my shortlists" for hiring managers. See [Resources](./resources.md).
+
+
+### 3 prompts
+
+Prepare interview brief, weekly shortlist review, candidate introduction email. See [Prompts](./prompts.md).
+
+
+### Bearer-token auth
+
+Same tokens as REST — mint at Settings → API Tokens. See [Authentication](../rest-api/authentication.md).
+
+## Endpoint and transport
+
+The server is mounted at `POST /api/mcp` (also handles `GET` and `DELETE` for transport handshake messages). It runs **stateless** — each HTTP request validates its own bearer token, builds a fresh `McpServer` via [`buildMcpServer`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/lib/mcp/server.ts), dispatches the JSON-RPC payload, and closes. No session continuity across requests.
+
+Tools, resources and prompts are wired up by [`registerAllTools`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/lib/mcp/tools/index.ts), `registerAllResources`, and `registerAllPrompts` respectively — each is a closure over the per-request `McpContext` (tenant, user, scopes, role), so handlers don't have to thread tenant context through the SDK's `args`.
+
+```ts
+// src/lib/mcp/server.ts
+export function buildMcpServer(ctx: McpContext): McpServer {
+  const server = new McpServer(SERVER_INFO, {
+    capabilities: { tools: {}, resources: {}, prompts: {} },
+  })
+  registerAllTools(server, ctx)
+  registerAllResources(server, ctx)
+  registerAllPrompts(server, ctx)
+  return server
+}
+```
+
+## Auth and scope
+
+Auth is identical to REST. The bearer token is validated, scoped, and rate-limited by the same code path the REST middleware uses — see [Authentication](../rest-api/authentication.md) for token format and scope inclusion rules, and [Rate limiting](../rest-api/rate-limiting.md) for the per-token / per-tenant / per-write sliding windows.
+
+The MCP entry point at [`src/app/api/mcp/route.ts`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/app/api/mcp/route.ts) additionally resolves the user's **product role** (`admin` / `recruiter` / `hiring_manager` / `viewer`) once per request, so delegated server actions can enforce role-based gating on top of API-token scope.
+
+## Write tools require explicit confirmation
+
+Every write tool's input schema includes a `confirmed: z.literal(true)` field. The MCP client (Claude Code, claude-desktop) renders this as an inline prompt — the user must explicitly OK each state-changing call before the JSON-RPC request is sent. If `confirmed: true` is missing, the tool refuses to execute.
+
+This sits *on top of* the token-scope check — a `write`-scoped token still needs human confirmation per call. The combination makes accidental destruction near-impossible from a Claude conversation.
+
+```ts
+// src/lib/mcp/tools/candidates.ts
+export const UpdateStatusInput = {
+  candidateId: z.string().uuid(),
+  status: z.enum([...]),
+  confirmed: z.literal(true).describe('Must be true. Write tools require explicit confirmation.'),
+}
+```
+
+## Per-call audit
+
+Every tool invocation writes an audit log row through the same `emitAudit` helper REST handlers use. Rate-limit rejections also emit `api.rate_limit_exceeded` with `{ via: 'mcp' }` in metadata so MCP-driven activity can be distinguished from REST in reporting.
+
+> **💡 Tip**
+>
+> The audit log is the single source of truth for "what did the AI do to the data". Pull it for compliance reviews; export it via the GDPR-DSAR flow if a data subject requests it.
+
+## Read vs write classification
+
+The MCP entry point uses a name-prefix heuristic to decide whether a JSON-RPC call is a write for rate-limiting purposes:
+
+```ts
+return /^(update_|archive_|create_|delete_|deactivate_|approve_|reject_|rescore_|bulk_)/.test(toolName)
+```
+
+It deliberately errs on the side of `false` — a false negative under-counts writes (mild overage on the write ceiling), whereas a false positive would unfairly throttle reads. The full list of write-classified prefixes is in [`isLikelyWrite()`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/app/api/mcp/route.ts) at the top of the route file.
+
+## Next steps
+
+- [Connecting from Claude Code](./connecting.md) — the `claude mcp add` recipe and claude-desktop config.
+- [Tool catalogue](./tools.md) — every tool, scope, and one-line description.
+- [Resources](./resources.md) — the four URI-addressable read views.
+- [Prompts](./prompts.md) — the three prebuilt multi-step workflows.

--- a/techdocs/mcp-server/prompts.md
+++ b/techdocs/mcp-server/prompts.md
@@ -1,0 +1,113 @@
+# Prompts
+
+_Three prebuilt multi-step workflows the SkillAI MCP server exposes — prepare-interview-brief, weekly-shortlist-review, email-candidate-introduction._
+
+MCP prompts are opinionated, parameterised templates that suggest a sequence of tool and resource calls to the LLM. They don't *execute* the work — they render into the user's chat as a structured instruction the model then follows.
+
+SkillAI ships three. The source is in [`src/lib/mcp/prompts/index.ts`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/lib/mcp/prompts/index.ts).
+
+## How prompts work
+
+The LLM client (Claude Code, claude-desktop) lists available prompts via `prompts/list` and surfaces them in the UI — usually as slash-commands or a picker. The user fills in the prompt's arguments, and the server returns a list of messages the client renders into the conversation. The LLM then drives the tool/resource calls described in the rendered messages.
+
+Prompts are the right primitive when you have a workflow that:
+
+- Always touches the same handful of tools/resources in a known order.
+- Has a small, stable set of inputs the user wants to fill in.
+- Produces a structured output (a brief, a review, a draft) rather than a single value.
+
+## `prepare-interview-brief`
+
+**What it does.** Assembles everything an interviewer needs to walk into a conversation with a candidate against a specific role: CV summary, dimension scores with reasoning, the generated interview pack, and any prior notes or transcript analyses.
+
+**Arguments.**
+
+```ts
+{
+  candidateId: z.string().uuid(),
+  roleId:      z.string().uuid(),
+}
+```
+
+**What it orchestrates.** The prompt walks the LLM through a five-step sequence: `get_candidate` → `get_role` → `get_candidate_score` (with attention to per-dimension reasoning) → `list_interview_packs` filtered by both ids → `get_interview_pack` for the most recent complete one. It also suggests dereferencing `skillai://candidates/{id}` for a richer snapshot.
+
+**Sample output structure.** A one-page interviewer brief in en-GB English with the sections:
+
+- *At a glance* — overall score, location, availability, agency.
+- *Strengths* — drawn from per-dimension reasoning above ~75.
+- *Risks / things to probe* — drawn from per-dimension reasoning below ~65.
+- *Recommended questions* — the top 5–7 from the interview pack.
+- *Open questions for the candidate* — model-generated based on context gaps.
+
+The LLM is explicitly told not to invent skills the data doesn't support — strengths and risks both anchor to the dimension reasoning text.
+
+## `weekly-shortlist-review`
+
+**What it does.** For a hiring manager, summarises the current state of approvals on a role and surfaces the candidates still awaiting a decision.
+
+**Arguments.**
+
+```ts
+{
+  roleId: z.string().uuid(),
+}
+```
+
+**What it orchestrates.** Three tool calls: `get_role` (title, customer, deadlines, budget) → `get_role_with_candidates` (ranked shortlist) → `get_approvals_for_role` (pending decisions). The manager flow is the primary use case, and this prompt pairs naturally with the [`skillai://my-shortlists`](./resources.md#skillaimy-shortlists) resource for picking the roleId.
+
+**Sample output structure.** A markdown document with:
+
+- A 2–3 sentence headline — role title, days until `cutoffDate`, count pending, count decided.
+- A *still to decide* table — one row per pending candidate with `overallScore`, status, and a one-sentence rationale.
+- An *already decided* appendix — name + decision + comment.
+
+The output is deterministic in structure but the rationale text is model-generated, so the manager gets a consistent format with reasoning grounded in the score data.
+
+## `email-candidate-introduction`
+
+**What it does.** Drafts an introduction email to a third party — typically a hiring manager — about a specific candidate against a specific role. Pulls the CV summary and score so the narrative is grounded in actual SkillAI data rather than the model's imagination.
+
+**Arguments.**
+
+```ts
+{
+  candidateId:    z.string().uuid(),
+  roleId:         z.string().uuid(),
+  recipientEmail: z.string().email(),
+}
+```
+
+**What it orchestrates.** Three reads: `get_candidate` (name, location, availability) → `get_role` (title, customer, location) → `get_candidate_score` (AI summary plus per-dimension reasoning above 75). Note the explicit threshold — the prompt tells the LLM to only surface dimensions where the model has actual signal, not to fish for things to say.
+
+**Sample output structure.** A single-paragraph subject line plus 4–6 short body paragraphs in en-GB English:
+
+- *Why this candidate* — one sentence drawn from the AI summary.
+- *Relevant strengths* — max three bullets, grounded in dimension reasoning.
+- *Availability and location* — from the candidate record.
+- *Next-step ask* — a 30-minute call, a CV download from the dashboard, etc.
+- *Sign-off* — references SkillAI and the calling user.
+
+> **ℹ️ Note**
+>
+> The prompt explicitly tells the model: "Do not invent skills or experience the data does not support. If a dimension is below 60, do not mention it in the email — flag it back to me separately." That's a guardrail against the AI confabulating positives the candidate doesn't actually have.
+
+## Common pattern
+
+All three prompts:
+
+- Validate their arguments with Zod (UUIDs and emails) so a malformed call fails fast on the client.
+- Return a single user-message in the response — the LLM treats it as if the user typed it.
+- Hard-code the language (`en-GB English`) to keep the output consistent.
+- Tell the model exactly which tools to call and in what order, by tool name, so the model doesn't have to guess.
+- Anchor every assertion to a specific tool result, not the model's prior beliefs about the candidate.
+
+## Where this lives in code
+
+- Registry function: `registerAllPrompts(server, _ctx)` in [`src/lib/mcp/prompts/index.ts`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/lib/mcp/prompts/index.ts).
+- Args schemas (`PrepareBriefArgs`, `ShortlistReviewArgs`, `EmailIntroArgs`) are exported alongside each prompt for client-side validation if needed.
+- The prompts don't carry any per-call audit overhead — they're pure templates. The tools they tell the LLM to call carry their own audit entries as usual.
+
+## See also
+
+- [Tool catalogue](./tools.md) — the tools each prompt orchestrates.
+- [Resources](./resources.md) — `skillai://my-shortlists` pairs naturally with `weekly-shortlist-review`.

--- a/techdocs/mcp-server/resources.md
+++ b/techdocs/mcp-server/resources.md
@@ -1,0 +1,72 @@
+# Resources
+
+_Four URI-addressable read views exposed by the SkillAI MCP server — candidate snapshots, role + ranked shortlist, interview packs, and the manager-only "my shortlists" view._
+
+MCP resources are URI-addressable read views. Where a tool is an explicit function call (`get_candidate(...)`), a resource is a handle the LLM can reference inline (`skillai://candidates/<id>`) and the MCP client knows how to materialise into JSON.
+
+SkillAI exposes four. The full source is in [`src/lib/mcp/resources/index.ts`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/lib/mcp/resources/index.ts).
+
+## When to use a resource vs a tool
+
+A resource is the right primitive when:
+
+- The LLM only needs to **read** the entity (resources are read-only by design).
+- You'd rather the model embed the URI as a reference than call a tool and round-trip the result through chat.
+- You want a stable, addressable identity for the entity that survives across conversations.
+
+A tool is the right primitive when you need filtering, pagination, parameters beyond the URI itself, or any mutation. The resource handlers below all delegate to the same query helpers a tool would use — they're optimised for "give me everything you know about *this exact thing*".
+
+## `skillai://candidates/{id}`
+
+**What's in it.** A single candidate row joined with the candidate's agency name. Returned as JSON with shape `{ candidate, agencyName }`. Fields on `candidate` include identity (`firstName`, `lastName`, `email`), CV text, rates, availability, and the agency FK.
+
+**When to use it.** When the LLM has a candidate id (from a list, a score, an approval) and wants the full record without negotiating filters. Cheaper than `get_candidate` for the LLM because the URI is self-documenting.
+
+**How it differs from `get_candidate`.** The tool version supports lookup by id and returns the same data, but takes a function-call-shaped argument structure. The resource is read-only and addressable — the LLM can drop the URI into prose ("see `skillai://candidates/9f1e...`") and the client knows how to dereference it.
+
+```ts
+new ResourceTemplate('skillai://candidates/{id}', { list: undefined })
+```
+
+## `skillai://roles/{id}`
+
+**What's in it.** The role record plus all candidates that have been scored against it, sorted by `overallScore` descending. Shape: `{ role, candidates: [{ candidateId, firstName, lastName, overallScore, scoreStatus }, ...] }`. If the role doesn't exist or is in another tenant, `role` is `null` and `candidates` is `[]`.
+
+**When to use it.** For any "give me the current state of this role" question — preparing for a hiring discussion, looking up the top of the pile, generating a status update. The ranked-candidate join is done server-side so the LLM doesn't need to call `list_candidates` + cross-reference scores.
+
+**How it differs from `get_role` + `get_role_with_candidates`.** The two tools return the same data when called in succession; the resource bundles both in one snapshot and exposes it under a URI. Use the resource when you want the snapshot; use the tools when you need additional filtering on either side.
+
+## `skillai://interview-packs/{id}`
+
+**What's in it.** An interview pack header plus all of its generated questions. Shape: `{ pack, questions: [...] }`. The pack header includes the candidate / role link, type (full technical / pre-screening), language, and generation status. Questions include text, dimension, expected difficulty, and ordering.
+
+**When to use it.** When an interviewer (or the LLM acting for them) needs the full pack inline — for example, the `prepare-interview-brief` prompt dereferences this resource to render the recommended questions section. Faster than calling `list_interview_packs` + `get_interview_pack` separately.
+
+**How it differs from the tool equivalents.** `list_interview_packs` filters across packs; `get_interview_pack` fetches one. The resource is the "single pack, fully expanded" snapshot — same effect as `get_interview_pack`, but addressable by URI and embeddable in prompt templates.
+
+## `skillai://my-shortlists`
+
+**What's in it.** For the calling user, the roles where they have outstanding approval decisions to make. Shape: `{ assignedRoles: [...] }`. The list is per-user, derived from the `role_managers` junction; it returns the roles the calling user is assigned to as a manager along with each role's pending-decision state.
+
+**When to use it.** Hiring-manager workflow. The `weekly-shortlist-review` prompt uses this to find the roles a manager needs to review without making them remember role ids. A no-argument URI makes it perfect for "what's on my plate?" prompts.
+
+**How it differs from the other three.** This one is a **static URI** (no `{id}` template) because the answer is always "for me, right now". It internally calls [`getMyAssignedRoles()`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/actions/role-managers.ts) inside a `runWithActionContext` so the server action sees the correct caller identity. There is no `list` capability for templated resources, so the LLM can't enumerate candidates / roles / packs via resource listing — this URI is the only "tell me about me" resource.
+
+> **ℹ️ Note**
+>
+> A non-manager calling this resource gets an empty `assignedRoles` array. The resource doesn't error on role mismatch; the prompt templates assume the LLM will degrade gracefully if there's nothing on the plate.
+
+## Subscribe semantics
+
+The MCP SDK supports resource subscriptions, but SkillAI's resources are **point-in-time** reads — there is no server-side change notification. Calling `resources/read` re-runs the query against current state; the client gets a fresh snapshot each time. This is fine for the conversational use case where the LLM re-fetches as needed during a session.
+
+## Where this lives in code
+
+- Registry function: `registerAllResources(server, ctx)` in [`src/lib/mcp/resources/index.ts`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/lib/mcp/resources/index.ts).
+- Each handler runs inside `withTenant(ctx.tenantId, ...)` so RLS is enforced — no resource can ever leak data across tenants regardless of the URI provided.
+- The `my-shortlists` handler additionally wraps the call in `runWithActionContext` so downstream server actions see the calling user's role.
+
+## See also
+
+- [Tool catalogue](./tools.md) — the full 48-tool surface, including the `get_*` tools that overlap with these resources.
+- [Prompts](./prompts.md) — pre-authored workflows that orchestrate resources + tools together.

--- a/techdocs/mcp-server/tools.md
+++ b/techdocs/mcp-server/tools.md
@@ -1,0 +1,141 @@
+# Tool catalogue
+
+_Every tool the SkillAI MCP server exposes — auto-generated from the live tool registry on 2026-05-29._
+
+> **ℹ️ Note** — This page is generated from `docs-site/src/data/mcp-catalogue.json` by `scripts/sync-techdocs.mjs`. Do not edit it by hand; re-run `npm run techdocs:sync`.
+
+## Summary
+
+| Metric | Count |
+|---|---|
+| Tools total | 48 |
+| Read tools | 27 |
+| Write tools | 21 |
+| Modules | 12 |
+| Resources | 4 |
+| Prompts | 3 |
+
+## candidates (9)
+
+| Tool | Scope | Description |
+|---|---|---|
+| `list_candidates` | read | List candidates in the active tenant. Optional filters: substring search on name, agencyId, pipeline status, availability status. Returns id, name, email, agency, status, and (if scored) overallScore. Pagination via limit (max 200) and offset. |
+| `get_candidate` | read | Fetch a single candidate by id with their CV text, agency, contact details, rates, and availability. Returns null if the candidate does not exist or belongs to another tenant. |
+| `find_candidate_by_email` | read | Look up a candidate by their email address (case-insensitive). Returns the candidate record or null. Useful when an external system references a person by email. |
+| `update_candidate_status` | write | Move a candidate to a new pipeline stage (new / shortlisted / interviewing / offered / hired / rejected / rejected_by_customer). Requires write scope and confirmed: true. |
+| `update_candidate_availability` | write | Set a candidate's availability flag (available / on_project / unavailable) and an optional availableFrom date. Requires write scope and confirmed: true. |
+| `find_candidate_by_name` | read | Case-insensitive substring match against `firstName + " " + lastName`. Returns up to 20 matches with their agency. Useful when the LLM has only a free-text name. |
+| `semantic_search_candidates` | read | Vector-similarity search for candidates against a role's description using pgvector cosine distance. Provide `roleId` (the action embeds the role text). Already-scored candidates on the role are excluded. NOTE v1: free-text `query` is accepted by the schema but returns a clear error — the underlying matching action only supports roleId-based search at present. |
+| `create_candidate` | write | Create a new candidate by uploading a CV (base64-encoded). The CV is validated, parsed, stored, and a pending score row is queued against the supplied roleId. Embedding generation runs in the background. Max 10MB per file. Requires write scope and confirmed: true. |
+| `archive_candidate` | write | Soft-archive a candidate (sets isActive = false). The candidate remains queryable for audit/history. Requires write scope and confirmed: true. |
+
+## roles (6)
+
+| Tool | Scope | Description |
+|---|---|---|
+| `list_roles` | read | List job roles in the active tenant with their customer, location, deadlines, and budget. By default hides archived roles (set activeOnly=false to include them). |
+| `get_role` | read | Fetch a single role by id with description, requirements, key skills, top requirements, language requirements, and budget. Returns null if not found. |
+| `get_role_with_candidates` | read | Fetch a role and the candidates scored against it, sorted by overallScore descending. Includes per-dimension scores. Optional minScore filter. |
+| `update_role` | write | Edit an existing role. The server action does a full replace of the editable fields — title/description/requirements are always required. Optional fields default to null/empty when omitted. Tag regeneration runs after the response. Requires write scope and confirmed: true. |
+| `regenerate_role_tags` | write | Re-run AI tag extraction (key skills + top requirements) for a role using its current description and requirements. Runs in the background after the response. Requires write scope and confirmed: true. |
+| `archive_role` | write | Soft-archive a role (isActive=false). Requires write scope and confirmed: true. |
+
+## agencies (2)
+
+| Tool | Scope | Description |
+|---|---|---|
+| `list_agencies` | read | List recruitment agencies in the active tenant. The internal-employee bench is exposed as the system "Internal" agency (isInternal=true). Hides archived rows by default. |
+| `get_agency` | read | Fetch a single agency by id with its contact details and notes. |
+
+## customers (2)
+
+| Tool | Scope | Description |
+|---|---|---|
+| `list_customers` | read | List customer entities (the companies we hire for). Archived rows hidden by default. |
+| `get_customer` | read | Fetch a single customer by id with portal URL, contact details, and active status. |
+
+## scoring (2)
+
+| Tool | Scope | Description |
+|---|---|---|
+| `get_candidate_score` | read | Fetch the score row for a candidate against a specific role, including all four dimension scores (technical, experience, cultural fit, communication), AI reasoning per dimension, and the AI summary. Returns null if no scoring run exists yet. |
+| `rescore_candidate` | write | Re-run AI scoring for a candidate against a role. The score is reset to pending and the AI pipeline runs in the background. Poll get_candidate_score for results. Requires write scope and confirmed: true. |
+
+## interviews (3)
+
+| Tool | Scope | Description |
+|---|---|---|
+| `list_interview_packs` | read | List interview packs in the active tenant. Filter by candidateId and/or roleId. Includes generation status (pending/processing/complete/failed), packType, language, and recommended duration. |
+| `generate_interview_pack` | write | Queue an interview pack generation job for a candidate × role pair. The pack is created with status="pending" — actual AI generation runs in the background; the LLM should poll get_interview_pack to fetch the questions once status="complete". Pre-screening packs are short, full_technical packs are longer and may include a code challenge. Recruiter/admin only. Requires write scope and confirmed: true. |
+| `get_interview_pack` | read | Fetch a full interview pack (the pack record plus all generated questions). Returns { pack: null, questions: [] } if the pack id is not found in the active tenant. |
+
+## approvals (5)
+
+| Tool | Scope | Description |
+|---|---|---|
+| `get_approvals_for_role` | read | Fetch the approval state for every shortlisted candidate × assigned manager combination on a role. Returns approval status (pending/approved/rejected), decided-at timestamps, and comments. Used by recruiters to track shortlist progress. |
+| `approve_candidate` | write | Record a manager approval for a candidate on a role. Only assigned managers (or admins) may decide. Optional comment. Requires write scope and confirmed: true. |
+| `send_shortlist_for_approval` | write | Mark a role's shortlist as sent to its assigned hiring managers and seed pending approval rows for every (shortlisted candidate × manager) pair. Idempotent — re-sending does not reset existing decisions. Recruiter/admin only. Requires write scope and confirmed: true. |
+| `approve_all_remaining` | write | Bulk-approve every still-pending approval row owned by the calling manager on the role. Manager scope (the calling user must be assigned as a manager on the role). Optional comment is applied to every row. Requires write scope and confirmed: true. |
+| `reject_candidate` | write | Record a manager rejection for a candidate on a role. Only assigned managers (or admins) may decide. Optional comment. Requires write scope and confirmed: true. |
+
+## managers (4)
+
+| Tool | Scope | Description |
+|---|---|---|
+| `get_my_assigned_roles` | read | For the calling hiring manager, list every role that has been assigned to them with pending and decided counts. Returns an empty list if the caller is not a manager. |
+| `get_role_managers` | read | List the hiring managers currently assigned to a role, with email, name, primary flag, and added-at timestamp. Returns [] if no managers are assigned (or role does not exist). |
+| `assign_role_managers` | write | Replace the full set of hiring managers for a role with the supplied userIds. Non-hiring_manager users are silently dropped. If primaryUserId is supplied AND is in the valid set it is flagged as primary. Recruiter/admin only. Requires write scope and confirmed: true. |
+| `remove_role_manager` | write | Detach a single hiring manager from a role. Recruiter/admin only. Requires write scope and confirmed: true. |
+
+## notes (3)
+
+| Tool | Scope | Description |
+|---|---|---|
+| `create_note` | write | Add a timestamped note to a candidate. Body is plain text up to 5000 chars. The note is attributed to the calling user. Requires write scope and confirmed: true. |
+| `update_note` | write | Edit the body of an existing note. Only the original author or an admin may edit. Sets isEdited=true. Requires write scope and confirmed: true. |
+| `delete_note` | write | Permanently delete a note. Only the original author or an admin may delete. Requires write scope and confirmed: true. |
+
+## users (4)
+
+| Tool | Scope | Description |
+|---|---|---|
+| `list_users` | admin | List all users in the active tenant. Admin scope required. |
+| `update_user_role` | admin | Change a user's product-role (admin / recruiter / hiring_manager / viewer). You cannot change your own role. Admin scope required, confirmed: true required. |
+| `invite_user` | admin | Create a single-use invitation for a new user in the active tenant. Returns the invitation id, raw token, and a fully-qualified invite URL the admin can share. The role can be any of admin/recruiter/hiring_manager/viewer. Note: createInvitation server action reads its tenant from HTTP headers, so we mirror its (small) logic here against withTenant — same pattern used by update_user_role and deactivate_user. Admin scope and confirmed: true required. |
+| `deactivate_user` | admin | Soft-deactivate a user (sets isActive=false). You cannot deactivate yourself. Admin scope and confirmed: true required. |
+
+## settings (1)
+
+| Tool | Scope | Description |
+|---|---|---|
+| `list_configured_keys` | admin | List which AI provider keys (anthropic / google / openai) are configured for the active tenant. Returns just the key NAMES, never the secret values. Admin scope required. |
+
+## exports (7)
+
+| Tool | Scope | Description |
+|---|---|---|
+| `export_candidate_cv_pdf` | read | Return the candidate's stored CV file as a base64 attachment. The file is whatever format was uploaded (PDF/DOCX/ODT/RTF/TXT/MD) — not necessarily PDF. Returns null attachment if the candidate has no stored file. |
+| `export_candidate_internal_pdf` | read | Render the full internal candidate profile PDF — includes scores, agency, rates, recruiter notes, transcript red flags, and recommended decision. If roleId is supplied the PDF's "active role" section uses that role's score; otherwise the most recent complete score is used. |
+| `export_candidate_customer_pdf` | read | Render the customer-facing candidate profile PDF — strips recruiter notes, candidate rate, margin, red flags, recommended decision, and blanks low-confidence transcript reasoning. Safe to forward outside the company. |
+| `export_role_brief_pdf` | read | Render a one-role-brief PDF with title, customer, location, work mode, language requirements, key skills, top requirements, budget, and the full description + requirements. |
+| `export_shortlist_pdf` | read | Render the ranked shortlist for a role as a single PDF. audience="recruiter" includes agency + margin per candidate; audience="customer" suppresses the margin column. |
+| `export_interview_pack_pdf` | read | Render a fully-generated interview pack (questions + optional code challenge) as a PDF. Returns null attachment if the pack does not exist or has not finished generating (generationStatus must be "complete"). |
+| `compose_candidate_email_attachments` | read | Killer-workflow tool. Returns everything an LLM needs to draft an email about a candidate-on-a-role in a single call: { candidate, role, attachments: { cv, interviewPack?, scoreSummary } }. Sub-fetches: (1) the raw CV file from disk, (2) the most recent interview pack for this candidate × role pair (omitted if none exists or the latest is not yet complete), (3) the structured score record (overall, dimensions, reasoning, summary). Read-only; no confirm. |
+
+## Resources
+
+| URI | Name | Description |
+|---|---|---|
+| `skillai://candidates/{id}` | candidate | A single candidate record with their agency name and contact details. |
+| `skillai://roles/{id}` | role | A role record together with all candidates scored against it, sorted by overallScore. |
+| `skillai://interview-packs/{id}` | interview-pack | An interview pack with all generated questions. |
+| `skillai://my-shortlists` | my-shortlists | For the calling user, the roles where you have approvals to make. |
+
+## Prompts
+
+| Name | Description |
+|---|---|
+| `prepare-interview-brief` | Assemble everything an interviewer needs to walk into a conversation with a specific candidate against a specific role: CV summary, dimension scores with reasoning, the generated interview pack, and any prior notes or transcript analyses. |
+| `weekly-shortlist-review` | For a hiring manager, summarise the current state of approvals on a role and surface the top candidates still awaiting a decision. |
+| `email-candidate-introduction` | Draft an introduction email to a third party (typically a hiring manager) about a specific candidate against a specific role. Pulls the CV summary and score so the narrative is grounded in actual SkillAi data. |

--- a/techdocs/operations/aws-deploy.md
+++ b/techdocs/operations/aws-deploy.md
@@ -1,0 +1,198 @@
+# AWS deployment
+
+_Reference architecture for deploying SkillAI on AWS EKS — RDS for Postgres, EFS for uploads, NLB + cert-manager for TLS._
+
+This is the trimmed reference for an AWS EKS deployment. The full runbook with every script, recovery procedure, and troubleshooting table lives at [`docs/aws-deploy.md`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/docs/aws-deploy.md) in the repo — read it before doing a real deploy.
+
+Target: small production, eu-west-2 (London), ~$150/mo realistic cost.
+
+## Target architecture
+
+```
+                Internet
+                    │
+                    ▼
+        AWS Network Load Balancer (NLB)
+                    │
+                    ▼
+        NGINX Ingress + cert-manager
+        (Let's Encrypt via ACME HTTP-01)
+                    │
+                    ▼
+        EKS skillai (1x t4g.small node)
+                    │
+        ┌───────────┴────────────┐
+        ▼                        ▼
+   RDS PostgreSQL 17        EFS filesystem
+   db.t4g.micro             (mounted at /app/uploads)
+   pgvector enabled         RWX, single AZ
+   private subnet           single AZ
+```
+
+What you get:
+
+- **EKS** for the application (1× `t4g.small` Graviton node by default).
+- **RDS PostgreSQL 17** (`db.t4g.micro`) with pgvector enabled, in a private subnet.
+- **EFS** for the `/app/uploads` volume — appears as a normal POSIX filesystem, no code changes vs the Docker volume layout.
+- **NLB** in front of NGINX Ingress for TLS termination.
+- **cert-manager** managing TLS certs via Let's Encrypt.
+- **ECR** for the container image (`linux/arm64` for Graviton).
+- **NAT Gateway** for outbound Anthropic / Gemini API calls (private subnet → internet).
+
+The Terraform that provisions all of this lives in `infra/terraform/`; the helper scripts that drive it sit in `infra/scripts/`.
+
+## Prerequisites
+
+| Tool | Min version |
+|---|---|
+| `aws` CLI | 2.15 |
+| `kubectl` | 1.30 |
+| `terraform` | 1.7 |
+| `helm` | 3.14 |
+| `direnv` | 2.x |
+| `docker` (with buildx) | 24+ |
+| `psql` | 15+ |
+
+AWS account permissions for: EKS, RDS, EFS, ECR, EC2 (VPC, subnets, NAT, NLB), IAM (OIDC provider, IRSA roles).
+
+## Secrets management
+
+Two secrets are load-bearing:
+
+- **`ENCRYPTION_KEY`** — encrypts per-tenant AI API keys stored in `tenant_settings` using AES-256-GCM. **If you deploy a different value than your local one, every tenant's stored keys become unreadable.** The `50-render-secret.sh` script asserts that `.envrc` matches `.env.local` and refuses to proceed otherwise.
+- **`AUTH_SECRET`** — JWT signing key. Changing it invalidates every active session.
+
+Set both in `.envrc` (project-local, gitignored). For real production, layer **AWS Secrets Manager** in front: store the values there, inject into the EKS deployment via the External Secrets Operator or the Secrets Store CSI driver. The Terraform module supports both wiring patterns; pick one for your security model.
+
+All other secrets (`ANTHROPIC_API_KEY`, RDS password, etc.) live in `.envrc` and get rendered into a Kubernetes `Secret` by `infra/scripts/50-render-secret.sh`. The rendered `secret.yaml` is gitignored — never commit it.
+
+## Required env vars in `.envrc`
+
+| Variable | Notes |
+|---|---|
+| `AWS_PROFILE` | Or use access-key pair. |
+| `AWS_REGION` | `eu-west-2` for the default Terraform config. |
+| `ENCRYPTION_KEY` | **Verbatim copy** of your local `.env.local` value. |
+| `AUTH_SECRET` | Same. |
+| `ANTHROPIC_API_KEY` | Anthropic key. |
+| `TF_VAR_allowed_operator_cidrs` | Restricts EKS public API endpoint to your IPs. `["X.X.X.X/32"]` — required, Terraform refuses to apply if empty. |
+| `NEXTAUTH_URL` / `APP_URL` / `NEXT_PUBLIC_APP_URL` | Set after the NLB is provisioned (step 4). |
+
+## Deploy pipeline
+
+```bash
+# 1. Preflight — verify all tools + env vars
+infra/scripts/00-preflight.sh
+
+# 2. Bootstrap Terraform state (ONCE per AWS account — creates S3 bucket + lock table)
+infra/scripts/05-state-bootstrap.sh
+
+# 3. Provision AWS infrastructure (18-25 minutes)
+infra/scripts/10-terraform-apply.sh
+
+# 4. Wire kubeconfig + install platform components (EFS CSI, NGINX Ingress, cert-manager)
+infra/scripts/20-kubeconfig.sh
+infra/scripts/30-platform-install.sh
+# Note the NLB IP printed at the end. Set NEXTAUTH_URL / APP_URL in .envrc to that IP.nip.io.
+
+# 5. Build + push the arm64 image
+infra/scripts/40-push-image.sh
+
+# 6. Render the Kubernetes Secret + deploy
+infra/scripts/50-render-secret.sh
+infra/scripts/80-deploy.sh
+
+# 7. Verify
+infra/scripts/90-verify.sh
+```
+
+### Step 3 — what Terraform provisions
+
+- VPC `10.10.0.0/16`, 2 public + 2 private subnets across 2 AZs
+- NAT Gateway in `eu-west-2a` (required for Anthropic/Gemini egress)
+- EKS cluster `skillai` v1.30 with 1× `t4g.small` managed node
+- RDS PostgreSQL 17, `db.t4g.micro`, 20 GB gp3, single-AZ, private subnet
+- EFS filesystem for uploads (RWX, single AZ)
+- ECR repository `skillai`
+- IAM: OIDC provider, IRSA roles for the EFS CSI driver
+- KMS envelope encryption for Kubernetes Secrets in etcd
+
+### Step 6 — what the deploy script does
+
+`infra/scripts/80-deploy.sh`:
+
+1. Substitutes `__ECR_REPO__`, `__IMAGE_TAG__`, `__INGRESS_HOST__` into temporary copies of the kustomize files (originals untouched).
+2. Applies `infra/k8s/overlays/prod` — includes the rendered Secret, deployment, service, ingress, and PVC.
+3. Waits for the `skillai-migrate` Job to complete (runs Drizzle migrations against RDS, plus `CREATE EXTENSION IF NOT EXISTS vector`).
+4. Waits for the deployment rollout.
+5. Prints the ingress URL.
+
+## Migrating data from local on first deploy
+
+Skip this if you're starting fresh in production.
+
+```bash
+infra/scripts/60-db-migrate.sh    # Phase A: schema, Phase B: data via pg_dump + pg_restore
+infra/scripts/70-uploads-sync.sh  # rsync ./uploads/ into the EFS PVC
+```
+
+Phase B is **not idempotent**. If it fails partway through, truncate all tables before re-running — full procedure in the source runbook.
+
+## Rolling updates (day 2)
+
+```bash
+infra/scripts/40-push-image.sh   # build + push new image
+infra/scripts/80-deploy.sh       # apply new image to cluster
+```
+
+With 1 replica there's a ~30 s downtime window during pod replacement. For zero-downtime, bump `replicas: 2` in `deployment.yaml` and scale the node group to `min=2`.
+
+## Cost reference
+
+| Line item | Monthly |
+|---|---:|
+| EKS control plane | $73 |
+| 1× t4g.small node (on-demand, 24/7) | $15 |
+| RDS db.t4g.micro single-AZ (20 GB gp3) | $13 |
+| NLB (1 hour-rate + minimal LCU) | $16 |
+| NAT Gateway (24/7 + data processed) | $32 |
+| EFS (10–100 MB stored) | $0.30 |
+| Data transfer out | $1 |
+| ECR storage | $0.10 |
+| **Total** | **~$150** |
+
+The largest avoidable cost is the **NAT Gateway** (~$32/mo), required for Anthropic / Gemini API egress. If you ever route LLM calls through AWS Bedrock, the NAT cost could be eliminated.
+
+## Tear-down
+
+`infra/scripts/destroy.sh` runs a two-phase destroy:
+
+1. **Cluster-side teardown** — deletes the `skillai` namespace (releases EBS PVCs), uninstalls NGINX (releases the NLB), uninstalls cert-manager, waits up to 90 s for NLB ENIs to drain.
+2. **Terraform destroy** — empties ECR, writes a temporary `prevent_destroy` override, takes a final RDS snapshot named `skillai-db-final-<YYYYMMDD-hhmm>`, then tears down everything else.
+
+The EFS filesystem is **not** auto-snapshotted. Pull uploaded files with `infra/scripts/70-uploads-sync.sh` before destroying if you need them.
+
+For dev / throwaway environments where data loss is acceptable: `FORCE_DESTROY=1 infra/scripts/destroy.sh` skips the snapshot.
+
+## Architecture notes
+
+- **Why `nip.io` instead of a real domain** — `nip.io` is wildcard DNS that resolves `<ip>.nip.io` to `<ip>`. Enables a valid Let's Encrypt cert without buying a domain. For a real deployment, swap `NEXTAUTH_URL` and the ingress host to your domain and point an A record at the NLB.
+- **Why arm64 (`t4g`) not amd64 (`t3`)** — Graviton is ~30% cheaper for the same RAM/CPU. The `docker buildx --platform linux/arm64` build produces the correct image. Local dev docker-compose still uses the host architecture.
+- **EKS control plane audit logging** — enabled by Terraform, logs land in `/aws/eks/skillai/cluster` in CloudWatch with 90-day retention.
+
+## Where to look in the source runbook
+
+The full `docs/aws-deploy.md` covers in detail:
+
+- **Recovery from mid-failure** for every script (idempotent vs not).
+- **Troubleshooting** — TLS cert pending, CrashLoopBackOff, migrate job failures, 502 Bad Gateway, ECR auth failures, NLB IP not resolving, t4g.small OOM.
+- **Specific Terraform output names** the scripts depend on.
+- **The Drizzle migrate script path** and how to verify it inside the image.
+
+Read it before a real production deploy. This page is the navigational summary.
+
+## Related
+
+- [Backup & recovery](./backup-runbook.md) — operator-level Postgres dump + uploads tarball procedure.
+- [Health & monitoring](./health-monitoring.md) — `/api/health` endpoint shape and the audit log table.
+- [File storage](../architecture/file-storage.md) — EFS in EKS works identically to the local Docker volume.

--- a/techdocs/operations/backup-runbook.md
+++ b/techdocs/operations/backup-runbook.md
@@ -1,0 +1,267 @@
+# Backup & recovery
+
+_Postgres dump plus uploads tarball — the operator-level backup procedure, restore steps, and what NOT to confuse with backups._
+
+SkillAI runs two complementary backup mechanisms: an **operator-level full backup** (Postgres dump + uploads tarball) and an **admin-level per-tenant JSON export** triggered from the UI. They are not interchangeable. This page is the operator-level procedure.
+
+> **⚠️ Caution**
+>
+> **Take a backup before any runtime change.** Editing `docker-compose.yml`, the Dockerfile, env vars, or running a migration — back up first. The portal is in continuous live use, not a sandbox. Doc/script-only edits don't need it.
+
+## RTO / RPO targets
+
+| Target | Value | Achieved by |
+|---|---|---|
+| **RPO** — max data loss | 24 hours (default daily cadence) | Daily `pg_dump` + uploads tarball cron |
+| **RTO** — max recovery time | &lt; 15 minutes for &lt;100 MB datasets | `pg_restore` + tar extract on the same host |
+
+Both targets are conservative for the current dataset (~10 MB dump, ~118 candidates). They scale linearly with data — at 10× the size, restore time roughly 10× (still well under an hour).
+
+## When to back up
+
+**Take a backup before:**
+
+- Editing `docker-compose.yml` or `docker-compose.override.yml`
+- Editing the `Dockerfile`
+- Changing environment variables (`.env`, `.env.local`)
+- Running a database migration (`drizzle-kit push`, `drizzle-kit migrate`, raw SQL)
+- Upgrading the database image (`pgvector/pgvector:pgXX`)
+- Restoring from a previous backup
+- Any change that touches the `uploads_data` or `postgres_data` Docker volume
+
+**Backups are not required for:**
+
+- Documentation-only edits
+- Script-only edits that aren't invoked as part of the change
+- Application code changes that don't touch the schema and don't run a migration
+
+If in doubt, back up. It takes under a minute and the dump is ~10 MB.
+
+## Pre-flight checklist
+
+```bash
+# 1. Confirm services are healthy
+docker compose ps
+# Both skillai-app-1 and skillai-db-1 should be "running (healthy)".
+# If db is unhealthy or restarting, DO NOT take a backup — investigate first.
+
+# 2. Confirm disk space
+df -h .
+# Allow at least 1 GB free.
+
+# 3. Pick a target directory
+TS=$(date +%Y%m%d-%H%M%S)
+mkdir -p backups/$TS
+echo "Target: backups/$TS"
+```
+
+`backups/` is gitignored — backups never get committed.
+
+## Backup procedure
+
+All three commands run from the SkillAI repo root.
+
+### 1. Database dump
+
+```bash
+docker exec skillai-db-1 pg_dump \
+  --format=custom --compress=9 \
+  -U skillai skillai \
+  > backups/$TS/skillai.dump
+```
+
+- `--format=custom` produces a portable binary archive `pg_restore` can read selectively or in full.
+- `--compress=9` is maximum zlib compression. CPU cost is negligible for a ~10 MB DB.
+- Verify the container name with `docker compose ps` if you've renamed the project.
+
+### 2. Uploads volume backup
+
+```bash
+docker run --rm \
+  -v skillai_uploads_data:/source:ro \
+  -v "$(pwd)/backups/$TS":/backup \
+  alpine tar -czf /backup/uploads.tar.gz -C /source .
+```
+
+- `:ro` mounts the source read-only — the backup cannot accidentally write to live data.
+- `-C /source .` archives the contents of `/source` directly (no leading prefix), making restore extraction symmetric.
+
+### 3. Integrity manifest
+
+```bash
+cd backups/$TS && sha256sum skillai.dump uploads.tar.gz > MANIFEST.sha256 && cd -
+```
+
+The manifest catches bitrot when backups are copied to slow / unreliable storage (NAS, USB), and confirms "this is the exact dump from that date" before restoring over live data.
+
+### 4. (Recommended) Drop a `README.txt`
+
+```bash
+cat > backups/$TS/README.txt <<EOF
+SkillAI backup taken before <reason>.
+
+Date: $(date -Iseconds)
+Reason: <one sentence>
+
+Files:
+  skillai.dump      pg_dump --format=custom --compress=9 of the skillai DB
+  uploads.tar.gz    tar of the skillai_uploads_data Docker volume
+  MANIFEST.sha256   sha256 sums for both files
+EOF
+```
+
+Pre-change backups (named with a clear reason in `README.txt`) are forensic gold — never prune them.
+
+## Verifying a backup
+
+Before trusting any backup — especially before a restore — verify it.
+
+```bash
+cd backups/<TS> && sha256sum -c MANIFEST.sha256
+```
+
+Expected:
+
+```
+skillai.dump: OK
+uploads.tar.gz: OK
+```
+
+If either says `FAILED`, **do not restore**. Inspect the dump's table of contents without restoring:
+
+```bash
+docker exec -i skillai-db-1 pg_restore --list < backups/<TS>/skillai.dump | head -40
+```
+
+You should see schema objects (`SCHEMA - public`, `TABLE - candidates`, etc.) and data items.
+
+```bash
+tar -tzf backups/<TS>/uploads.tar.gz | head -20
+```
+
+You should see paths like `./<tenant-uuid>/cv/<file>.pdf` and `./<tenant-uuid>/logos/<file>.png`.
+
+## Restore procedure
+
+> **⚠️ Caution**
+>
+> **Destructive.** A restore overwrites the live database and uploads volume. Read this whole section before running anything.
+
+### Pre-restore checklist
+
+1. **Verify the backup first** (above). Restoring from a corrupt dump leaves you with neither the old state nor the new.
+2. **Notify users** — restore breaks any in-flight session.
+3. **Take a fresh backup of the current (broken) state** before restoring. You may want to triage the broken DB later, and `pg_restore --clean` will erase it.
+
+### Step 1 — Stop the app, keep the DB up
+
+```bash
+docker compose stop app migrate
+```
+
+Leave `db` running — `pg_restore` connects to it.
+
+### Step 2 — Restore the database
+
+```bash
+docker cp backups/<TS>/skillai.dump skillai-db-1:/tmp/skillai.dump
+docker exec skillai-db-1 pg_restore \
+  --clean --if-exists \
+  -U skillai -d skillai \
+  /tmp/skillai.dump
+docker exec skillai-db-1 rm /tmp/skillai.dump
+```
+
+`--clean --if-exists` drops every object before recreating it. Warnings about extensions (`pgvector`) already existing are safe to ignore.
+
+### Step 3 — Restore the uploads volume
+
+```bash
+docker run --rm \
+  -v skillai_uploads_data:/target \
+  -v "$(pwd)/backups/<TS>":/backup \
+  alpine sh -c "rm -rf /target/* && tar -xzf /backup/uploads.tar.gz -C /target"
+```
+
+`rm -rf /target/*` wipes the live uploads volume before extracting the backup over it. **Never run this except as part of an actual restore.**
+
+### Step 4 — Restart the app
+
+```bash
+docker compose start app
+```
+
+`migrate` will re-run on the next `docker compose up`, which is harmless — the restored schema already matches the migrations it would apply.
+
+### Step 5 — Smoke-test
+
+1. Open `http://localhost:3000` and sign in with a known account.
+2. Open **Candidates** — confirm rows are present.
+3. Open a known **Role** detail page — confirm ranked candidates render.
+4. Download a CV — confirms the uploads volume restored correctly.
+5. Check `docker compose logs app | tail -50` for any startup errors.
+
+If any fail, capture the logs immediately and stop.
+
+## Retention
+
+Operator's discretion. Suggested cadence:
+
+| Tier | Cadence | Keep |
+|---|---|---|
+| Hourly | Not recommended | — |
+| Daily | Cron (see below) | Last **7** |
+| Weekly | First daily of each week | Last **4** |
+| Monthly | First daily of each month | Last **12** |
+| Pre-change | Ad-hoc, before any runtime change | **Indefinite** — these are forensic gold |
+
+## Cron'ed daily backup (sketch)
+
+Not implemented in-repo. If you choose to automate:
+
+```bash
+# /etc/cron.d/skillai-backup — adjust user, path, and time
+0 3 * * * youruser cd /path/to/SkillAi && /usr/local/bin/skillai-backup.sh >> /var/log/skillai-backup.log 2>&1
+```
+
+The wrapper would: set `TS=$(date +%Y%m%d-%H%M%S)`, run the three backup commands above, prune `backups/` per the retention table, exit non-zero on any failure so cron emails the operator.
+
+## Off-host copy (gap, not prescription)
+
+Backups on the same host as the database protect against application-level failures (bad migration, corrupted row). They **do not** protect against host loss (disk failure, theft, ransomware, accidental `rm -rf /`).
+
+A complete strategy copies backups off the SkillAI host. Options range from cheap to robust:
+
+- `rsync` to a NAS over the local network (no encryption by default)
+- `restic` or `borg` to a remote repository (deduplicating, encrypted at rest)
+- S3-compatible remote (AWS S3, Backblaze B2, Garage) via `rclone` or `aws s3 sync`
+- Tarsnap (encrypted, deduplicating, paid)
+
+If you do nothing else, **copy the latest pre-change backup to a USB drive every month**. Primitive but better than zero.
+
+## NOT a backup — the GDPR / DSAR export
+
+SkillAI exposes two in-app exports that operators sometimes confuse with backups:
+
+- **Per-tenant JSON export** (Settings → Backups & Data Export) — admin-triggered ZIP with one JSON per table, scoped to a single tenant. Useful as a DSAR response or for tenant migration. **Not a backup** — restore-from-export is not implemented and binary files (CVs) are only included via the opt-in `?files=1` flag.
+- **GDPR per-candidate erasure** ([DEC-011](../decisions/dec-011-gdpr-erasure.md)) — hard-deletes a candidate's data with audit-log redaction. The companion DSAR export covers the candidate's own data, not the tenant.
+
+Neither replaces a Postgres dump. They serve compliance use cases, not disaster recovery.
+
+## What this runbook does NOT cover
+
+Each would need its own document and operator decisions:
+
+- **Point-in-time recovery (PITR)** — restoring to an arbitrary moment between dumps. Requires WAL archive shipping; worth considering once the dataset grows beyond what a 24-hour-RPO dump can lose.
+- **Encrypted backups at rest** — current backups are unencrypted on local disk. Acceptable while the host is trusted; not acceptable for off-host third-party storage. `gpg`, `age`, or `restic` are all reasonable.
+- **Multi-region replication** — only relevant once file storage is on Garage / S3 and there's a second region to replicate to.
+- **Per-tenant restore** — the dump is database-wide. Surgical restore of one tenant requires either the in-app JSON export (already shipped) or a temporary parallel database.
+- **Schema-only / data-only dumps** — `pg_dump --schema-only` / `--data-only` aren't the default and aren't covered here.
+
+When any of these become real needs, add them as separate documents rather than bolting onto this runbook.
+
+## Related
+
+- [Health & monitoring](./health-monitoring.md) — verify the DB is healthy before backing up.
+- [AWS deployment](./aws-deploy.md) — RDS snapshots replace the manual `pg_dump` flow in EKS deployments.
+- [DEC-011 — GDPR erasure pattern](../decisions/dec-011-gdpr-erasure.md) — what the per-candidate hard-delete actually does.

--- a/techdocs/operations/health-monitoring.md
+++ b/techdocs/operations/health-monitoring.md
@@ -1,0 +1,199 @@
+# Health & monitoring
+
+_The /api/health endpoint, the audit log table, and the AI usage ledger — what SkillAI exposes for operational visibility._
+
+SkillAI exposes three observability surfaces, all built into the application — no Prometheus scrape endpoint, no metrics push to Datadog. Operators monitor it the way they monitor any Postgres-backed Node app: a liveness endpoint, a structured action history in the database, and an AI spend ledger surfaced as a dashboard.
+
+> **ℹ️ Note**
+>
+> There is no `/metrics` endpoint and no built-in tracing exporter. If you need Prometheus-style metrics, scrape `/api/health` for liveness and tail `docker compose logs app` (or the EKS pod logs) for structured request logs. Adding a real metrics endpoint is on the roadmap but not built.
+
+## `/api/health` — liveness probe
+
+`src/app/api/health/route.ts` exposes an unauthenticated health endpoint for Docker healthchecks, EKS readiness probes, and external monitors.
+
+### Shape
+
+```bash
+curl -s http://localhost:3000/api/health
+```
+
+```json
+{
+  "status": "ok",
+  "db": "ok",
+  "uptime": 42.3,
+  "timestamp": "2026-05-29T12:00:00.000Z"
+}
+```
+
+| Field | Type | Meaning |
+|---|---|---|
+| `status` | `'ok' \| 'unhealthy'` | overall liveness — `unhealthy` whenever any sub-check fails |
+| `db` | `'ok' \| 'error'` | result of a trivial `SELECT 1` against the connection pool |
+| `uptime` | number (seconds) | `process.uptime()` since the Node process started — useful for spotting unexpected restarts |
+| `timestamp` | ISO 8601 string | `new Date().toISOString()` at the moment the response was generated |
+
+### HTTP status
+
+- **200** when `status === 'ok'`
+- **503** when the DB query throws (connection refused, pool exhausted, RDS failover in progress, etc.)
+
+`Cache-Control: no-store` is set on both responses — monitors must always get a live result.
+
+### What it does NOT check
+
+Intentionally minimal. The endpoint does not verify:
+
+- Anthropic / Gemini API reachability (would burn AI quota on every poll)
+- File storage writability (would require disk I/O on every poll)
+- Auth session validity (the endpoint is unauthenticated by design)
+- Migration freshness or schema integrity
+
+If any of those are critical to your monitoring, add separate probes against specific routes. Don't bloat `/api/health` — it's polled every few seconds by Docker.
+
+## The audit log
+
+`src/db/schema/audit-logs.ts` defines `audit_logs` as the canonical action history.
+
+### Schema
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | UUID PK | |
+| `tenant_id` | UUID NOT NULL | FK to `tenants.id`, RLS-scoped |
+| `user_id` | UUID nullable | nullable — system actions (cron, `after()` jobs) have no user |
+| `user_email` | varchar(200) | denormalised for fast read |
+| `action` | varchar(100) NOT NULL | dotted convention, e.g. `score.completed`, `candidate.deleted_gdpr` |
+| `entity_type` | varchar(50) NOT NULL | `candidate`, `role`, `score`, `interview_slot`, etc. |
+| `entity_id` | UUID nullable | nullable for bulk / list actions |
+| `entity_label` | varchar(200) | human-readable label, e.g. `"John Smith"` |
+| `metadata` | jsonb nullable | extra context — role title, score value, error message |
+| `created_at` | timestamptz NOT NULL | indexed alongside `tenant_id` |
+
+Indexed by `(tenant_id, created_at)` and `(entity_type, entity_id)` for the two common query shapes: per-tenant timeline and per-entity history.
+
+### What gets logged
+
+Every server action that mutates tenant data emits an audit row via `emitAudit()` from `src/lib/audit-middleware.ts`. Concrete action names live in the code; representative ones:
+
+- **Lifecycle:** `candidate.created`, `role.created`, `role.updated`, `user.created`, `email_template.created`, `email_template.updated`, `email_template.deleted`
+- **AI pipeline:** `score.completed`, `score.failed`, `transcript_analysis.completed`, `transcript_analysis.failed`
+- **Manager workflow:** `shortlist.sent`, `candidate.approved_by_manager`, `candidate.rejected_by_manager`, `role.manager_assigned`
+- **Calendar:** `interview_slot.created`, `interview_slot.updated`, `interview_slot.rescheduled_external`, `interview_slot.cancelled_external`, `calendar.sync_failed`
+- **GDPR:** `candidate.deleted_gdpr`, `candidate.dsar_exported`
+- **Tenant export:** `tenant.exported`, `tenant.csv_exported`
+- **API tokens:** `api_token.created`
+- **OAuth credentials:** `settings.oauth_credentials_updated`, `settings.oauth_credentials_removed`
+
+The action enum is **not** constrained in the DB — it's `varchar(100)`. Adding a new action means writing the string at the `emitAudit` call site; no migration required.
+
+### How to export the audit log
+
+The audit log is queryable via the dashboard (Settings → Audit Log surface, per role) and via the REST API. The simplest export path:
+
+```bash
+# Direct SQL (set the tenant context first so RLS doesn't filter you out)
+docker exec -it skillai-db-1 psql -U skillai -d skillai
+```
+
+```sql
+SET app.tenant_id = '<your-tenant-uuid>';
+
+\COPY (
+  SELECT created_at, user_email, action, entity_type, entity_label, metadata
+  FROM audit_logs
+  ORDER BY created_at DESC
+) TO '/tmp/audit.csv' WITH CSV HEADER;
+```
+
+```bash
+docker cp skillai-db-1:/tmp/audit.csv ./audit.csv
+```
+
+The per-tenant JSON export from the Settings UI also includes `audit-log.json` as one of the tables in the ZIP. See the [backup runbook](./backup-runbook.md) for the distinction between the JSON export and a full backup.
+
+### Audit log retention
+
+No automatic pruning. The schema includes both compound indexes that stay cheap up to ~1 M rows. Past that, partition `audit_logs` by month and expire after 24 months unless a legal-hold flag is set — see [Performance baselines](../architecture/performance.md) for the threshold.
+
+GDPR erasure ([DEC-011](../decisions/dec-011-gdpr-erasure.md)) redacts PII from existing audit rows but **does not delete them** — the action history is preserved for accountability under Article 5(2) / Article 30 while the personal data fields (`entity_label`, `metadata`) get replaced with `[redacted-gdpr]`.
+
+## The AI usage ledger
+
+`src/db/schema/ai-usage.ts` defines `ai_usage`, the per-call ledger for every Claude and Gemini request.
+
+### Schema
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | UUID PK | |
+| `tenant_id` | UUID NOT NULL | RLS-scoped |
+| `user_id` | UUID nullable | nullable — background `after()` jobs have no user context |
+| `operation` | varchar(64) NOT NULL | from `AI_OPERATIONS` const in code, see below |
+| `model` | varchar(100) NOT NULL | e.g. `claude-sonnet-4-6`, `models/gemini-2.0-flash` |
+| `input_tokens` | integer NOT NULL | |
+| `output_tokens` | integer NOT NULL | |
+| `cache_creation_tokens` | integer nullable | Anthropic prompt-cache writes |
+| `cache_read_tokens` | integer nullable | Anthropic prompt-cache reads |
+| `cost_usd` | decimal(10, 6) NOT NULL | computed at log time from per-model unit prices |
+| `duration_ms` | integer nullable | wall-clock API duration |
+| `metadata` | jsonb nullable | `{ candidateName, roleTitle, ... }` |
+| `created_at` | timestamptz NOT NULL | indexed alongside `tenant_id` |
+
+### Operation tags
+
+The `operation` field is constrained at the **application layer** via the `AI_OPERATIONS` const + `AiOperation` type — kept out of the DB schema so adding a new AI surface doesn't require a migration. Current operations:
+
+`cv_scoring_claude`, `cv_scoring_gemini`, `cv_profile_extract`, `interview_pack_generate`, `transcript_analysis`, `cv_reformat`, `synechron_extract`, `profile_match`, `role_fit`, `shortlist_summary`, `role_tag_extract`, `embedding`, `personal_site_summary`, `welcome_letter_generate`, `auto_match_scoring`.
+
+This is why the auto-match cost cap can query `WHERE operation = 'auto_match_scoring'` and get a clean per-feature spend total without touching unrelated calls.
+
+### The cost dashboard
+
+`/dashboard/reports` surfaces the ledger as:
+
+- **AI cost trend** — line chart with month-over-month delta. Component: `src/components/reports/ai-cost-trend-chart.tsx`.
+- **AI spend breakdown** — per-model, per-operation, per-user drill-down (PR #152 closing issue #151).
+- **Per-tenant usage panel** — current month + recent calls. Component: `src/components/settings/ai-usage-panel.tsx`. Lives on the Settings page.
+
+Admins also get a CSV export of the AI cost trend via `/api/reports/ai-cost-trend/csv`.
+
+### Per-call cost computation
+
+`cost_usd` is computed at log time from per-model unit prices in `src/lib/ai/pricing.ts`. The price table is hand-maintained; bump it when Anthropic / Google publish a new rate card.
+
+## Application logs
+
+Standard `console.log` / `console.error` to stdout. Pick them up via:
+
+```bash
+# Local dev
+# (logs appear in the terminal running `npm run dev`)
+
+# Docker
+docker compose logs -f app
+
+# EKS
+kubectl logs deployment/skillai-app -n skillai --tail=100 --follow
+```
+
+Scoring failures, interview pack failures, calendar sync failures, and AI API errors all log with the relevant entity ID and the error message. There is no structured log format (JSON lines) — adding one is on the roadmap.
+
+## Notifications — Slack + Teams webhooks
+
+Separate from health monitoring, but worth knowing about. Tenants configure per-tenant Slack and Teams webhook URLs (encrypted in `tenant_settings`); the dispatcher in `src/lib/notifications/dispatcher.ts` fans out on specific audit-log events:
+
+- Candidate scored ≥ 85 (configurable threshold)
+- Interview scheduled
+- Stale priorities
+- Manager approved / rejected a shortlist
+- Daily digest: "N awaiting score, M interviews this week"
+
+Per-user preferences let recruiters opt out of noisy channels. See PR #168 for the implementation.
+
+## Related
+
+- [System overview](../architecture/system-overview.md) — where the health endpoint sits in the request lifecycle.
+- [Performance baselines](../architecture/performance.md) — when to start worrying about the audit_logs table size.
+- [AI scoring pipeline](../architecture/ai-scoring-pipeline.md) — how the AI cost cap uses the `ai_usage` ledger as backpressure.

--- a/techdocs/overview/live-demo.md
+++ b/techdocs/overview/live-demo.md
@@ -1,0 +1,130 @@
+# Live demo
+
+_How to try SkillAI locally in five minutes — Docker quick-start, demo data seeding, and a recipe for capturing screenshots and demo GIFs._
+
+> **⚠️ Caution — No public demo instance**
+>
+> SkillAI is an **internal tool**. There is no public-facing demo URL — every deployment lives behind a recruiter's own infrastructure. The fastest way to see it is to run it locally against the seed data. Five minutes from `git clone` to "ranked shortlist".
+
+## Five-minute local demo
+
+1. **Clone the repo and start the stack**
+
+   ```bash
+   git clone https://github.com/olafkfreund/SkillAi.git
+   cd SkillAi
+   docker compose up -d
+   ```
+
+   This brings up Postgres 17 (with pgvector), the Next.js app, and the local upload volume. First build takes ~3 min; subsequent starts are ~5 sec.
+
+2. **Run the database migrations and seed**
+
+   ```bash
+   docker compose exec app npm run db:push
+   docker compose exec app npm run db:seed
+   ```
+
+   The seed creates one tenant, an admin user, ten realistic candidates with embeddings, and three open roles. None of the data is real — every name, email, and CV is synthetic.
+
+3. **Open the portal**
+
+   ```
+   http://localhost:3000
+   ```
+
+   Log in with the credentials printed by the seed script (e.g. `admin@demo.local` / a generated password). You'll land on the dashboard.
+
+4. **Try the ranking flow**
+
+   - Open one of the seeded roles
+   - Watch the ranked shortlist populate (AI runs in the background, polled via TanStack Query)
+   - Open a candidate; click "Generate interview pack"
+   - Export the pack as PDF
+
+5. **Try the MCP integration** (optional)
+
+   In a separate terminal:
+
+   ```bash
+   claude mcp add --transport http --scope user skillai \
+     http://localhost:3000/api/mcp \
+     --header "Authorization: Bearer $(curl -s -X POST http://localhost:3000/api/api-tokens \
+        -H 'Cookie: <your session cookie>' | jq -r .token)"
+   ```
+
+   Now in Claude Code you can run `/mcp` and call any of the 48 SkillAI tools.
+
+→ Full step-by-step: [Quick start](../getting-started/quick-start.md)
+
+## Demo video
+
+> **💡 Tip — Coming soon**
+>
+> A 90-second narrated walkthrough is on the to-do list. Drop a `demo.gif` or `demo.mp4` into `docs-site/src/assets/` and add an `` / HTML `<video>` block below this callout when ready.
+
+{/* Placeholder for future demo video:
+<video controls width="100%" poster="../../../assets/screenshots/01-dashboard.png">
+  <source src="../../../assets/demo.mp4" type="video/mp4" />
+</video>
+*/}
+
+## Capturing your own screenshots
+
+The existing screenshots in `docs/screenshots/` were captured against a development instance with the seed data. To refresh them or add new ones:
+
+**Single screen**
+
+1. Start the dev server: `npm run dev` (not Docker — faster reload)
+2. Use a 1440×900 viewport (matches the existing set)
+3. Hide the browser chrome (F11) and the Next.js dev overlay
+4. Use Cmd+Shift+4 (macOS) or `gnome-screenshot -a` (Linux) for a precise selection
+5. Save as `docs/screenshots/NN-name.png` — the numeric prefix controls tour order
+6. Run `cp docs/screenshots/*.png docs-site/src/assets/screenshots/` to refresh the docs site
+
+**Animated GIF**
+
+For demo GIFs, use [`peek`](https://github.com/phw/peek) (Linux) or [`Gifski`](https://gif.ski) (macOS):
+
+```bash
+# Linux, with peek
+sudo apt install peek
+peek  # draw a rectangle, hit "Record"
+# Save as demo.gif into docs-site/src/assets/
+```
+
+Keep GIFs under 5 MB — the docs site is gzipped on GitHub Pages but huge assets still hurt LCP.
+
+**Full demo video**
+
+For a narrated walkthrough, use OBS Studio:
+
+1. Record at 1080p30, max 8 Mbps bitrate
+2. Export to MP4 (H.264, AAC audio)
+3. Convert to a web-friendly size:
+   ```bash
+   ffmpeg -i raw.mp4 -vf "scale=1280:-2" -c:v libx264 -crf 28 -preset slow \
+     -c:a aac -b:a 96k -movflags +faststart demo.mp4
+   ```
+4. Drop into `docs-site/src/assets/demo.mp4` and embed via `<video>` above.
+
+## Hosting your own instance
+
+Want to skip Docker and run on real infrastructure?
+
+- **AWS** — see [AWS deployment](../operations/aws-deploy.md) (EKS + RDS + S3 via Garage adapter)
+- **Generic VPS** — `docker compose up -d` on any host with Postgres 17 + pgvector
+- **Nix / NixOS** — the MCP bridge ships a Nix flake at `skillai-mcp/`; the main app is plain Next.js standalone (`next build` produces a self-contained server)
+
+The platform-agnostic answer: anywhere Node 22 + Postgres 17 + pgvector + a writeable volume can run, SkillAI can run.
+
+## Telemetry & data isolation
+
+The local demo is **completely offline by default**:
+
+- No external analytics
+- No telemetry pings
+- No external auth — Auth.js with local credentials, no SSO call-out
+- AI calls (Claude / Gemini) only fire if you've configured API keys in **Settings → API Keys** — they're stored encrypted per-tenant
+
+You can run the full feature set against the seed data without ever connecting to the internet (AI features will degrade gracefully when keys are absent — scoring jobs queue but never fire).

--- a/techdocs/overview/product-tour.md
+++ b/techdocs/overview/product-tour.md
@@ -1,0 +1,95 @@
+# Product tour
+
+_A guided, screenshot-driven walkthrough of every major surface in SkillAI — dashboard, candidates, roles, interviews, customers, settings._
+
+A tour through the recruiter's day-to-day, captured from the live portal. Every screen below maps to a deeper guide elsewhere in the docs — follow the **→ Read more** links to see how each piece works under the hood.
+
+## 1. Dashboard
+
+The first thing a recruiter sees on login. Three columns of glanceable state:
+
+- **For you** — personal action streams: pending interviews, candidates awaiting score, stale priorities, expired roles, manager approval requests
+- **Active roles + recent uploads + top candidates** — tenant-wide context
+- **Next interviews** — calendar widget pulling from the integrated calendar sync
+
+Every widget runs in a single parallel `Promise.all` inside one `withTenant()` round-trip — see [Dashboard performance + index tuning](../architecture/performance.md) for the optimisation history.
+
+→ Read more: [System overview](../architecture/system-overview.md)
+
+## 2. Candidate list
+
+The candidate archive — every CV ever uploaded, filterable by skills, agency, status, availability, score range, and date. The left-edge checkbox column drives bulk actions (change status, add to a role, send for approval). Click any row to open the profile.
+
+Each row shows the 20-px agency-logo chip with initials fallback — recruiters instantly see who sourced the candidate. Internal-bench candidates get an **INTERNAL** badge, never any AI scoring boost (see [DEC-010](../decisions/dec-010-internal-bench.md)).
+
+→ Read more: [Audience-based view sanitisation](../code-patterns/audience-sanitisation.md)
+
+## 3. Candidate profile
+
+The single source of truth for a candidate. Top: identity + commercial fields (rate, availability, right-to-work). Middle: AI-extracted structured profile (summary, skills, experience, education). Right rail: shared notes, status timeline, and the candidate's history of matched roles with inline scores.
+
+The page is rendered by an `audience`-aware component — recruiters see everything, customers see no internal notes / rates / margin / agency, managers see scores + reasoning but read-only.
+
+→ Read more: [Audience-based view sanitisation](../code-patterns/audience-sanitisation.md), [DEC-009 — Soft budget signal](../decisions/dec-009-soft-budget-signal.md)
+
+## 4. CV viewer
+
+The raw extracted CV text, plus a "Reformat with AI" button that runs Claude Haiku to clean up the text into structured markdown. Useful for legacy PDFs where the extraction was messy.
+
+→ Read more: [AI scoring pipeline](../architecture/ai-scoring-pipeline.md)
+
+## 5. Roles list
+
+All open roles, with status badges, customer linkage, target fill date, and cut-off date. Roles past their cut-off date show a **red EXPIRED badge** and a red banner on the detail view — but **never auto-archive**. The recruiter decides whether to extend the deadline or close the role (see [DEC-008](../decisions/dec-008-manual-archive.md)).
+
+→ Read more: [Roadmap](../roadmap.md)
+
+## 6. Role detail (the heart of the product)
+
+This is where the AI ranking lives. The page shows:
+
+- Role description + requirements + commercial fields (customer day-rate budget)
+- **Ranked candidates panel** — every scored candidate, sorted by overall score, with per-dimension breakdowns (skills, experience, role-fit, communication) and AI reasoning on every row
+- **Auto-match panel** (top-3 archive matches) — surfaces when a new role is created
+- Manager assignment + send-for-approval workflow
+- Customer share-link generator
+
+Margin is computed inline (`role.customerDayRate − candidate.candidateRate`) and shown to recruiters. Over-budget candidates aren't filtered out — Claude is told about the budget as a *soft signal* in the prompt, not a scored dimension (see [DEC-009](../decisions/dec-009-soft-budget-signal.md)).
+
+→ Read more: [AI scoring pipeline](../architecture/ai-scoring-pipeline.md), [REST API for scoring](../rest-api/endpoints.md#scoring)
+
+## 7. Agencies
+
+Recruitment agencies are first-class entities. Each agency has contact details, notes, a logo, and a candidate list with performance metrics. The per-tenant **system "Internal" agency** is auto-provisioned and protected from archival — that's how the internal-bench model surfaces here (see [DEC-010](../decisions/dec-010-internal-bench.md)).
+
+→ Read more: [Logo upload pattern](../code-patterns/logo-upload.md)
+
+## 8. Settings
+
+Per-tenant configuration: API keys (Claude + Gemini, AES-256-GCM encrypted), default pack language, trusted hosts, calendar OAuth credentials, AI cost tracking dashboard, API tokens, backups, CSV exports, and the GDPR DSAR / erasure tools (admin-only).
+
+→ Read more: [DEC-006 — Auth.js over Clerk](../decisions/dec-006-authjs-over-clerk.md), [DEC-011 — GDPR erasure](../decisions/dec-011-gdpr-erasure.md)
+
+## 9. Interview pack
+
+Generated on demand per candidate × role. Includes personalised technical questions, behavioural questions, a STAR-format pre-screen variant, and an optional code challenge. Output is streamed back to the client via TanStack Query polling so the recruiter sees progress in real time.
+
+The pack is exportable as a polished PDF (react-pdf), as is the welcome letter that goes to the candidate in their preferred language.
+
+→ Read more: [AI scoring pipeline](../architecture/ai-scoring-pipeline.md)
+
+---
+
+## What's not in screenshots
+
+A few surfaces ship today but didn't make this batch:
+
+- **Manager approval queue** (`/dashboard/manager`) — hiring managers see only their assigned roles with pending counts
+- **Customer share view** — public, sanitised candidate cards opened via a tokenised share link
+- **Reports dashboard** (`/dashboard/reports`) — time-to-fill, agency hit-rate, AI cost trend, cycle health, top performers
+- **Help hub** (`/dashboard/help`) — 20+ in-app articles, audience-filtered per role
+- **Skills explorer** (`/dashboard/skills`) — clickable skill chips with candidate counts
+- **Submissions index** (`/dashboard/submissions`) — every candidate sent to a customer with status + share-link state
+- **Command palette** (Cmd-K / `/`) — fast cross-app navigation
+
+These are tracked for the next screenshot pass — see [Live demo](./live-demo.md) for how to capture them locally.

--- a/techdocs/overview/what-is-skillai.md
+++ b/techdocs/overview/what-is-skillai.md
@@ -1,0 +1,135 @@
+# What is SkillAI?
+
+_An internal AI-powered recruiting portal that ranks and archives candidates against job roles using Claude and Gemini, with explainable per-dimension scoring and a reusable candidate archive._
+
+## The pitch
+
+SkillAI is an internal AI-powered recruiting portal that helps recruiters and hiring managers quickly rank and navigate candidates against specific job roles by using Claude and Gemini to score CVs across skills, experience, and role-fit dimensions. It replaces manual CV sifting with fast, explainable AI scoring while maintaining a growing historical candidate archive.
+
+> **💡 Tip**
+>
+> SkillAI is deliberately **not** a full ATS. It does one thing — rank candidates fast — and keeps the rest of the workflow out of its way. The reasoning is in [DEC-001 — Build vs buy](../decisions/dec-001-build-vs-buy.md).
+
+## Who it's for
+
+### Primary customers
+
+- **Internal Recruiters** — responsible for sourcing, reviewing, and shortlisting candidates across multiple open roles.
+- **Hiring Managers** — consuming ranked shortlists and making final hire decisions.
+
+### User personas
+
+
+### Senior Recruiter (30–45)
+
+**Role:** Talent Acquisition Specialist
+
+**Context:** Managing 5–15 open roles simultaneously, receiving 50–200 CVs per role from multiple agencies.
+
+**Pain points:** Drowning in unstructured CVs, inconsistent scoring across reviewers, no historical candidate memory, hard to match past candidates to new roles.
+
+**Goals:** Shortlist top 5–10 candidates per role within hours, reuse historical candidates for new roles, track agency performance.
+
+
+### Hiring Manager (35–55)
+
+**Role:** Engineering Manager / Department Head
+
+**Context:** Receives candidate shortlists from a recruiter and needs to make fast decisions.
+
+**Pain points:** Inconsistent candidate summaries, no standard scoring to compare against, no context on why a candidate was shortlisted.
+
+**Goals:** Understand at a glance why each candidate scored highly, compare candidates side-by-side, add personal notes and decisions.
+
+## The problems we solve
+
+### CV volume overwhelm
+
+Recruiters receive dozens to hundreds of CVs per role from multiple recruitment agencies. Manually reviewing each one is slow, inconsistent, and leaves good candidates buried. This costs companies days of recruiter time per role.
+
+**Our solution:** AI automatically parses and scores every CV against a role description, surfacing the best-fit candidates in seconds with explainable dimension scores.
+
+### No candidate memory
+
+When a candidate is not selected for one role, their profile is lost. When a similar role opens months later, the recruiter starts from scratch. Industry data suggests 20–40% of past candidates are relevant to future roles.
+
+**Our solution:** Every scored candidate is archived with their AI-generated profile summary and dimension scores, searchable and re-rankable against any future role.
+
+### Inconsistent evaluation standards
+
+Different recruiters and hiring managers apply different standards, making it impossible to compare candidates fairly across time or across team members.
+
+**Our solution:** Standardised AI scoring rubrics per role dimension ensure every candidate is evaluated against the same criteria, with per-dimension breakdowns and reasoning.
+
+### Agency tracking gap
+
+Companies use multiple recruitment agencies but rarely track which agencies deliver the best candidates at what cost over time.
+
+**Our solution:** Recruitment companies are first-class entities in the system — candidates are linked to their originating agency, and notes / history are maintained per agency.
+
+## What makes SkillAI different
+
+### Fast, not a platform
+
+Unlike full ATS systems (Greenhouse, Workday, Lever), SkillAI does one thing: rank candidates fast. No complex pipelines, no integrations, no bloat. You get a result in seconds, not after configuring 15 settings.
+
+### Reusable candidate archive
+
+Unlike ad-hoc spreadsheet tracking, every candidate is stored with AI-generated skills profiles and full scoring history, making past candidates immediately reusable against future roles without manual re-review.
+
+### Explainable AI scores
+
+Unlike black-box ranking tools, SkillAI shows per-dimension scores (technical skills, experience level, role-fit, communication indicators) with brief AI reasoning, so recruiters understand and trust the ranking.
+
+## Key features
+
+
+### CV upload + AI parsing
+
+Upload PDFs / Word docs; AI extracts and structures skills, experience, and profile data.
+
+
+### Role-based ranking
+
+Upload or create a job role description; AI scores all candidates against it with per-dimension breakdowns.
+
+
+### Candidate archive
+
+All candidates stored historically with profile summaries and scoring history, searchable across past and current roles.
+
+
+### Role description library
+
+Store internal job descriptions as reusable templates for repeated use across hiring rounds.
+
+
+### AI model flexibility
+
+Use Claude (`claude-sonnet-4-6`) or Gemini (`gemini-2.0-flash`) for scoring; switch per-role or compare outputs.
+
+
+### Multi-tenant access
+
+Multiple users / teams with isolated data per tenant; role-based access (admin, recruiter, viewer, hiring manager).
+
+
+### Recruitment agency management
+
+Maintain a list of agencies with notes, performance history, and candidate linkage.
+
+
+### Candidate notes + history
+
+Add structured notes, interview feedback, and decisions to any candidate at any point in time. See every role a candidate has been scored against.
+
+
+### Side-by-side comparison
+
+Select 2–5 candidates and compare their dimension scores, summaries, and notes on one screen.
+
+## Keep reading
+
+- [Product tour](./product-tour.md) — a guided, screenshot-driven walkthrough of every major surface.
+- [System overview](../architecture/system-overview.md) — how the pieces fit together at a technical level.
+- [Decisions log](../decisions/index.md) — every architecturally-meaningful choice with rationale, alternatives, and consequences.

--- a/techdocs/rest-api/authentication.md
+++ b/techdocs/rest-api/authentication.md
@@ -1,0 +1,117 @@
+# Authentication
+
+_Bearer-token auth for the SkillAI REST API and MCP server — token format, argon2id storage, scope inclusion, revocation, and the mint-and-store recipe._
+
+The SkillAI REST API and the MCP server share a single auth model: a Bearer token in the `Authorization` header. Tokens are issued from the dashboard, stored argon2-hashed, and scoped to one of three access levels.
+
+## Token format
+
+Tokens look like `skl_<env>_<24-base62>` — for example `skl_prod_xxxxxxxxxxxxxxxxxxxxxxxx` (24 random characters from the base62 alphabet). The `env` segment is either `dev` or `prod` and is purely a discriminator; the validator does not enforce environment-to-server matching.
+
+The schema is in [`src/db/schema/api-tokens.ts`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/db/schema/api-tokens.ts). Each row stores:
+
+- `prefix` (first 12 chars, indexed and globally unique) for O(1) lookup before the hash check.
+- `hash` — the argon2id digest of the full raw token; the raw secret is **never** persisted.
+- `scopes` — a text array of `read` / `write` / `admin` grants.
+- `expiresAt`, `revokedAt`, `lastUsedAt` — lifecycle timestamps.
+
+## Where to mint a token
+
+Tokens are minted from **Settings → API Tokens** in the dashboard. The raw token is shown **exactly once** on creation — copy it into your secret store immediately. After that, only the prefix is visible in the UI for identification.
+
+> **⚠️ Caution**
+>
+> There is no recovery path. If you lose a token, revoke it and mint a new one.
+
+## Validation pipeline
+
+Every request runs through [`validateApiToken`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/lib/api-tokens/validate.ts):
+
+1. Format guard — the token must start with `skl_`.
+2. Prefix lookup — query `api_tokens` by `prefix` (the prefix is unique, so this works without tenant context).
+3. Argon2 verify — timing-safe verification of the full raw token against the stored hash.
+4. Expiry check — reject if `expiresAt` has passed.
+5. Revocation check — reject if `revokedAt` is set.
+6. Side effects — bump `lastUsedAt` fire-and-forget, sample 1-in-10 audit log entries to avoid log flood.
+
+Any failure returns `null` and the upstream middleware emits a 401. The validator never leaks why — `unknown prefix`, `wrong secret`, `expired`, and `revoked` all surface the same response.
+
+## Scope hierarchy
+
+Scopes are inclusive — a higher scope satisfies any lower requirement. From [`requireScope`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/lib/api/auth-middleware.ts) in the auth middleware:
+
+| Granted scope | Satisfies |
+|---|---|
+| `admin` | read, write, admin |
+| `write` | read, write |
+| `read` | read only |
+
+So an `admin` token is the master key, `write` covers everything that mutates state below admin, and `read` is safe for read-only integrations (dashboards, reports, scripts that only consume data).
+
+> **ℹ️ Note**
+>
+> The hierarchy is enforced at the route level — each endpoint declares the **minimum** scope it accepts. Token scopes are stored as an array, but in practice every issued token has exactly one entry. Pick the lowest scope that lets the integration do its job.
+
+## Mint and store recipe
+
+1. **Mint the token in the UI.**
+
+   Navigate to **Settings → API Tokens** in the SkillAI dashboard, click **New token**, give it a memorable name (e.g. `cli-script-staging`), pick a scope, and optionally set an expiry. The raw token appears in a one-time-view dialog.
+
+2. **Copy it into your secret store immediately.**
+
+   Once you close the dialog, the raw value is gone forever — only the prefix remains visible.
+
+   ```bash
+   # Example: store in 1Password CLI
+   op item create --category=apicredential \
+     --title='SkillAi cli-script-staging' \
+     credential='skl_prod_xxxxxxxxxxxxxxxxxxxxxxxx'
+
+   # Or just a local env file (don't commit)
+   echo 'SKILLAI_TOKEN=skl_prod_xxxxxxxxxxxxxxxxxxxxxxxx' >> .env.local
+   ```
+
+3. **Call the API.**
+
+   ```bash
+   curl -H "Authorization: Bearer skl_prod_xxxxxxxxxxxxxxxxxxxxxxxx" \
+        https://your-skillai-host/api/roles
+   ```
+
+4. **Revoke when you're done.**
+
+   Back in **Settings → API Tokens**, click **Revoke** on the row. Future requests with that token immediately fail with 401.
+
+## Same token, two transports
+
+The same token works for both the REST API and the MCP server. The MCP entry point at [`src/app/api/mcp/route.ts`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/app/api/mcp/route.ts) extracts the bearer token, runs the same `validateApiToken` flow, and then dispatches the JSON-RPC body to the matching tool.
+
+
+**REST**
+
+```bash
+curl -H "Authorization: Bearer skl_prod_xxxxxxxxxxxxxxxxxxxxxxxx" \
+     -H "Content-Type: application/json" \
+     -X POST https://your-skillai-host/api/candidates/abc-123/status \
+     -d '{"status":"shortlisted"}'
+```
+
+
+**MCP (Claude Code)**
+
+```bash
+claude mcp add --transport http --scope user skillai \
+  https://your-skillai-host/api/mcp \
+  --header "Authorization: Bearer skl_prod_xxxxxxxxxxxxxxxxxxxxxxxx"
+```
+
+See [Connecting from Claude Code](../mcp-server/connecting.md) for the full MCP setup.
+
+## What gets audited
+
+- **Token use** is logged via sampled audit (`api_token.used`, ~1 in 10 calls) so the trail captures activity without flooding the audit log.
+- **Rate limit hits** are always logged (`api.rate_limit_exceeded`) — see [Rate limiting](./rate-limiting.md).
+- **Mint, revoke, and expiry** events are written by the Settings UI server actions.
+
+A revoked or expired token fails the validator with no audit entry on the failed request — invalid attempts are not audit-worthy at this volume.

--- a/techdocs/rest-api/endpoints.md
+++ b/techdocs/rest-api/endpoints.md
@@ -1,0 +1,94 @@
+# Endpoint reference
+
+_Auto-generated REST endpoint reference for SkillAI. All endpoints require a Bearer API token._
+
+> **ℹ️ Note**
+>
+> This page is **auto-generated** from the source-of-truth OpenAPI document. To regenerate locally, run `npm run docs:gen:openapi` from `docs-site/`. Last generated: **2026-05-29**.
+
+**35 paths**, **43 operations**. Download the raw spec: [openapi.json](https://olafkfreund.github.io/SkillAi/openapi.json).
+
+All endpoints require an `Authorization: Bearer skl_<env>_<token>` header. See [Authentication](./authentication.md) for details.
+
+## approvals
+
+| Method | Path | Scope | Summary |
+|---|---|---|---|
+| `GET` | `/api/approvals/{roleId}` | `admin` | Get approvals for a role |
+| `POST` | `/api/approvals/{roleId}/{candidateId}/approve` | `admin` | Approve a candidate for a role |
+| `POST` | `/api/approvals/{roleId}/{candidateId}/reject` | `admin` | Reject a candidate for a role |
+| `POST` | `/api/approvals/{roleId}/approve-all` | `admin` | Approve all remaining pending candidates for a role |
+| `POST` | `/api/approvals/{roleId}/send` | `admin` | Send shortlist for hiring manager approval |
+
+## candidates
+
+| Method | Path | Scope | Summary |
+|---|---|---|---|
+| `PATCH` | `/api/candidates/{candidateId}` | `admin` | Update candidate details |
+| `POST` | `/api/candidates/{candidateId}/agency` | `admin` | Assign or remove a candidate agency |
+| `POST` | `/api/candidates/{candidateId}/archive` | `admin` | Archive (soft-delete) a candidate |
+| `POST` | `/api/candidates/{candidateId}/availability` | `admin` | Update candidate availability status |
+| `POST` | `/api/candidates/{candidateId}/cv/reformat` | `admin` | Reformat a candidate CV with AI (Claude Haiku) |
+| `POST` | `/api/candidates/{candidateId}/enrichment/confirm` | `admin` | Confirm a verified profile for a candidate |
+| `POST` | `/api/candidates/{candidateId}/enrichment/dismiss` | `admin` | Dismiss a suggested profile for a candidate |
+| `POST` | `/api/candidates/{candidateId}/enrichment/trigger` | `admin` | Trigger web enrichment for a candidate |
+| `GET` | `/api/candidates/{candidateId}/notes` | `admin` | Get notes for a candidate |
+| `POST` | `/api/candidates/{candidateId}/status` | `admin` | Update candidate pipeline status |
+
+## customers
+
+| Method | Path | Scope | Summary |
+|---|---|---|---|
+| `DELETE` | `/api/customers/{customerId}/framework` | `admin` | Delete the hiring framework for a customer |
+| `GET` | `/api/customers/{customerId}/framework` | `admin` | Get the hiring framework for a customer |
+| `PUT` | `/api/customers/{customerId}/framework` | `admin` | Save or update the hiring framework for a customer |
+
+## notes
+
+| Method | Path | Scope | Summary |
+|---|---|---|---|
+| `POST` | `/api/notes` | `admin` | Create a note for a candidate |
+| `DELETE` | `/api/notes/{noteId}` | `admin` | Delete a note |
+| `PATCH` | `/api/notes/{noteId}` | `admin` | Update a note |
+
+## roles
+
+| Method | Path | Scope | Summary |
+|---|---|---|---|
+| `POST` | `/api/roles` | `admin` | Create a new role |
+| `PATCH` | `/api/roles/{roleId}` | `admin` | Update an existing role |
+| `POST` | `/api/roles/{roleId}/archive` | `admin` | Archive (soft-delete) a role |
+| `GET` | `/api/roles/{roleId}/managers` | `admin` | Get managers assigned to a role |
+| `POST` | `/api/roles/{roleId}/managers` | `admin` | Assign managers to a role (replaces existing set) |
+| `DELETE` | `/api/roles/{roleId}/managers/{userId}` | `admin` | Remove a manager from a role |
+| `POST` | `/api/roles/{roleId}/regenerate-tags` | `admin` | Regenerate AI tags for a role |
+
+## scores
+
+| Method | Path | Scope | Summary |
+|---|---|---|---|
+| `DELETE` | `/api/scores` | `admin` | Remove a candidate from a role (delete score) |
+| `POST` | `/api/scores/rescore` | `admin` | Re-score a candidate against a role |
+
+## settings
+
+| Method | Path | Scope | Summary |
+|---|---|---|---|
+| `GET` | `/api/settings/api-keys` | `admin` | List which API keys have been configured (names only, no values) |
+| `POST` | `/api/settings/api-keys` | `admin` | Save or update an API key |
+| `DELETE` | `/api/settings/api-keys/{provider}` | `admin` | Remove a configured API key |
+| `GET` | `/api/settings/default-pack-language` | `admin` | Get the default interview pack language |
+| `PUT` | `/api/settings/default-pack-language` | `admin` | Set the default interview pack language |
+| `GET` | `/api/settings/general` | `admin` | Get general (non-secret) tenant settings |
+| `PATCH` | `/api/settings/general` | `admin` | Save a general tenant setting |
+| `GET` | `/api/settings/trusted-hosts` | `admin` | Get trusted hostnames list |
+| `PUT` | `/api/settings/trusted-hosts` | `admin` | Replace the trusted hostnames list |
+
+## users
+
+| Method | Path | Scope | Summary |
+|---|---|---|---|
+| `GET` | `/api/users` | `admin` | List all users in the tenant |
+| `POST` | `/api/users/{userId}/deactivate` | `admin` | Deactivate a user account |
+| `PATCH` | `/api/users/{userId}/role` | `admin` | Update a user role |
+| `POST` | `/api/users/invite` | `admin` | Create a user invitation link |

--- a/techdocs/rest-api/overview.md
+++ b/techdocs/rest-api/overview.md
@@ -1,0 +1,107 @@
+# REST API overview
+
+_Bearer-token authenticated REST API for SkillAI — 35 unique paths, 41 operations, scope-based access, sliding-window rate limits, and a live OpenAPI document._
+
+The SkillAI REST API is the same surface the dashboard uses, exposed for machine-to-machine integration. It covers candidate management, role lifecycle, scoring, interview packs, approvals, notes, settings, and exports. Every operation that mutates state in the UI has a documented REST equivalent.
+
+## What it covers
+
+There are **41 operations across 35 unique paths** registered in the OpenAPI document. Each route file in `src/app/api/*` self-registers via `registerRoute(...)` (see [`src/lib/api/openapi.ts`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/lib/api/openapi.ts)) at module load, so the spec is always in lock-step with the code.
+
+The full endpoint table is in [Endpoint reference](./endpoints.md).
+
+
+### Auth model
+
+Bearer tokens issued from Settings → API Tokens. The same token works for [REST](./authentication.md) and the [MCP server](../mcp-server/overview.md).
+
+
+### Scope hierarchy
+
+`admin` ⊃ `write` ⊃ `read`. An `admin` token can call any endpoint; `write` covers reads + writes; `read` covers reads only.
+
+
+### Rate limits
+
+Sliding-window per-token / per-tenant / per-write. Configurable per tenant. See [Rate limiting](./rate-limiting.md).
+
+
+### OpenAPI 3.1
+
+Live spec at `GET /api/openapi.json` (read scope). Schemas generated from Zod via `z.toJSONSchema()`.
+
+## Request flow
+
+Every authenticated route goes through the `withApiAuth` wrapper defined in [`src/lib/api/auth-middleware.ts`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/lib/api/auth-middleware.ts). It validates the bearer token, enforces the scope declared by the route, runs the rate limiter, and only then calls the handler with an enriched context (`tenantId`, `userId`, `tokenId`, `scopes`).
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant M as withApiAuth
+    participant V as validateApiToken
+    participant R as checkRateLimit
+    participant T as withTenant (RLS)
+    participant H as Route handler
+
+    C->>M: Authorization: Bearer skl_prod_...
+    M->>V: argon2 verify + expiry + revocation
+    V-->>M: { tenantId, userId, scopes, tokenId }
+    M->>M: requireScope(required, granted)
+    M->>R: sliding-window check (token / tenant / write)
+    R-->>M: ok | retryAfter
+    M->>T: SET app.tenant_id = tenantId
+    T->>H: handler(req, ctx)
+    H-->>C: JSON response
+```
+
+If the token is missing or invalid → 401. If the scope is insufficient → 403. If a sliding-window bucket is full → 429 with `Retry-After`. If the handler throws → 500.
+
+## Response envelope
+
+Successful responses return a JSON object that route-specific. Errors follow a consistent two-field envelope:
+
+```json
+{
+  "error": "rate_limit_exceeded",
+  "code": "rate_limited"
+}
+```
+
+`error` is the human-readable label, `code` is a stable machine identifier safe to switch on. The full list of codes lives in the route handlers — common ones include `no_token`, `invalid_token`, `insufficient_scope`, `rate_limited`, `unhandled`.
+
+## HTTP status conventions
+
+| Status | Meaning | When |
+|---|---|---|
+| **200** | Success | Handler completed; body contains the response |
+| **401** | Unauthorized | Missing `Authorization: Bearer`, malformed token, expired, revoked |
+| **403** | Forbidden | Token is valid but the scope does not satisfy what the route requires |
+| **422** | Validation failed | Request body or query params failed Zod validation in the handler |
+| **429** | Rate limit exceeded | One of token / tenant / write sliding-window limits hit; see `Retry-After` |
+| **500** | Internal error | Unhandled exception bubbled up to `withApiAuth` |
+
+## The OpenAPI document
+
+A live OpenAPI 3.1 document is served at `GET /api/openapi.json`. The route itself is wrapped by `withApiAuth('read', ...)` (see [`src/app/api/openapi.json/route.ts`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/app/api/openapi.json/route.ts)), so you need a valid read-scope token to fetch it.
+
+```bash
+curl -H "Authorization: Bearer skl_prod_xxxxxxxxxxxxxxxxxxxxxxxx" \
+     https://your-skillai-host/api/openapi.json
+```
+
+The document includes:
+
+- A `bearerAuth` security scheme keyed on the `skl_<env>_<random>` token format.
+- One operation per registered route, tagged by the URL segment after `/api/`.
+- Per-operation `summary`, `description`, and required scope embedded in the description (`Requires write scope (admin satisfies this)`).
+- `requestBody` and response schemas reflected from Zod via `z.toJSONSchema()` — see `toJsonSchema()` in `src/lib/api/openapi.ts`.
+
+> **💡 Tip**
+>
+> Drop the JSON into Swagger UI, Stoplight, or Insomnia to explore the surface interactively. The schemas are accurate down to the field — they come from the same Zod schemas the runtime uses.
+
+## Next steps
+
+- [Authentication](./authentication.md) — token format, scope inclusion, the mint-and-store recipe.
+- [Rate limiting](./rate-limiting.md) — the sliding-window math, response headers, configuration keys.
+- [Endpoint reference](./endpoints.md) — auto-generated per-endpoint table grouped by module.

--- a/techdocs/rest-api/rate-limiting.md
+++ b/techdocs/rest-api/rate-limiting.md
@@ -1,0 +1,93 @@
+# Rate limiting
+
+_Three independent sliding-window rate limits (per-token, per-tenant, per-write), configurable per tenant via tenant_settings, with response headers and a worked example._
+
+The SkillAI API enforces three independent sliding-window rate limits on every authenticated request — one per token, one per tenant, and one for writes. They live in [`src/lib/api/rate-limit.ts`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/lib/api/rate-limit.ts).
+
+## The three limits
+
+| Limit | Default | What it counts | When it trips |
+|---|---|---|---|
+| **Per token** | 60 req/min | All requests bearing the same `tokenId` | A single integration spamming the API |
+| **Per tenant** | 600 req/min | All requests across every token in the tenant | A team's combined integration footprint |
+| **Per write** | 30 req/min | Requests where `requiredScope !== 'read'` | Burst of state-mutating calls regardless of token |
+
+The three limits run in parallel — a request fails as soon as **any one** of them is exceeded. Each limit is checked *before* the bucket is incremented, so the request that would cross the threshold gets a clean rejection rather than going one over.
+
+## The sliding-window formula
+
+The limiter uses a Cloudflare-style sliding window. For each bucket the counter is stored per UTC minute. The effective count for "the last 60 seconds" is computed as:
+
+```
+effective = prevWindowCount × (1 − elapsedFraction) + currentWindowCount
+```
+
+where `elapsedFraction` is the fraction of the current minute that has already passed. At the start of a fresh minute the previous window contributes its full count; at the end it contributes zero. This smooths out the bucket-boundary cliff you'd get with a naive per-minute counter without needing per-request timestamps.
+
+Storage is in the `api_rate_limits` table, keyed by `(bucket_key, window_start)` with an `ON CONFLICT ... DO UPDATE` increment so multiple in-flight requests can't race past the limit.
+
+## Configuration
+
+Limits are read from `tenant_settings` with a 60-second in-process cache (see `getRateLimitConfig` in [`src/lib/api/rate-limit-config.ts`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/lib/api/rate-limit-config.ts)). The keys:
+
+| Setting key | Default | Description |
+|---|---|---|
+| `mcp.rate_limit.token_per_min` | `60` | Per-token request ceiling per minute |
+| `mcp.rate_limit.tenant_per_min` | `600` | Per-tenant aggregate request ceiling |
+| `mcp.rate_limit.write_per_min` | `30` | Per-tenant write-operation ceiling |
+
+A tenant admin can raise or lower any of the three by writing to `tenant_settings`. Changes take effect on the next cache miss (within 60 seconds).
+
+> **ℹ️ Note**
+>
+> The same three limits are enforced by the MCP server. A write detected in the MCP body (heuristic match on tool name prefixes like `update_`, `create_`, `archive_`) counts against `write_per_min` exactly as a REST write would. See [`src/app/api/mcp/route.ts`](https://github.com/olafkfreund/SkillAi/blob/core-mvp-foundation/src/app/api/mcp/route.ts).
+
+## Response on 429
+
+When any limit trips, the response is HTTP 429 with this body and headers:
+
+```json
+{
+  "error": "rate_limit_exceeded",
+  "code": "rate_limited"
+}
+```
+
+```
+HTTP/1.1 429 Too Many Requests
+Content-Type: application/json
+X-RateLimit-Limit: 60
+X-RateLimit-Remaining: 0
+X-RateLimit-Reset: 1735689660
+Retry-After: 23
+```
+
+- `X-RateLimit-Limit` is the per-token default in the current implementation (always `60`).
+- `X-RateLimit-Remaining` is `0` on a 429 — the bucket is full.
+- `X-RateLimit-Reset` is a UNIX timestamp at which the next minute window starts.
+- `Retry-After` is the number of seconds until that point. Honour this — re-trying earlier just burns more budget and triggers another 429.
+
+Each 429 also writes an `api.rate_limit_exceeded` audit row with `{ limit, retryAfter }` metadata so a tenant admin can correlate spikes to specific tokens.
+
+## Worked example: 50/60 → 61st call
+
+Suppose a token has consumed 50 requests in the current minute and the per-token limit is the default 60.
+
+1. **Calls 51–60** — each request passes the sliding-window check (the current bucket is still under 60), the bucket increments, and the request is served. The 60th call brings the bucket to 60.
+2. **Call 61** — the sliding-window count is **≥** 60 (the check is `tokenSliding >= config.tokenPerMin`, see line 143 of `rate-limit.ts`). The limiter returns `{ ok: false, limit: 'token', retryAfter: N }` where `N` is the seconds left in the current minute. Response is 429 with `Retry-After: N`.
+3. **At the minute boundary** — the previous minute's count gets weighted down by `elapsedFraction` as the new minute progresses. So at exactly the boundary, `effective = 60 × 1.0 + 0 = 60` (still over). One second in, it's `60 × (1 − 1/60) + 0 ≈ 59`. Calls can resume within the first second or two of the new window depending on exact elapsed time.
+4. **Best client behaviour** — wait for `Retry-After`, then continue. Don't poll faster.
+
+## When you hit a write limit specifically
+
+`write_per_min` (default 30) is the most likely to bite real integrations because writes are usually the bursty operation — bulk status updates, batch candidate creates, scoring runs. A 429 on a write counts under `limit: 'write'` in the audit metadata, so you can distinguish "I'm hitting the per-write ceiling" from "I'm hitting the per-token ceiling" by reading the audit log.
+
+If your integration legitimately needs sustained write throughput beyond 30/min, raise `mcp.rate_limit.write_per_min` in tenant settings rather than burning calls against the default.
+
+## Why three independent limits
+
+- **Per-token** isolates noisy integrations — one bad script doesn't starve the rest of the tenant.
+- **Per-tenant** caps the aggregate spend a single customer can impose on the AI backends downstream (Claude / Gemini calls are not free).
+- **Per-write** specifically protects the database and audit log from runaway state churn — reads are cheap, writes generate audit rows and can cascade scoring jobs.
+
+All three need to pass for a request to be served. The first one to fail wins, and the failure reason is surfaced in the audit log so the cause is visible.

--- a/techdocs/roadmap.md
+++ b/techdocs/roadmap.md
@@ -1,0 +1,146 @@
+# Roadmap
+
+_What's shipped, what's open, and what's tracked on GitHub. Phases 1–4 are done; Phase 5 is largely closed; Phase 6 captures the considerable body of work delivered beyond the original v1.0.0 plan._
+
+The canonical, line-by-line roadmap with every shipped PR lives at [`.agent-os/product/roadmap.md`](https://github.com/olafkfreund/SkillAi/blob/main/.agent-os/product/roadmap.md). This page summarises it so the docs reader can get a current picture in one screen and click out for detail.
+
+> **💡 Tip**
+>
+> Status conventions on this page: `shipped` is fully released, `partial` means scope partially delivered with a re-opened tracker, `open` means scoped but not yet started.
+
+## Shipped
+
+### Phase 1 — Foundation & Core MVP `shipped`
+
+End-to-end CV-upload → AI-score → ranked-list flow on Next.js 16 + TypeScript + Drizzle + PostgreSQL + pgvector + Docker. Auth.js v5 with credentials + JWT + RBAC, multi-tenant via PostgreSQL RLS. PDF / DOCX / ODT / TXT / RTF / MD parsing, Claude structured-output scoring, ranked-list UI, single candidate profile, interview question + code test generator, per-tenant API key management, PDF export of candidate / role / shortlist / interview pack.
+
+### Phase 2 — Candidate Archive & Role Library `shipped`
+
+Candidates persist beyond a single hire cycle and roles become reusable templates. Includes the archive with status history, pgvector semantic candidate search ("find similar to X"), role description library, candidate-to-role history, archive filter / sort, and bulk CV upload. Duplicate detection remains deferred — see [Open work](#open-work).
+
+### Phase 3 — Agency Management & Collaboration `shipped`
+
+Recruitment agencies as first-class entities. Agency CRUD, candidate-agency linkage, per-candidate notes, per-agency notes, agency performance view, multi-user collaboration per tenant, candidate status tags across the full pipeline, and a full activity / audit log.
+
+### Phase 4 — Side-by-Side Comparison & UX Polish `shipped`
+
+Shortlist PDF export, dashboard home, per-tenant Gemini model toggle, score explanation modal with full AI reasoning, and the Cmd-K global command palette (closes the deferred keyboard-shortcuts item). Candidate side-by-side comparison tray is the one Phase 4 item still deferred — see [Open work](#open-work).
+
+### Phase 5 — Admin & Operational Hardening `partial`
+
+Audit log, `/api/health` endpoint, CSP headers, session guards, RLS audits, and per-tenant sliding-window rate limiting are all shipped. AI cost tracking shipped via the `ai_usage` ledger plus the `/dashboard/reports` AI spend breakdown.
+
+The **admin panel** remains partial — only the user-invite slice is in. Tenant list / create / archive, role reassignment (admin / recruiter / hiring_manager / viewer), user deactivation / reactivation, force-password-reset, and an admin-scoped audit-log surface are re-opened as Epic [#37](https://github.com/olafkfreund/SkillAi/issues/37). File-storage migration to Garage, backup runbook automation, and HTTPS via Caddy are also still open.
+
+### Phase 6 — Beyond the original roadmap `shipped`
+
+A large body of work delivered mid-flight that wasn't in the original v1.0.0 plan. The headline pieces:
+
+
+### Commercial & placement
+
+Candidate day rates (pay + bill + currency), role customer day rate as budget, real-time margin calculation, soft AI budget signal ([DEC-009](./decisions/dec-009-soft-budget-signal.md)), location + language fields, role deadlines with EXPIRED badge ([DEC-008](./decisions/dec-008-manual-archive.md)), customer portal links.
+
+
+### Internal bench
+
+Per-tenant system "Internal" agency, orthogonal availability enum, derived bench view, INTERNAL badge, bench quick-filter — see [DEC-010](./decisions/dec-010-internal-bench.md).
+
+
+### Hiring Manager persona (Epic #73)
+
+New `hiring_manager` role, `role_managers` junction, `candidate_role_approvals` table, `/dashboard/manager` landing, `audience='manager'` sanitisation extending the recruiter / customer audience pattern, per-candidate Approve / Reject UI, recruiter-side assignment + dispatch controls, four new audit actions, `notes.is_shareable` opt-in.
+
+
+### Customers as first-class entities
+
+Customer CRUD, per-customer hiring frameworks, customer-facing sanitised candidate PDFs, customer-specific role IDs alongside the SkillAI internal role ID, welcome-letter PDF in the candidate's language.
+
+
+### Help & in-app docs (PR #96)
+
+`/dashboard/help` route, 20 articles across 8 categories, audience-tagged front-matter so each persona only sees their relevant content, static markdown loader with Zod-validated front-matter.
+
+
+### Branding & UI polish (PR #97)
+
+Agency + customer logos (PNG / JPEG / WebP, 2 MB cap), consolidated bulk-select column on candidate list, agency logo at 20–32 px across candidate list / role detail / candidate profile / PDF.
+
+
+### Light/dark mode v2 (Epic #103)
+
+`next-themes` + full CSS-var token system. PRs #161–#165 completed the conversion across every page — the v1 caveat about "detail pages stay dark-only" no longer applies.
+
+
+### MCP server (Epic #105)
+
+REST API parity (36 new routes + OpenAPI 3.1 at `/api/openapi.json`), API token system (argon2-hashed, scoped `read` / `write` / `admin`), per-tenant rate limiting, MCP server at `/api/mcp` with 48 tools / 4 resources / 3 prompts, bearer auth, write tools require `confirmed: true`. Cross-platform `skillai-mcp` stdio bridge (Epic #115) shipped via Bun-compiled single-file binaries plus `.deb` / `.rpm` / Nix flake.
+
+
+### GDPR (Epic #72)
+
+Right-to-erasure UI (Article 17) with explicit transactional deletes + audit redaction — see [DEC-011](./decisions/dec-011-gdpr-erasure.md). DSAR export (Article 15) streams a ZIP with 11 JSON files + the original CV + README cover letter.
+
+
+### Reporting & dashboards
+
+`/dashboard/reports` admin-only page with time-to-fill, agency hit-rate (Submission→Hire + Shortlist→Hire), AI cost trend, cycle health, top performers. Per-chart CSV export, date-range presets, three-layer admin gate. AI spend breakdown dashboard (PR #152) and tenant-scoped per-entity CSV exports.
+
+
+### Integrations
+
+Slack + Teams webhook notifications (PR #168), Cmd-K global command palette (PR #170), calendar 2-way sync (PR #133), per-tenant calendar OAuth credentials (PR #134 + #135), admin backups & data export (PRs #136 + #137).
+
+
+### Mobile + PWA (Epic #66)
+
+Sidebar drawer + top app bar + `xs:400` breakpoint, responsive candidate / role / submissions surfaces, responsive forms + modals + tap-target audit, and the PWA capstone with manifest + service worker + install prompt. Lighthouse PWA ≥90.
+
+
+### Submissions + customer share-link
+
+`/dashboard/submissions` index, per-role "sent to customer" tracking, customer-specific role IDs, recruiter email notifications on customer status updates.
+
+Plus AI cost tracking (closes [#36](https://github.com/olafkfreund/SkillAi/issues/36)), dashboard query batching + 6 perf indexes (PR #173), interview transcript analysis ([DEC-007](./decisions/dec-007-manual-transcript-upload.md)), interview slot scheduling with ICS import, in-app help catch-up (PR #172), and a long tail of reliability fixes. For the full PR-by-PR list, see the [canonical roadmap](https://github.com/olafkfreund/SkillAi/blob/main/.agent-os/product/roadmap.md#phase-6-beyond-original-roadmap--shipped).
+
+## Open work
+
+The genuinely-open items from the original v1.0.0 roadmap:
+
+- **Admin panel** `open` — re-opened as Epic [#37](https://github.com/olafkfreund/SkillAi/issues/37) with reduced scope: tenant list / create / archive, role reassignment, user deactivation / reactivation, force-password-reset, admin-scoped audit-log surface. The user-invite slice has already shipped.
+- **File storage migration to Garage** `open` — Phase 5. CVs and logos currently sit on a local Docker named volume. See [DEC-005 — Storage](./decisions/dec-005-storage.md) for the upgrade path.
+- **Backup runbook automation** `open` — Phase 5. Manual `pg_dump` + uploads tar is the current procedure.
+- **HTTPS via Caddy** `open` — Phase 5. Current setups use direct port exposure or a separate reverse proxy.
+- **Candidate side-by-side comparison tray** `open` — Phase 4. Select 2–5 candidates from the role detail view and open them side-by-side. Comparison view exists but the tray-based selection UX is not built yet.
+- **Duplicate candidate detection** `open` — Phase 2. Flag candidates whose CV closely matches an existing profile via vector similarity at upload time.
+
+## Future — tracked on GitHub
+
+Major pending initiatives are tracked as GitHub issues rather than expanded inline here, so progress can be followed alongside implementation commits.
+
+- **Shared folders & cloud storage integration** — tracker issue [#3](https://github.com/olafkfreund/SkillAi/issues/3) with 5 phase issues:
+  - [#4 host folders](https://github.com/olafkfreund/SkillAi/issues/4)
+  - [#5 Google Drive](https://github.com/olafkfreund/SkillAi/issues/5)
+  - [#6 OneDrive](https://github.com/olafkfreund/SkillAi/issues/6)
+  - [#7 SharePoint](https://github.com/olafkfreund/SkillAi/issues/7)
+  - [#8 webhooks](https://github.com/olafkfreund/SkillAi/issues/8)
+
+When new large initiatives are scoped, they follow the same pattern — a tracker issue + phase issues with acceptance criteria — and get linked from the canonical roadmap.
+
+## Recently closed
+
+These were on the open list as recently as a few weeks ago and have now shipped:
+
+- ✅ **AI cost tracking** — closed via [#36](https://github.com/olafkfreund/SkillAi/issues/36).
+- ✅ **Keyboard shortcuts** — closed via the Cmd-K command palette in PR [#170](https://github.com/olafkfreund/SkillAi/pull/170) (closes [#78](https://github.com/olafkfreund/SkillAi/issues/78)).
+- ✅ **Per-tenant rate limiting** — superseded and shipped as part of Epic #105 (REST + MCP entry-point rate limiting via `tenant_settings`). Per-API-cost limits are covered separately by the AI cost tracking ledger.
+
+## Design principles
+
+Every new feature should satisfy at least one of these tests:
+
+1. Does it make the recruiter **faster** at their core job (ranking and shortlisting)?
+2. Does it **reduce data loss** (candidate history, notes, decisions)?
+3. Does it improve **explainability** (why was this candidate ranked here)?
+
+Features that add complexity without satisfying one of these should be deferred. The application should remain deployable with a single `docker compose up` command. No mandatory external services beyond a PostgreSQL database and AI API keys.


### PR DESCRIPTION
## Summary

Annotates SkillAI for **Backstage** and mirrors the public GitHub Pages docs into **TechDocs**, with automated sync.

- **`catalog-info.yaml`** — Component `skillai` (`techdocs-ref: dir:.`), API `skillai-rest-api` (OpenAPI 3.1), API `skillai-mcp`, Resource `skillai-db`; `providesApis` / `dependsOn` relations. All four validated `isValid: true` against the live catalog model.
- **`mkdocs.yml` + `techdocs/`** (72 pages) — TechDocs mirror of the Starlight site (`docs-site/`). Strict `mkdocs build` with `techdocs-core` passes → 73 HTML pages.
- **`scripts/sync-techdocs.mjs`** + `npm run techdocs:sync` — deterministic Starlight MDX → MkDocs transform: callouts/cards/tabs, `/SkillAi/*` link rewriting, and the data-driven MCP tool catalogue rendered from `mcp-catalogue.json`.
- **`.github/workflows/techdocs.yml`** — on doc changes: regenerate (`docs:gen`) + sync, validate via `techdocs-cli build`, **auto-commit** drift on push (loop-safe via `[skip ci]`), **drift-gate** on PRs.

## How the sync works

`docs-site/` (Astro/Starlight → GitHub Pages) stays the single source of truth. The CI job transforms it into MkDocs markdown that Backstage's TechDocs generator consumes via `techdocs-ref: dir:.`, so the IDP docs track the website automatically.

## Test plan

- `npm run techdocs:sync` → 72 pages regenerated deterministically
- `mkdocs build --strict` with `techdocs-core` → exit 0, 73 HTML pages
- Catalog entities validated via Backstage catalog MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)