### PR TITLE
fix(deploy): move uploads PVC to sync-wave 2

### DIFF
--- a/deploy/k8s/pvc-uploads.yaml
+++ b/deploy/k8s/pvc-uploads.yaml
@@ -9,6 +9,13 @@ metadata:
   labels:
     app.kubernetes.io/name: skillai-app
     app.kubernetes.io/part-of: skillai
+  annotations:
+    # Same wave as the app Deployment. local-path is WaitForFirstConsumer, so
+    # this PVC stays Pending until a pod mounts it — keeping it in wave 0 would
+    # deadlock ArgoCD (it waits for the PVC to be Healthy/Bound before creating
+    # the app that would bind it). Applying both together in wave 2 lets the
+    # app pod schedule and bind the volume.
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   accessModes: ["ReadWriteOnce"]
   storageClassName: local-path


### PR DESCRIPTION
`skillai-uploads` uses `local-path` (WaitForFirstConsumer) so it stays `Pending` until a pod mounts it. In sync-wave 0 that deadlocks ArgoCD — it waits for the PVC to be Bound/Healthy before creating the app (wave 2) that would bind it. Move the PVC to wave 2 so it's applied with the app Deployment. Follow-up to #287/#288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)