### PR TITLE
fix(deploy): grant Postgres hugepages-2Mi (fixes initdb SIGBUS on p510)

### DIFF
--- a/deploy/k8s/statefulset-db.yaml
+++ b/deploy/k8s/statefulset-db.yaml
@@ -75,12 +75,20 @@ spec:
             timeoutSeconds: 5
             failureThreshold: 5
           resources:
+            # The p510 node reserves 2Mi huge pages (HugePages_Total=1024) and
+            # Postgres defaults to huge_pages=try. Without a hugepages allocation
+            # the container's hugetlb cgroup limit is 0: MAP_HUGETLB succeeds but
+            # the first page access SIGBUSes ("Bus error" during initdb) and
+            # 'try' never falls back. Granting hugepages-2Mi raises the cgroup
+            # limit so Postgres can actually use them. (See deploy/k8s/README.md.)
             requests:
               cpu: 100m
               memory: 256Mi
+              hugepages-2Mi: 512Mi
             limits:
               cpu: "1"
               memory: 1Gi
+              hugepages-2Mi: 512Mi
       volumes:
         - name: init
           configMap:


### PR DESCRIPTION
The p510 node reserves 1024×2Mi huge pages and Postgres defaults to `huge_pages=try`. With the container's hugetlb cgroup limit at 0, `MAP_HUGETLB` succeeds but the first page access SIGBUSes during initdb (`Bus error (core dumped)`), and `try` never falls back since the mmap itself didn't fail — so `skillai-db-0` CrashLoopBackOffs on first deploy. Requesting `hugepages-2Mi: 512Mi` raises the cgroup limit so Postgres can use them; verified initdb + server start clean in a test pod. Follow-up to #287/#288/#289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)