### PR TITLE
fix(deploy): use :core-mvp-foundation image tag (matches CI)

### DIFF
--- a/deploy/k8s/deployment-app.yaml
+++ b/deploy/k8s/deployment-app.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
         # ── App ───────────────────────────────────────────────────────────
         - name: app
-          image: ghcr.io/olafkfreund/skillai:main
+          image: ghcr.io/olafkfreund/skillai:core-mvp-foundation
           imagePullPolicy: Always
           ports:
             - name: http

--- a/deploy/k8s/job-migrate.yaml
+++ b/deploy/k8s/job-migrate.yaml
@@ -42,7 +42,7 @@ spec:
               done
       containers:
         - name: migrate
-          image: ghcr.io/olafkfreund/skillai-migrator:main
+          image: ghcr.io/olafkfreund/skillai-migrator:core-mvp-foundation
           imagePullPolicy: Always
           envFrom:
             # Provides DATABASE_URL (and the rest of the app env — harmless here).

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -24,6 +24,6 @@ resources:
 # pin to an immutable :<sha> for production rollouts.
 images:
   - name: ghcr.io/olafkfreund/skillai
-    newTag: main
+    newTag: core-mvp-foundation
   - name: ghcr.io/olafkfreund/skillai-migrator
-    newTag: main
+    newTag: core-mvp-foundation


### PR DESCRIPTION
The `deploy-image` workflow tags images by branch name (`GITHUB_REF_NAME` = `core-mvp-foundation`) + commit sha — `:main` is never published, so the migrate/app pods hit `ImagePullBackOff` (`NotFound`). Point the kustomization `images:` and manifests at `:core-mvp-foundation`. Follow-up to #287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)