### PR TITLE
fix(deploy): tailscale sidecar image -> docker.io/tailscale/tailscale:v1.98.4

### DIFF
--- a/deploy/k8s/deployment-app.yaml
+++ b/deploy/k8s/deployment-app.yaml
@@ -78,7 +78,7 @@ spec:
               memory: 1Gi
         # ── Tailscale sidecar (factory-gitops docs/sidecar-pattern.md) ─────
         - name: tailscale
-          image: ghcr.io/tailscale/tailscale:v1.74.0
+          image: docker.io/tailscale/tailscale:v1.98.4
           imagePullPolicy: IfNotPresent
           env:
             - name: TS_AUTHKEY


### PR DESCRIPTION
`ghcr.io/tailscale/tailscale:v1.74.0` (copied from the factory-gitops sidecar docs) does not exist on GHCR — `ImagePullBackOff: not found` (confirmed: anonymous pull 404s). The Tailscale image actually used on the p510 cluster is `docker.io/tailscale/tailscale:v1.98.4` (cached on the node, used by ArgoCD's own sidecar). Point the SkillAi app sidecar at it. The app container itself was already running 1/2; this brings the tailnet exposure up. Follow-up to #287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)