### PR TITLE
fix(deploy): disable tailscale kube-secret state (TS_KUBE_SECRET="")

### DIFF
--- a/deploy/k8s/deployment-app.yaml
+++ b/deploy/k8s/deployment-app.yaml
@@ -92,6 +92,11 @@ spec:
               value: "true"
             - name: TS_STATE_DIR
               value: "/tmp/tsstate"
+            # tailscale v1.98.x defaults to storing state in a Kubernetes Secret
+            # (needs RBAC on a "tailscale" secret). Empty disables that so it uses
+            # the file-based TS_STATE_DIR above — no RBAC needed for the pod SA.
+            - name: TS_KUBE_SECRET
+              value: ""
             - name: TS_EXTRA_ARGS
               value: "--accept-dns=false"
             - name: TS_SERVE_CONFIG


### PR DESCRIPTION
Tailscale v1.98.x defaults to storing `tailscaled` state in a Kubernetes Secret, which needs RBAC (`get`/`update` on secret `tailscale`) that the pod's `default` SA lacks → sidecar `CrashLoopBackOff` (`missing get permission on secret "tailscale"`). Setting `TS_KUBE_SECRET=""` disables kube-secret state so it uses the file-based `TS_STATE_DIR` (userspace) — no RBAC needed. The app container itself is already healthy; this brings the tailnet sidecar up. Follow-up to #292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)