### PR TITLE
fix(auth): suppress password-manager hydration warning on login form

### DIFF
--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -80,6 +80,10 @@ export function LoginForm({ callbackUrl, error }: Props) {
           autoComplete="email"
           required
           disabled={pending}
+          // Password managers (1Password/LastPass/etc.) inject attributes like
+          // data-com-onepassword-filled before React hydrates; suppress the
+          // resulting attribute-mismatch warning on this input.
+          suppressHydrationWarning
           className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
                      placeholder:text-[var(--color-fg-subtle)]
                      focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
@@ -102,6 +106,8 @@ export function LoginForm({ callbackUrl, error }: Props) {
           autoComplete="current-password"
           required
           disabled={pending}
+          // See email input above — suppress password-manager hydration noise.
+          suppressHydrationWarning
           className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-input)] text-[var(--color-fg)] px-3 py-2 text-sm
                      placeholder:text-[var(--color-fg-subtle)]
                      focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent


### PR DESCRIPTION
Password-manager extensions (1Password etc.) inject attributes like `data-com-onepassword-filled` into the login inputs before React hydrates, producing the "A tree hydrated but some attributes…didn't match" console error (call stack points at the extension's `injected.js`). Adds `suppressHydrationWarning` to the email + password inputs — React's documented escape hatch for extension-mutated attributes. No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)