### PR TITLE
ci(deploy): GitOps image promotion so ArgoCD auto-rolls new builds

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -45,11 +45,16 @@ jobs:
   build-push:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # contents: write so the job can commit the pinned image tag back to git
+      # (GitOps image promotion — ArgoCD then auto-syncs the new SHA).
+      contents: write
       packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # full history so the rebase-before-push in the pin step is reliable
+          fetch-depth: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -94,13 +99,42 @@ jobs:
           cache-from: type=gha,scope=skillai-migrator
           cache-to: type=gha,mode=max,scope=skillai-migrator
 
+      # GitOps image promotion: pin the freshly-built immutable SHA tag into
+      # deploy/k8s/kustomization.yaml and commit it back. ArgoCD watches git,
+      # sees the changed tag, and rolls out the new image automatically — no
+      # mutable-tag guessing, no manual `kubectl rollout restart`.
+      #
+      # Loop-safety: this commit only touches deploy/k8s/kustomization.yaml,
+      # which is NOT in this workflow's trigger paths, and it carries [skip ci],
+      # so it cannot retrigger any workflow.
+      - name: Pin image tag in kustomization + commit
+        env:
+          SHA: ${{ steps.tags.outputs.sha }}
+        run: |
+          set -euo pipefail
+          yq -i '(.images[] | select(.name == "ghcr.io/olafkfreund/skillai").newTag) = strenv(SHA)' deploy/k8s/kustomization.yaml
+          yq -i '(.images[] | select(.name == "ghcr.io/olafkfreund/skillai-migrator").newTag) = strenv(SHA)' deploy/k8s/kustomization.yaml
+
+          if git diff --quiet -- deploy/k8s/kustomization.yaml; then
+            echo "kustomization already at ${SHA}; nothing to commit"
+            exit 0
+          fi
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add deploy/k8s/kustomization.yaml
+          git commit -m "chore(deploy): pin image to ${SHA} [skip ci]"
+          # rebase onto any concurrent pushes before pushing back
+          git pull --rebase --autostash origin "${GITHUB_REF_NAME}"
+          git push origin "HEAD:${GITHUB_REF_NAME}"
+
       - name: Summary
         run: |
           {
-            echo "### Images pushed"
+            echo "### Images pushed & pinned"
             echo ""
-            echo "- \`${IMAGE_APP}:${{ steps.tags.outputs.branch }}\` / \`:${{ steps.tags.outputs.sha }}\`"
-            echo "- \`${IMAGE_MIGRATOR}:${{ steps.tags.outputs.branch }}\` / \`:${{ steps.tags.outputs.sha }}\`"
+            echo "- \`${IMAGE_APP}:${{ steps.tags.outputs.sha }}\` (+ \`:${{ steps.tags.outputs.branch }}\`)"
+            echo "- \`${IMAGE_MIGRATOR}:${{ steps.tags.outputs.sha }}\` (+ \`:${{ steps.tags.outputs.branch }}\`)"
             echo ""
-            echo "Bump \`deploy/k8s/kustomization.yaml\` images to \`:${{ steps.tags.outputs.sha }}\` for a pinned rollout."
+            echo "Pinned \`deploy/k8s/kustomization.yaml\` → \`:${{ steps.tags.outputs.sha }}\`; ArgoCD will sync the rollout."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs-site/src/content/docs/operations/k3d-p510-deploy.mdx
+++ b/docs-site/src/content/docs/operations/k3d-p510-deploy.mdx
@@ -104,10 +104,16 @@ Built + pushed to GHCR by `.github/workflows/deploy-image.yml`:
 - `ghcr.io/olafkfreund/skillai` — the app (Dockerfile `runner` target)
 - `ghcr.io/olafkfreund/skillai-migrator` — drizzle migrations (`migrator` target)
 
-Tagged by branch (`core-mvp-foundation`) + commit SHA; the packages are public.
-The deployed tag is set in `deploy/k8s/kustomization.yaml`. Because the branch tag
-is mutable and `imagePullPolicy: Always`, a `kubectl rollout restart deploy/skillai-app`
-pulls the latest build; pin a `:<sha>` for reproducible rollouts.
+Each build is tagged with the immutable commit `:<sha>` (plus the mutable
+`:core-mvp-foundation` pointer); the packages are public.
+
+**GitOps image promotion** — after pushing, the same workflow writes the new
+`:<sha>` into `deploy/k8s/kustomization.yaml` (`images[].newTag`) and commits it
+back to `core-mvp-foundation` (`[skip ci]`). ArgoCD sees the changed tag in git
+and rolls out the new image **automatically** — no manual `kubectl rollout
+restart`, and every deployed revision is pinned to an exact commit. The commit
+touches only `kustomization.yaml` (outside the workflow's trigger paths), so it
+can't loop.
 
 ## Secrets
 
@@ -156,7 +162,9 @@ curl https://skillai.freundcloud.org.uk/api/health
 kubectl -n factory get pods -l app.kubernetes.io/part-of=skillai
 kubectl -n argocd get application skillai
 
-# ship a new image build
+# shipping a new build is automatic: push to core-mvp-foundation → CI builds,
+# pins the :<sha> in kustomization.yaml, ArgoCD rolls it out. Manual restart is
+# only a fallback:
 kubectl -n factory rollout restart deploy/skillai-app
 
 # tunnel origin errors (502 → origin unreachable)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,98 +1,19 @@
+# mkdocs.yml — Backstage TechDocs configuration for SkillAI.
+#
+# GENERATED FILE — do not edit by hand. Regenerate with: npm run techdocs:sync
+# The nav + page content mirror the public GitHub Pages site (docs-site/).
+# Backstage builds this via the TechDocs generator (techdocs-ref: dir:. in
+# catalog-info.yaml), which runs `mkdocs build` against this repo.
+
 site_name: SkillAI
-site_description: >-
-  Internal AI-powered recruiting portal — ranks candidates fast, archives them
-  forever, integrates with Claude.
+site_description: Internal AI-powered recruiting portal — ranks candidates fast, archives them forever, integrates with Claude.
+docs_dir: techdocs
 repo_url: https://github.com/olafkfreund/SkillAi
 edit_uri: edit/core-mvp-foundation/docs-site/src/content/docs/
-docs_dir: techdocs
-nav:
-  - Home: index.md
-  - Overview:
-      - What is SkillAI: overview/what-is-skillai.md
-      - Product tour: overview/product-tour.md
-      - Live demo: overview/live-demo.md
-  - Getting started:
-      - Quick start: getting-started/quick-start.md
-      - Development workflow: getting-started/development.md
-  - Architecture:
-      - System overview: architecture/system-overview.md
-      - Tech stack: architecture/tech-stack.md
-      - Multi-tenancy & RLS: architecture/multi-tenancy-rls.md
-      - AI scoring pipeline: architecture/ai-scoring-pipeline.md
-      - File storage: architecture/file-storage.md
-      - Performance baselines: architecture/performance.md
-  - REST API:
-      - Overview: rest-api/overview.md
-      - Authentication: rest-api/authentication.md
-      - Rate limiting: rest-api/rate-limiting.md
-      - Endpoint reference: rest-api/endpoints.md
-  - MCP server:
-      - Overview: mcp-server/overview.md
-      - Connecting from Claude Code: mcp-server/connecting.md
-      - Tool catalogue: mcp-server/tools.md
-      - Resources: mcp-server/resources.md
-      - Prompts: mcp-server/prompts.md
-  - Database:
-      - Table reference:
-          - agencies: database/tables/agencies.md
-          - ai usage: database/tables/ai-usage.md
-          - api tokens: database/tables/api-tokens.md
-          - audit logs: database/tables/audit-logs.md
-          - calendar connections: database/tables/calendar-connections.md
-          - candidate enrichments: database/tables/candidate-enrichments.md
-          - candidate role approvals: database/tables/candidate-role-approvals.md
-          - candidates: database/tables/candidates.md
-          - code challenges: database/tables/code-challenges.md
-          - customer frameworks: database/tables/customer-frameworks.md
-          - customers: database/tables/customers.md
-          - cv profiles: database/tables/cv-profiles.md
-          - email templates: database/tables/email-templates.md
-          - interview packs: database/tables/interview-packs.md
-          - interview questions: database/tables/interview-questions.md
-          - interview slots: database/tables/interview-slots.md
-          - interview transcripts: database/tables/interview-transcripts.md
-          - notes: database/tables/notes.md
-          - role managers: database/tables/role-managers.md
-          - role submissions: database/tables/role-submissions.md
-          - roles: database/tables/roles.md
-          - scores: database/tables/scores.md
-          - sent emails: database/tables/sent-emails.md
-          - tenant settings: database/tables/tenant-settings.md
-          - tenants: database/tables/tenants.md
-          - transcript analyses: database/tables/transcript-analyses.md
-          - user invitations: database/tables/user-invitations.md
-          - users: database/tables/users.md
-      - Schema overview: database/overview.md
-  - Code patterns:
-      - Agency logo: code-patterns/agency-logo.md
-      - Audience sanitisation: code-patterns/audience-sanitisation.md
-      - Force dynamic: code-patterns/force-dynamic.md
-      - Help content: code-patterns/help-content.md
-      - Logo upload: code-patterns/logo-upload.md
-      - Theme tokens: code-patterns/theme-tokens.md
-  - Operations:
-      - Kubernetes (k3d @ p510): operations/k3d-p510-deploy.md
-      - AWS deployment: operations/aws-deploy.md
-      - Backup & recovery: operations/backup-runbook.md
-      - Health & monitoring: operations/health-monitoring.md
-  - Design decisions:
-      - Index: decisions/index.md
-      - DEC-001 — Build vs buy: decisions/dec-001-build-vs-buy.md
-      - DEC-002 — Drizzle over Prisma: decisions/dec-002-drizzle-over-prisma.md
-      - DEC-003 — Row-Level Security: decisions/dec-003-row-level-security.md
-      - DEC-004 — Claude as primary AI: decisions/dec-004-claude-primary.md
-      - DEC-005 — Local storage + Garage: decisions/dec-005-storage.md
-      - DEC-006 — Auth.js over Clerk: decisions/dec-006-authjs-over-clerk.md
-      - DEC-007 — Manual transcript upload: decisions/dec-007-manual-transcript-upload.md
-      - DEC-008 — Manual archive on expiry: decisions/dec-008-manual-archive.md
-      - DEC-009 — Soft budget signal: decisions/dec-009-soft-budget-signal.md
-      - DEC-010 — Internal bench model: decisions/dec-010-internal-bench.md
-      - DEC-011 — GDPR erasure pattern: decisions/dec-011-gdpr-erasure.md
-  - Roadmap: roadmap.md
+
 theme:
   name: material
-plugins:
-  - techdocs-core
+
 markdown_extensions:
   - admonition
   - pymdownx.details
@@ -100,3 +21,91 @@ markdown_extensions:
   - tables
   - toc:
       permalink: true
+
+plugins:
+  - techdocs-core
+
+nav:
+  - Home: index.md
+  - Overview:
+    - What is SkillAI: overview/what-is-skillai.md
+    - Product tour: overview/product-tour.md
+    - Live demo: overview/live-demo.md
+  - Getting started:
+    - Quick start: getting-started/quick-start.md
+    - Development workflow: getting-started/development.md
+  - Architecture:
+    - System overview: architecture/system-overview.md
+    - Tech stack: architecture/tech-stack.md
+    - Multi-tenancy & RLS: architecture/multi-tenancy-rls.md
+    - AI scoring pipeline: architecture/ai-scoring-pipeline.md
+    - File storage: architecture/file-storage.md
+    - Performance baselines: architecture/performance.md
+  - REST API:
+    - Overview: rest-api/overview.md
+    - Authentication: rest-api/authentication.md
+    - Rate limiting: rest-api/rate-limiting.md
+    - Endpoint reference: rest-api/endpoints.md
+  - MCP server:
+    - Overview: mcp-server/overview.md
+    - Connecting from Claude Code: mcp-server/connecting.md
+    - Tool catalogue: mcp-server/tools.md
+    - Resources: mcp-server/resources.md
+    - Prompts: mcp-server/prompts.md
+  - Database:
+    - Table reference:
+      - agencies: database/tables/agencies.md
+      - ai usage: database/tables/ai-usage.md
+      - api tokens: database/tables/api-tokens.md
+      - audit logs: database/tables/audit-logs.md
+      - calendar connections: database/tables/calendar-connections.md
+      - candidate enrichments: database/tables/candidate-enrichments.md
+      - candidate role approvals: database/tables/candidate-role-approvals.md
+      - candidates: database/tables/candidates.md
+      - code challenges: database/tables/code-challenges.md
+      - customer frameworks: database/tables/customer-frameworks.md
+      - customers: database/tables/customers.md
+      - cv profiles: database/tables/cv-profiles.md
+      - email templates: database/tables/email-templates.md
+      - interview packs: database/tables/interview-packs.md
+      - interview questions: database/tables/interview-questions.md
+      - interview slots: database/tables/interview-slots.md
+      - interview transcripts: database/tables/interview-transcripts.md
+      - notes: database/tables/notes.md
+      - role managers: database/tables/role-managers.md
+      - role submissions: database/tables/role-submissions.md
+      - roles: database/tables/roles.md
+      - scores: database/tables/scores.md
+      - sent emails: database/tables/sent-emails.md
+      - tenant settings: database/tables/tenant-settings.md
+      - tenants: database/tables/tenants.md
+      - transcript analyses: database/tables/transcript-analyses.md
+      - user invitations: database/tables/user-invitations.md
+      - users: database/tables/users.md
+    - Schema overview: database/overview.md
+  - Code patterns:
+    - Agency logo: code-patterns/agency-logo.md
+    - Audience sanitisation: code-patterns/audience-sanitisation.md
+    - Force dynamic: code-patterns/force-dynamic.md
+    - Help content: code-patterns/help-content.md
+    - Logo upload: code-patterns/logo-upload.md
+    - Theme tokens: code-patterns/theme-tokens.md
+  - Operations:
+    - Kubernetes (k3d @ p510): operations/k3d-p510-deploy.md
+    - AWS deployment: operations/aws-deploy.md
+    - Backup & recovery: operations/backup-runbook.md
+    - Health & monitoring: operations/health-monitoring.md
+  - Design decisions:
+    - Index: decisions/index.md
+    - DEC-001 — Build vs buy: decisions/dec-001-build-vs-buy.md
+    - DEC-002 — Drizzle over Prisma: decisions/dec-002-drizzle-over-prisma.md
+    - DEC-003 — Row-Level Security: decisions/dec-003-row-level-security.md
+    - DEC-004 — Claude as primary AI: decisions/dec-004-claude-primary.md
+    - DEC-005 — Local storage + Garage: decisions/dec-005-storage.md
+    - DEC-006 — Auth.js over Clerk: decisions/dec-006-authjs-over-clerk.md
+    - DEC-007 — Manual transcript upload: decisions/dec-007-manual-transcript-upload.md
+    - DEC-008 — Manual archive on expiry: decisions/dec-008-manual-archive.md
+    - DEC-009 — Soft budget signal: decisions/dec-009-soft-budget-signal.md
+    - DEC-010 — Internal bench model: decisions/dec-010-internal-bench.md
+    - DEC-011 — GDPR erasure pattern: decisions/dec-011-gdpr-erasure.md
+  - Roadmap: roadmap.md

--- a/techdocs/operations/k3d-p510-deploy.md
+++ b/techdocs/operations/k3d-p510-deploy.md
@@ -101,10 +101,16 @@ Built + pushed to GHCR by `.github/workflows/deploy-image.yml`:
 - `ghcr.io/olafkfreund/skillai` — the app (Dockerfile `runner` target)
 - `ghcr.io/olafkfreund/skillai-migrator` — drizzle migrations (`migrator` target)
 
-Tagged by branch (`core-mvp-foundation`) + commit SHA; the packages are public.
-The deployed tag is set in `deploy/k8s/kustomization.yaml`. Because the branch tag
-is mutable and `imagePullPolicy: Always`, a `kubectl rollout restart deploy/skillai-app`
-pulls the latest build; pin a `:<sha>` for reproducible rollouts.
+Each build is tagged with the immutable commit `:<sha>` (plus the mutable
+`:core-mvp-foundation` pointer); the packages are public.
+
+**GitOps image promotion** — after pushing, the same workflow writes the new
+`:<sha>` into `deploy/k8s/kustomization.yaml` (`images[].newTag`) and commits it
+back to `core-mvp-foundation` (`[skip ci]`). ArgoCD sees the changed tag in git
+and rolls out the new image **automatically** — no manual `kubectl rollout
+restart`, and every deployed revision is pinned to an exact commit. The commit
+touches only `kustomization.yaml` (outside the workflow's trigger paths), so it
+can't loop.
 
 ## Secrets
 
@@ -153,7 +159,9 @@ curl https://skillai.freundcloud.org.uk/api/health
 kubectl -n factory get pods -l app.kubernetes.io/part-of=skillai
 kubectl -n argocd get application skillai
 
-# ship a new image build
+# shipping a new build is automatic: push to core-mvp-foundation → CI builds,
+# pins the :<sha> in kustomization.yaml, ArgoCD rolls it out. Manual restart is
+# only a fallback:
 kubectl -n factory rollout restart deploy/skillai-app
 
 # tunnel origin errors (502 → origin unreachable)


### PR DESCRIPTION
## Problem
`deploy-image.yml` pushed images to the **mutable** `:core-mvp-foundation` tag, but the git manifest never changed — so ArgoCD saw no diff and **never deployed new builds**. New images only went live after a manual `kubectl rollout restart`.

## Fix — GitOps image promotion
After building+pushing, the workflow now:
1. Pins the freshly-built **immutable `:<sha>`** into `deploy/k8s/kustomization.yaml` (`images[].newTag`, via `yq`).
2. Commits it back to `core-mvp-foundation` (`[skip ci]`, `contents: write`, rebase-before-push).

ArgoCD watches git → sees the changed tag → **rolls out automatically**. Every deployed revision is pinned to an exact commit (reproducible). The commit touches only `kustomization.yaml` — outside the workflow's trigger paths and `[skip ci]` — so it can't loop. (This mirrors the existing auto-commit pattern in `techdocs.yml`.)

Docs (`operations/k3d-p510-deploy` TechDocs page) updated to describe the auto-promotion flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)