### PR TITLE
ops(#216): base-branch commit guard + agent worktree recovery runbook

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,21 @@
+# Git hooks (`.githooks/`)
+
+Committed, opt-in git hooks for this repo. They are **not** active until you point
+git at this directory:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Run that once per clone / checkout. CI does not need it (the hooks no-op when `CI`
+or `GITHUB_ACTIONS` is set).
+
+## Hooks
+
+| Hook | Purpose |
+|---|---|
+| `pre-commit` | **Base-branch commit guard** (issue #216). Refuses a commit made directly on `core-mvp-foundation`, the protected base branch. Feature work and background agents must commit on their own branch / worktree. Override a deliberate base commit with `ALLOW_BASE_COMMIT=1 git commit …`. |
+
+See [`docs/agent-worktree-recovery.md`](../docs/agent-worktree-recovery.md) for the
+background, the failure modes this prevents, and the recovery procedure when an
+agent has already contaminated the main checkout.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,51 @@
+#!/bin/sh
+# SkillAI base-branch commit guard  (issue #216)
+#
+# Refuses a commit made directly on the protected base branch
+# `core-mvp-foundation` in a working checkout, which is almost always a
+# background agent that meant to be on a feature branch / worktree but is
+# actually sitting in the main checkout. Accidental commits there corrupt the
+# shared dev server (wrong branch, stale .next, root-owned cache).
+#
+# Opt out for a deliberate base-branch commit:
+#     ALLOW_BASE_COMMIT=1 git commit ...
+#
+# This hook is intentionally dependency-free POSIX sh, fast, and a no-op in CI.
+#
+# Enable it once per checkout (it is NOT active until you point git at it):
+#     git config core.hooksPath .githooks
+# See docs/agent-worktree-recovery.md for the full rationale + recovery steps.
+
+# Never block automation in CI.
+if [ -n "$CI" ] || [ -n "$GITHUB_ACTIONS" ]; then
+  exit 0
+fi
+
+# Explicit opt-out for an intentional base-branch commit.
+if [ "$ALLOW_BASE_COMMIT" = "1" ]; then
+  exit 0
+fi
+
+PROTECTED_BRANCH="core-mvp-foundation"
+
+# Resolve the current branch; tolerate detached HEAD (symbolic-ref fails -> allow).
+current_branch=$(git symbolic-ref --short -q HEAD) || exit 0
+
+if [ "$current_branch" = "$PROTECTED_BRANCH" ]; then
+  echo "" >&2
+  echo "✋ pre-commit blocked: you are committing directly on '$PROTECTED_BRANCH'." >&2
+  echo "" >&2
+  echo "   This is the protected base branch. Background agents and feature work" >&2
+  echo "   must commit on their own branch / worktree, not the main checkout." >&2
+  echo "   (See issue #216 — base-branch commits corrupt the shared dev server.)" >&2
+  echo "" >&2
+  echo "   Fix: move your work to a feature branch, e.g." >&2
+  echo "       git switch -c feat/my-change" >&2
+  echo "" >&2
+  echo "   If this commit on the base branch is genuinely intended, re-run with:" >&2
+  echo "       ALLOW_BASE_COMMIT=1 git commit ..." >&2
+  echo "" >&2
+  exit 1
+fi
+
+exit 0

--- a/docs/agent-worktree-recovery.md
+++ b/docs/agent-worktree-recovery.md
@@ -1,0 +1,96 @@
+# Agent worktree recovery & isolation runbook
+
+> Recovering from — and preventing — background-agent contamination of the main
+> checkout. Tracking issue: [#216](https://github.com/olafkfreund/SkillAi/issues/216).
+
+## What goes wrong
+
+Background agents are supposed to operate in an isolated git worktree
+(`.claude/worktrees/agent-<id>/`). In practice an agent's shell `cwd` can default
+to the **main checkout** (`/home/olafkfreund/Source/GitHub/SkillAi`), so any
+`git checkout`, `npm`, or `docker` command without an explicit `cd` lands in the
+shared checkout instead of the worktree. This has caused repeated dev-portal
+outages:
+
+- An in-progress (non-`async`) export left in `settings.ts` — Next.js `'use server'`
+  rejects it and the portal breaks until hand-fixed.
+- Multiple agents writing rapidly into the main checkout corrupt the
+  bind-mounted `.next/dev/` cache.
+- An agent running `npm run build` inside the main checkout leaves a **root-owned**
+  stale `.next/` (container UID writes vs host UID), after which Next.js dev throws
+  `ENOENT` for `build-manifest.json` on every request.
+
+## Symptoms
+
+- `git branch --show-current` in the main checkout shows a `feat/…` branch instead
+  of `core-mvp-foundation`.
+- Untracked / modified files in `git status` that match an in-flight agent's scope.
+- The dev portal returns `ENOENT` manifest errors after a flurry of file changes.
+- `.next/dev/` contains root-owned files.
+
+## Recovery procedure
+
+Run these in the **main checkout** (`/home/olafkfreund/Source/GitHub/SkillAi`).
+
+1. **Confirm the damage.**
+
+   ```bash
+   git -C /home/olafkfreund/Source/GitHub/SkillAi status
+   git -C /home/olafkfreund/Source/GitHub/SkillAi branch --show-current
+   ```
+
+2. **Rescue anything you want to keep.** If the stray changes are real work,
+   move them to a branch before resetting:
+
+   ```bash
+   git -C /home/olafkfreund/Source/GitHub/SkillAi switch -c rescue/agent-stray-$(date +%s)
+   git -C /home/olafkfreund/Source/GitHub/SkillAi add -A && git commit -m "rescue: stray agent changes"
+   ```
+
+   Otherwise skip to step 3 to discard them.
+
+3. **Reset the main checkout to the clean base.**
+
+   ```bash
+   git -C /home/olafkfreund/Source/GitHub/SkillAi fetch origin
+   git -C /home/olafkfreund/Source/GitHub/SkillAi switch core-mvp-foundation
+   git -C /home/olafkfreund/Source/GitHub/SkillAi reset --hard origin/core-mvp-foundation
+   git -C /home/olafkfreund/Source/GitHub/SkillAi clean -fd   # removes untracked files — review first
+   ```
+
+4. **Fix root-owned `.next` ownership** (only if the cache went root-owned). From
+   the host:
+
+   ```bash
+   sudo chown -R "$(id -u):$(id -g)" /home/olafkfreund/Source/GitHub/SkillAi/.next
+   # or just remove it; Next rebuilds on next start
+   rm -rf /home/olafkfreund/Source/GitHub/SkillAi/.next
+   ```
+
+5. **Restart the dev container** to clear the in-memory build manifest:
+
+   ```bash
+   docker compose restart app
+   ```
+
+6. **Verify recovery.** The portal should serve again; `git status` should be clean
+   on `core-mvp-foundation`.
+
+## How to avoid this
+
+- **Always run agents with worktree isolation** (`isolation: "worktree"`), and have
+  each agent **`cd` into its worktree first** — never run `git` / `npm` / `docker`
+  from the main checkout.
+- **Branch from `origin/core-mvp-foundation` explicitly** inside the worktree so the
+  base is correct regardless of where the shell started.
+- **Never run a dev server or `docker` from a worktree** — build / typecheck only.
+  The dev server belongs to the main checkout alone.
+- **Enable the base-branch commit guard** so an accidental commit on the protected
+  branch is rejected before it lands:
+
+  ```bash
+  git config core.hooksPath .githooks
+  ```
+
+  See [`.githooks/README.md`](../.githooks/README.md). Override a deliberate base
+  commit with `ALLOW_BASE_COMMIT=1 git commit …`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -177,6 +177,7 @@ See [`docs/mcp-tools.md`](docs/mcp-tools.md) for the full tool / resource / prom
 - [Architecture](docs/architecture.md)
 - [Development Guide](docs/development.md)
 - [Roadmap](docs/roadmap.md)
+- [Agent Worktree Recovery](docs/agent-worktree-recovery.md)
 
 ---
 


### PR DESCRIPTION
## What

Repo-level mitigations for **#216** — background agents repeatedly committing into the main checkout on a non-`core-mvp-foundation` branch, corrupting the shared dev server (wrong branch, stale/root-owned `.next`, ENOENT manifest errors). Harness-level fixes are out of scope; this delivers the two repo-level items from the issue.

### 1. `.githooks/pre-commit` — base-branch commit guard
- Dependency-free POSIX `sh`. Refuses a commit made directly on the protected base branch `core-mvp-foundation`.
- **No-op in CI** (`CI` / `GITHUB_ACTIONS`).
- **Override** a deliberate base commit: `ALLOW_BASE_COMMIT=1 git commit …`.
- **Opt-in per checkout** (not forced on anyone): `git config core.hooksPath .githooks`. Documented in `.githooks/README.md` and the runbook — I deliberately did **not** mutate the repo's shared `core.hooksPath`.
- Tolerates detached HEAD (allows).

### 2. `docs/agent-worktree-recovery.md` — recovery runbook
- Symptoms (wrong branch in main checkout, ENOENT manifest errors, root-owned `.next/dev/`).
- Step-by-step recovery: rescue stray work → `reset --hard origin/core-mvp-foundation` → fix root-owned `.next` → `docker compose restart app` → verify.
- "How to avoid" section: always isolate in a worktree, `cd` into it, branch from `origin/core-mvp-foundation`, never run npm/docker from the main checkout, enable the guard hook.

Plus `.githooks/README.md` and a link from `docs/index.md`.

## Verified
Invoked the hook directly across all paths (without mutating shared git config):
- ✅ feature branch → exit 0 (normal commits unaffected)
- ✅ base branch → exit 1 with a clear, actionable message
- ✅ `ALLOW_BASE_COMMIT=1` on base branch → exit 0
- ✅ `CI=1` → exit 0

No app code touched; no build required.

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GpmSnQ7nL6sTdjgWRGvkDw