### PR TITLE
feat(skills): candidate filter + nav + help doc; wire existing Skills page (#273, #274)

### DIFF
--- a/src/app/(dashboard)/dashboard/candidates/page.tsx
+++ b/src/app/(dashboard)/dashboard/candidates/page.tsx
@@ -22,6 +22,7 @@ interface PageProps {
     availability?: string
     page?: string
     missingCv?: string
+    skills?: string
   }>
 }
 
@@ -29,10 +30,18 @@ export default async function CandidatesPage({ searchParams }: PageProps) {
   const session = await auth()
   const tenantId = session?.user.tenantId
 
-  const { q, status, agencyId, availability, page: pageParam, missingCv: missingCvParam } = await searchParams
+  const { q, status, agencyId, availability, page: pageParam, missingCv: missingCvParam, skills: skillsParam } = await searchParams
   const page = Math.max(1, parseInt(pageParam ?? '1', 10) || 1)
   const offset = (page - 1) * PAGE_SIZE
   const missingCvFilter = missingCvParam === '1'
+
+  // Skills filter (from the Skills Explorer): comma-separated, case-insensitive,
+  // ANDed (a candidate must have ALL listed skills). Next has already URL-decoded
+  // the value, so we only split + trim here.
+  const skillsFilter = (skillsParam ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
 
   // Validate status is a known enum value
   const validStatuses: CandidateStatus[] = [
@@ -77,6 +86,23 @@ export default async function CandidatesPage({ searchParams }: PageProps) {
 
     if (missingCvFilter) {
       conditions.push(isNull(candidates.filePath))
+    }
+
+    // One EXISTS per skill so multiple skills AND together. The cv_profiles
+    // subquery is tenant-scoped automatically by RLS (app.tenant_id) inside
+    // withTenant. Skill values are bound params — never interpolated.
+    for (const skill of skillsFilter) {
+      conditions.push(
+        sql`EXISTS (
+          SELECT 1 FROM cv_profiles cp
+          WHERE cp.candidate_id = ${candidates.id}
+            AND cp.extraction_status = 'complete'
+            AND EXISTS (
+              SELECT 1 FROM jsonb_array_elements_text(cp.technical_skills) AS s
+              WHERE lower(trim(s)) = lower(trim(${skill}))
+            )
+        )`
+      )
     }
 
     return and(...conditions)
@@ -162,7 +188,7 @@ export default async function CandidatesPage({ searchParams }: PageProps) {
   const rangeFrom = totalCount === 0 ? 0 : offset + 1
   const rangeTo = Math.min(offset + PAGE_SIZE, totalCount)
 
-  const currentFilters = { q, status, agencyId, availability, missingCv: missingCvFilter }
+  const currentFilters = { q, status, agencyId, availability, missingCv: missingCvFilter, skills: skillsFilter }
 
   // Build pagination URL helper
   const buildPageUrl = (p: number) => {
@@ -172,6 +198,7 @@ export default async function CandidatesPage({ searchParams }: PageProps) {
     if (agencyId) params.set('agencyId', agencyId)
     if (availability) params.set('availability', availability)
     if (missingCvFilter) params.set('missingCv', '1')
+    if (skillsFilter.length) params.set('skills', skillsFilter.join(','))
     params.set('page', String(p))
     return `?${params.toString()}`
   }
@@ -224,7 +251,7 @@ export default async function CandidatesPage({ searchParams }: PageProps) {
         <div className="flex flex-col items-center justify-center rounded-xl border-2 border-dashed
                         border-[var(--color-border)] bg-[var(--color-bg-app)] px-6 py-16 text-center">
           <UsersIcon className="h-10 w-10 text-[var(--color-fg-subtle)] mb-3" />
-          {totalCount === 0 && !q && !status && !agencyId && !availability && !missingCvFilter ? (
+          {totalCount === 0 && !q && !status && !agencyId && !availability && !missingCvFilter && skillsFilter.length === 0 ? (
             <>
               <p className="text-[var(--color-fg-muted)] font-medium">No candidates yet</p>
               <p className="text-[var(--color-fg-subtle)] text-sm mt-1">

--- a/src/components/candidates/candidate-filters.tsx
+++ b/src/components/candidates/candidate-filters.tsx
@@ -6,7 +6,7 @@ import { SearchIcon, XIcon, FileXIcon } from 'lucide-react'
 
 type Props = {
   agencies: { id: string; name: string }[]
-  currentFilters: { q?: string; status?: string; agencyId?: string; availability?: string; missingCv?: boolean }
+  currentFilters: { q?: string; status?: string; agencyId?: string; availability?: string; missingCv?: boolean; skills?: string[] }
 }
 
 const STATUS_OPTIONS = [
@@ -47,6 +47,7 @@ export function CandidateFilters({ agencies, currentFilters }: Props) {
       if (currentFilters.agencyId) params.set('agencyId', currentFilters.agencyId)
       if (currentFilters.availability) params.set('availability', currentFilters.availability)
       if (currentFilters.missingCv) params.set('missingCv', '1')
+      if (currentFilters.skills?.length) params.set('skills', currentFilters.skills.join(','))
       // Reset page on any filter change
       params.delete('page')
 
@@ -89,12 +90,18 @@ export function CandidateFilters({ agencies, currentFilters }: Props) {
     updateParams({ availability: value })
   }
 
+  const removeSkill = (skill: string) => {
+    const remaining = (currentFilters.skills ?? []).filter((s) => s !== skill)
+    updateParams({ skills: remaining.join(',') })
+  }
+
   const hasActiveFilters =
     !!currentFilters.q ||
     !!currentFilters.status ||
     !!currentFilters.agencyId ||
     !!currentFilters.availability ||
-    !!currentFilters.missingCv
+    !!currentFilters.missingCv ||
+    (currentFilters.skills?.length ?? 0) > 0
 
   const clearFilters = () => {
     setSearchValue('')
@@ -104,8 +111,31 @@ export function CandidateFilters({ agencies, currentFilters }: Props) {
   }
 
   return (
-    <div className="flex flex-col gap-3
-                    sm:flex-row sm:items-center sm:flex-wrap">
+    <div className="flex flex-col gap-3">
+      {/* Active skill chips (from the Skills Explorer) */}
+      {(currentFilters.skills?.length ?? 0) > 0 && (
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs text-[var(--color-fg-subtle)]">Skills:</span>
+          {currentFilters.skills!.map((skill) => (
+            <button
+              key={skill}
+              onClick={() => removeSkill(skill)}
+              className="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium
+                         bg-blue-100 dark:bg-blue-950 text-blue-700 dark:text-blue-300
+                         border border-blue-300 dark:border-blue-800
+                         hover:bg-blue-200 dark:hover:bg-blue-900 transition-colors"
+              aria-label={`Remove skill filter ${skill}`}
+            >
+              {skill}
+              <XIcon className="h-3 w-3 opacity-70" aria-hidden="true" />
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Filter controls */}
+      <div className="flex flex-col gap-3
+                      sm:flex-row sm:items-center sm:flex-wrap">
       {/* Search input */}
       <div className="relative flex-1 min-w-0
                       sm:min-w-[240px] sm:max-w-sm">
@@ -207,6 +237,7 @@ export function CandidateFilters({ agencies, currentFilters }: Props) {
           Clear
         </button>
       )}
+      </div>
     </div>
   )
 }

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -15,6 +15,7 @@ import {
   HelpCircleIcon,
   BarChart3Icon,
   SendIcon,
+  SparklesIcon,
 } from 'lucide-react'
 import type { UserRole } from '@/lib/auth/types'
 import { ThemeToggle } from '@/components/theme/theme-toggle'
@@ -52,6 +53,13 @@ export const NAV_ITEMS: NavItem[] = [
     label: 'Candidates',
     icon: UsersIcon,
     minRole: 'viewer',
+    hideForRoles: ['hiring_manager'],
+  },
+  {
+    href: '/dashboard/skills',
+    label: 'Skills',
+    icon: SparklesIcon,
+    minRole: 'recruiter',
     hideForRoles: ['hiring_manager'],
   },
   {

--- a/src/content/help/auto-match-and-skills.md
+++ b/src/content/help/auto-match-and-skills.md
@@ -1,0 +1,71 @@
+---
+title: "Auto-match & Skills Explorer"
+category: "Roles & Candidates"
+audience: ["recruiter", "admin"]
+order: 15
+lastUpdated: "2026-06-20"
+tags: ["auto-match", "skills", "archive", "matching", "shortlist", "availability", "budget"]
+---
+
+# Auto-match & Skills Explorer
+
+Two features help you reuse your candidate archive instead of starting every role from scratch: **auto-match** surfaces the best existing candidates the moment you create a role, and the **Skills Explorer** lets you browse your whole archive by skill.
+
+## How auto-match works
+
+When you create a new role, SkillAi automatically scans your existing candidate archive and surfaces the **top 3 matches** on the role detail page, usually within about 60 seconds. While it runs you'll see a loading state in the "Top matches from archive" panel; the results fill in once scoring completes — you don't need to refresh.
+
+Behind the scenes SkillAi:
+
+1. Finds archive candidates that are a strong semantic fit for the role description.
+2. Filters out candidates who don't qualify (see below).
+3. Scores the survivors with Claude against this specific role and keeps the three highest overall scores.
+
+## What gets filtered out, and why
+
+A candidate is excluded from auto-match when any of these is true:
+
+- **Unavailable.** Candidates whose availability is set to *unavailable* are skipped. *Available* and *on-project* candidates are kept (on-project candidates show when they free up — see below).
+- **Previously rejected by this customer.** If the candidate was rejected for any earlier role belonging to the same customer — either marked rejected on a submission or rejected by a hiring manager — they won't be re-surfaced for that customer.
+- **Well over budget.** When the role has a customer day rate (budget) and the candidate's rate is in the **same currency**, candidates more than **25% over budget** are excluded. Candidates within that range stay, with the overage shown on a pill (see below).
+
+## Reading a match
+
+Each surfaced candidate shows:
+
+- **Overall score** for this role. Click through to the candidate to see the full per-dimension breakdown (technical skills, experience, role-fit, communication) and Claude's reasoning — the panel keeps the summary compact and links out for the detail.
+- **Availability badge** — *Available now*, or *Available from DD MMM* for someone currently on a project.
+- **Rate-fit pill:**
+  - **Within budget** — the candidate's rate is at or under the role budget.
+  - **Over by X%** — over budget but within the 25% tolerance; the percentage is shown so you can judge the negotiation.
+  - **Currency mismatch** — the candidate's rate and the role budget are in different currencies. SkillAi does **not** convert currencies automatically, so it flags the mismatch and leaves the comparison to you.
+
+## Why a candidate might NOT appear in auto-match
+
+Run through this checklist if you expected someone and didn't see them:
+
+- Their availability is set to *unavailable*.
+- They were previously rejected by this customer on another role.
+- Their rate is more than 25% over the role budget (same currency).
+- Their CV profile hasn't finished extracting yet — a freshly uploaded CV takes roughly 30–60 seconds to process before its skills and profile are available to matching.
+- They simply weren't among the top 3 — auto-match only shows the strongest three. Use the full ranking or the Skills Explorer to dig deeper.
+
+## Using the Skills Explorer
+
+Open **Skills** in the sidebar (`/dashboard/skills`). You'll see every skill across your candidate archive as a chip, each with a count of how many candidates have it. Skills are grouped case-insensitively, so "React", "react" and " REACT " collapse into one chip.
+
+Click any chip to jump to the candidate list filtered to that skill — answering "who knows Rust?" in two clicks instead of searching CV text.
+
+## Combining skills with other filters
+
+Skill filters appear as removable chips above the candidate filter bar. Click the **✕** on a chip to drop just that skill.
+
+When more than one skill is active they are **ANDed** — only candidates who have **all** of the selected skills are shown. Skill filters also compose with the existing status, agency, availability, and search filters, so you can narrow to, say, available bench candidates who know both React and TypeScript.
+
+## Why a skill might be missing
+
+Only candidates whose CV profile has been **fully extracted** contribute skills. A new upload typically takes 30–60 seconds to extract; until then that candidate's skills won't appear as chips or match a skill filter. If a skill you expect is missing, give recent uploads a minute and refresh.
+
+## Cost note
+
+Auto-match runs a small amount of AI scoring per new role — roughly **\$0.03–\$0.05** in AI credit at current Claude pricing. You can see the running total under **Settings → AI Usage**.

--- a/src/content/help/roles-creating-and-editing.md
+++ b/src/content/help/roles-creating-and-editing.md
@@ -57,8 +57,11 @@ Click **Edit** on the role detail page. Anything is editable, but be aware:
 - **Don't put the same skills twice.** The AI weights them, not counts them. Listing "Python" five times doesn't make it more important; it just makes the JD harder to read.
 - **Keep one role per req.** Don't bundle "Senior backend OR mid-level full-stack" into one role — you'll get confused rankings. Two roles, two shortlists.
 
+After saving a new role, SkillAi automatically scans your archive for the top 3 candidate matches — see [Auto-match & Skills Explorer](/dashboard/help/auto-match-and-skills).
+
 ## See also
 
+- [Auto-match & Skills Explorer](/dashboard/help/auto-match-and-skills)
 - [Tips for getting better rankings](/dashboard/help/tips-getting-better-rankings)
 - [Customers and frameworks](/dashboard/help/customers-and-frameworks)
 - [Uploading CVs](/dashboard/help/candidates-uploading-cvs)


### PR DESCRIPTION
## What

Completes the **Skills Explorer** slice of Epic #267. The `/dashboard/skills` page already shipped (#272) but was **unreachable** (no sidebar entry) and its chips pointed at a `?skills=` filter that didn't exist. This wires the whole thing together and adds the help doc.

### #273 — candidate filter + nav
- **Candidate list query** (`candidates/page.tsx`): parse `?skills=React,TypeScript` (comma-separated, case-insensitive) → one `EXISTS` on `cv_profiles.technical_skills` **per skill, ANDed** (a candidate must have *all* listed skills). Bound params only — no string interpolation. Composes with the existing status / agency / availability / search filters; RLS-scoped via `withTenant`. Matches the page's `displayName` chip links case-insensitively (`lower(trim(...))`).
- **Filters component**: active skills render as removable chips above the filter bar (the **✕** removes just that skill), preserved through `updateParams`, page resets to 1 on change, and they count toward `hasActiveFilters` / Clear.
- **Sidebar**: new **Skills** nav entry (recruiter + admin, hidden for `hiring_manager`) — the page is finally reachable from the menu.

### #274 — help doc
- New `src/content/help/auto-match-and-skills.md` covering **both** the (already-shipped) auto-match feature and the Skills Explorer: how auto-match works, what's filtered out, the rate-fit pill, availability badges, why a candidate/skill might not appear, AND-filter semantics, and the cost note.
- Cross-link added from the role-creation help article.
- **Schema fix vs. the issue text:** the real help loader requires `audience` as an **array** and a **required `lastUpdated`** — the issue's scalar `audience: recruiter` with no `lastUpdated` would have silently failed validation and never rendered. Front-matter here is schema-correct.
- Doc notes the live auto-match panel shows the overall score and links out for the per-dimension breakdown (matches the merged behaviour).

## Not duplicated
Reused the existing `/dashboard/skills` page and `getUniqueSkillsWithCandidateCounts()` — no new page or aggregation action.

## Verified
- ✅ `tsc --noEmit` — 0 errors
- ✅ `eslint` — 0 errors (pre-existing test-file warnings only)
- ✅ `next build` — compiled successfully, 29/29 static pages

Closes #273
Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GpmSnQ7nL6sTdjgWRGvkDw