### PR TITLE
feat(onboarding): first-run checklist for new tenants (#80)

### DIFF
--- a/src/actions/onboarding.ts
+++ b/src/actions/onboarding.ts
@@ -1,0 +1,101 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { and, eq, ne, count } from 'drizzle-orm'
+import { withTenant } from '@/db'
+import { agencies, roles, candidates, scores, tenantSettings } from '@/db/schema'
+import { getActionContext } from '@/lib/auth/action-context'
+
+// Plain-text tenant_settings flag (not a secret). Once set, the first-run
+// onboarding checklist never shows again for the tenant.
+const ONBOARDING_DISMISSED_KEY = 'onboarding_dismissed'
+
+export type OnboardingSteps = {
+  agency: boolean
+  role: boolean
+  candidate: boolean
+  score: boolean
+}
+
+export type OnboardingState = {
+  visible: boolean
+  steps: OnboardingSteps
+}
+
+const EMPTY: OnboardingState = {
+  visible: false,
+  steps: { agency: false, role: false, candidate: false, score: false },
+}
+
+/**
+ * Computes the first-run onboarding state for the current tenant: whether the
+ * checklist should show, and which of the four steps are already done.
+ *
+ * The checklist is shown until the tenant either dismisses it or completes all
+ * four steps. A brand-new tenant (everything at zero) sees it; an established
+ * tenant that has already added an agency, created a role, uploaded a CV and
+ * scored a candidate never does. The per-tenant auto-provisioned "Internal"
+ * system agency is excluded from the agency step (is_system), so it doesn't
+ * tick step 1 for free.
+ */
+export async function getOnboardingState(): Promise<OnboardingState> {
+  const ctx = await getActionContext()
+  if (!ctx) return EMPTY
+  const { tenantId } = ctx
+
+  return withTenant(tenantId, async (tx) => {
+    const [
+      [{ value: dismissedCount }],
+      [{ value: agencyCount }],
+      [{ value: roleCount }],
+      [{ value: candidateCount }],
+      [{ value: scoreCount }],
+    ] = await Promise.all([
+      tx
+        .select({ value: count() })
+        .from(tenantSettings)
+        .where(and(eq(tenantSettings.tenantId, tenantId), eq(tenantSettings.key, ONBOARDING_DISMISSED_KEY))),
+      tx
+        .select({ value: count() })
+        .from(agencies)
+        .where(and(eq(agencies.isActive, true), ne(agencies.isSystem, true))),
+      tx.select({ value: count() }).from(roles),
+      tx.select({ value: count() }).from(candidates).where(eq(candidates.isActive, true)),
+      tx.select({ value: count() }).from(scores).where(eq(scores.scoreStatus, 'complete')),
+    ])
+
+    const steps: OnboardingSteps = {
+      agency: agencyCount > 0,
+      role: roleCount > 0,
+      candidate: candidateCount > 0,
+      score: scoreCount > 0,
+    }
+    const allComplete = steps.agency && steps.role && steps.candidate && steps.score
+    const dismissed = dismissedCount > 0
+
+    return { visible: !dismissed && !allComplete, steps }
+  })
+}
+
+/**
+ * Persists the "dismissed" flag so the onboarding checklist never shows again
+ * for this tenant. Idempotent.
+ */
+export async function dismissOnboarding(): Promise<{ success: boolean }> {
+  const ctx = await getActionContext()
+  if (!ctx) return { success: false }
+  const { tenantId, userId } = ctx
+
+  await withTenant(tenantId, async (tx) => {
+    await tx
+      .insert(tenantSettings)
+      .values({ tenantId, key: ONBOARDING_DISMISSED_KEY, value: 'true', updatedBy: userId })
+      .onConflictDoUpdate({
+        target: [tenantSettings.tenantId, tenantSettings.key],
+        set: { value: 'true', updatedBy: userId, updatedAt: new Date() },
+      })
+  })
+
+  revalidatePath('/dashboard')
+  return { success: true }
+}

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -16,7 +16,9 @@ import { roles, candidates, scores, interviewPacks, agencies, interviewSlots, us
 import { NextInterviewsCard } from '@/components/dashboard/next-interviews-card'
 import { ForYouSection } from '@/components/dashboard/for-you-section'
 import { AwaitingCustomerFeedbackWidget } from '@/components/dashboard/awaiting-customer-feedback-widget'
+import { OnboardingChecklist } from '@/components/dashboard/onboarding-checklist'
 import { getForYouFeed } from '@/actions/dashboard-tasks'
+import { getOnboardingState } from '@/actions/onboarding'
 
 export const metadata = { title: 'Dashboard — SkillAI' }
 
@@ -85,7 +87,7 @@ export default async function DashboardPage() {
   // withTenant opens a transaction and sets the RLS session variable, so each
   // is one round-trip to Postgres. Collapsing to three top-level fetches
   // (parallel), one of which batches four queries, removes ~7 round-trips.
-  const [feed, stats, lists] = await Promise.all([
+  const [feed, stats, lists, onboarding] = await Promise.all([
     getForYouFeed(
       session.user.id,
       session.user.role as 'admin' | 'recruiter' | 'hiring_manager' | 'viewer',
@@ -170,6 +172,7 @@ export default async function DashboardPage() {
           .limit(5),
       ])
     ),
+    getOnboardingState(),
   ])
 
   const { roleCount, candidateCount, scoredCount, packsCount, missingCvCount } = stats
@@ -185,6 +188,9 @@ export default async function DashboardPage() {
           <span className="font-medium text-[var(--color-fg-muted)]">{session?.user.name}</span>.
         </p>
       </div>
+
+      {/* ── First-run onboarding checklist (new tenants only) ───────────── */}
+      {onboarding.visible && <OnboardingChecklist steps={onboarding.steps} />}
 
       {/* ── For You section ────────────────────────────────────────────── */}
       <ForYouSection feed={feed} />

--- a/src/components/dashboard/onboarding-checklist.tsx
+++ b/src/components/dashboard/onboarding-checklist.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import Link from 'next/link'
+import { CheckCircle2Icon, CircleIcon, XIcon, SparklesIcon } from 'lucide-react'
+import { dismissOnboarding, type OnboardingSteps } from '@/actions/onboarding'
+
+const STEP_DEFS: Array<{
+  key: keyof OnboardingSteps
+  label: string
+  description: string
+  href: string
+  cta: string
+}> = [
+  {
+    key: 'agency',
+    label: 'Add an agency',
+    description: 'Track where your candidates come from.',
+    href: '/dashboard/agencies',
+    cta: 'Add agency',
+  },
+  {
+    key: 'role',
+    label: 'Create your first role',
+    description: 'Describe the job you are hiring for.',
+    href: '/dashboard/roles',
+    cta: 'Create role',
+  },
+  {
+    key: 'candidate',
+    label: 'Upload a CV',
+    description: 'Add a candidate from a role page to get them into the archive.',
+    href: '/dashboard/roles',
+    cta: 'Upload CV',
+  },
+  {
+    key: 'score',
+    label: 'Score the candidate',
+    description: 'Let AI rank them against the role across four dimensions.',
+    href: '/dashboard/roles',
+    cta: 'Score',
+  },
+]
+
+export function OnboardingChecklist({ steps }: { steps: OnboardingSteps }) {
+  const [dismissed, setDismissed] = useState(false)
+  const [isPending, startTransition] = useTransition()
+
+  if (dismissed) return null
+
+  const completed = STEP_DEFS.filter((s) => steps[s.key]).length
+  const pct = Math.round((completed / STEP_DEFS.length) * 100)
+
+  const handleSkip = () => {
+    setDismissed(true) // optimistic — hide immediately
+    startTransition(async () => {
+      await dismissOnboarding()
+    })
+  }
+
+  return (
+    <div className="mb-8 rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-elevated)] p-5">
+      <div className="flex items-start justify-between gap-4 mb-4">
+        <div className="flex items-center gap-2.5">
+          <SparklesIcon className="h-5 w-5 text-violet-500 flex-shrink-0" />
+          <div>
+            <h2 className="text-sm font-semibold text-[var(--color-fg)]">Get started with SkillAI</h2>
+            <p className="text-xs text-[var(--color-fg-subtle)] mt-0.5">
+              {completed} of {STEP_DEFS.length} complete
+            </p>
+          </div>
+        </div>
+        <button
+          onClick={handleSkip}
+          disabled={isPending}
+          className="inline-flex items-center gap-1 text-xs text-[var(--color-fg-muted)]
+                     hover:text-[var(--color-fg)] transition-colors disabled:opacity-50"
+          aria-label="Skip onboarding"
+        >
+          <XIcon className="h-3.5 w-3.5" />
+          Skip
+        </button>
+      </div>
+
+      {/* Progress bar */}
+      <div className="h-1.5 w-full rounded-full bg-[var(--color-bg-input)] mb-4 overflow-hidden">
+        <div
+          className="h-full bg-violet-500 transition-all"
+          style={{ width: `${pct}%` }}
+          role="progressbar"
+          aria-valuenow={pct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        />
+      </div>
+
+      <ul className="space-y-2">
+        {STEP_DEFS.map((s) => {
+          const done = steps[s.key]
+          return (
+            <li
+              key={s.key}
+              className="flex items-center justify-between gap-3 rounded-lg px-3 py-2 bg-[var(--color-bg-app)]"
+            >
+              <div className="flex items-center gap-3 min-w-0">
+                {done ? (
+                  <CheckCircle2Icon className="h-5 w-5 text-green-500 flex-shrink-0" />
+                ) : (
+                  <CircleIcon className="h-5 w-5 text-[var(--color-fg-subtle)] flex-shrink-0" />
+                )}
+                <div className="min-w-0">
+                  <p className={`text-sm ${done ? 'text-[var(--color-fg-subtle)] line-through' : 'text-[var(--color-fg)]'}`}>
+                    {s.label}
+                  </p>
+                  {!done && (
+                    <p className="text-xs text-[var(--color-fg-subtle)] truncate">{s.description}</p>
+                  )}
+                </div>
+              </div>
+              {!done && (
+                <Link
+                  href={s.href}
+                  className="flex-shrink-0 rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white
+                             hover:bg-blue-700 transition-colors"
+                >
+                  {s.cta}
+                </Link>
+              )}
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}


### PR DESCRIPTION
## What

Closes **#80**. A brand-new tenant landed on a dashboard of zeros with no guidance. This adds a 4-step getting-started checklist at the top of the dashboard.

### Behaviour
- **4 steps:** Add an agency → Create your first role → Upload a CV → Score the candidate. Each step shows a tick when its underlying data exists, a short description, and a CTA button linking to the right page.
- **Progress bar** + "N of 4 complete".
- **Skip** control — optimistically hides and persists dismissal so it never returns.
- **Visibility:** shown until the tenant dismisses it **or** completes all four steps. Established tenants with the full loop never see it.

### Implementation
- `src/actions/onboarding.ts` — `getOnboardingState()` derives the four step booleans from existing tables (non-system agencies, roles, active candidates, complete scores) and reads the `onboarding_dismissed` flag from `tenant_settings`; `dismissOnboarding()` writes it. RLS-scoped via `withTenant`. The auto-provisioned **Internal** system agency is excluded (`is_system`) so step 1 isn't ticked for free.
- `src/components/dashboard/onboarding-checklist.tsx` — client card.
- `dashboard/page.tsx` — fetched inside the existing `Promise.all` (one batched query, no extra round-trip pattern broken).
- **No DB schema change** — reuses the `tenant_settings` KV pattern.

### Deviation from the issue (called out)
The issue says "overlay"; I built a dismissible **top-of-dashboard card** (the standard getting-started-checklist pattern, à la Linear/Vercel) rather than a blocking modal — friendlier, non-nagging, and it self-hides once the core loop is done.

## Verified
- ✅ `tsc --noEmit` — 0 errors
- ✅ `eslint` — 0 errors (pre-existing warnings only)
- ✅ `next build` — compiled successfully, 29/29 static pages

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GpmSnQ7nL6sTdjgWRGvkDw