### PR TITLE
feat(ingestion): host-folder inbox worker — Phase 1 foundation (#4)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,16 @@ COPY src/db/migrations ./migrations
 COPY scripts/migrate.mjs ./scripts/migrate.mjs
 CMD ["node", "scripts/migrate.mjs"]
 
+# ── Stage 4b: Host-folder inbox worker (used by the 'worker' Compose service) ──
+# Runs the TS worker directly via tsx (an explicit devDependency, so no network
+# fetch at runtime). Needs full source + node_modules. See issue #4 / Epic #3.
+FROM base AS worker
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+CMD ["npm", "run", "worker"]
+
 # ── Stage 5: Production runner ─────────────────────────────────────────────────
 FROM base AS runner
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,36 @@ services:
       - skillai_net
     restart: unless-stopped
 
+  # Host-folder inbox worker (issue #4 / Epic #3, Phase 1). Polls
+  # INBOX_ROOT/<tenantId>/ for dropped CVs and ingests them. Shares the
+  # uploads_data volume with `app` so persisted CV files land where the app
+  # reads them. Run as a single instance (scale=1) — no leader election yet.
+  worker:
+    build:
+      context: .
+      target: worker
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-skillai}:${POSTGRES_PASSWORD:-skillai}@db:5432/${POSTGRES_DB:-skillai}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+      UPLOAD_DIR: /app/uploads
+      INBOX_ROOT: /app/inbox
+      INGEST_POLL_MS: ${INGEST_POLL_MS:-30000}
+    dns:
+      - 1.1.1.1
+      - 8.8.8.8
+    volumes:
+      - uploads_data:/app/uploads
+      - inbox_data:/app/inbox
+    depends_on:
+      db:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    networks:
+      - skillai_net
+    restart: unless-stopped
+
   db:
     image: pgvector/pgvector:pg17
     environment:
@@ -79,6 +109,7 @@ services:
 volumes:
   postgres_data:
   uploads_data:
+  inbox_data:
 
 networks:
   skillai_net:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -110,6 +110,33 @@ docker compose exec app npm run db:push
 docker compose exec app npm run db:seed
 ```
 
+### Host-folder inbox worker (optional)
+
+The `worker` Compose service watches a host-mounted folder and auto-ingests CVs
+dropped into it — no web upload needed (issue #4 / Epic #3, Phase 1).
+
+- Layout: drop CVs into `INBOX_ROOT/<tenantId>/`. Each tenant gets its own
+  subfolder (named by its UUID). Supported: PDF, DOCX, ODT, RTF, TXT, MD.
+- Handled files are moved into `<tenantId>/.processed/` (success) or
+  `<tenantId>/.failed/` (rejected) so nothing is ingested twice.
+- Ingested CVs land in the candidate archive (role-less) and get embedding +
+  CV-profile extraction automatically.
+
+```bash
+docker compose up -d worker         # start it
+docker compose logs -f worker       # watch ingestion
+```
+
+Run it locally without Docker via `npm run worker`. Configuration:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `INBOX_ROOT` | `<cwd>/inbox` (Docker: `/app/inbox`) | Root folder scanned for per-tenant subfolders |
+| `INGEST_POLL_MS` | `30000` (floor 5000) | How often the folder is polled |
+
+Run a single worker instance (the Compose service is `scale=1`); multi-replica
+leader election is not yet implemented.
+
 ---
 
 ## Production Considerations

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "eslint-config-next": "16.2.3",
         "jsdom": "^29.0.2",
         "tailwindcss": "^4",
+        "tsx": "^4.22.4",
         "typescript": "^5",
         "vitest": "^4.1.6"
       }
@@ -1092,6 +1093,448 @@
       "dependencies": {
         "@esbuild-kit/core-utils": "^3.3.2",
         "get-tsconfig": "^4.7.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -7741,6 +8184,48 @@
         "benchmarks"
       ]
     },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -8645,7 +9130,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -14340,14 +14824,13 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
+        "esbuild": "~0.28.0"
       },
       "bin": {
         "tsx": "dist/cli.mjs"
@@ -14357,490 +14840,6 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/tsx/node_modules/fsevents": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "db:push": "drizzle-kit push",
     "db:seed": "npx tsx src/db/seed.ts",
     "db:studio": "drizzle-kit studio",
+    "worker": "npx tsx src/worker/index.ts",
     "test": "NODE_ENV=test vitest run",
     "test:watch": "NODE_ENV=test vitest",
     "test:coverage": "NODE_ENV=test vitest run --coverage",
@@ -80,6 +81,7 @@
     "eslint-config-next": "16.2.3",
     "jsdom": "^29.0.2",
     "tailwindcss": "^4",
+    "tsx": "^4.22.4",
     "typescript": "^5",
     "vitest": "^4.1.6"
   }

--- a/src/lib/ingestion/inbox.ts
+++ b/src/lib/ingestion/inbox.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure helpers for the host-folder inbox worker (issue #4 / Epic #3, Phase 1).
+ *
+ * These functions are deliberately side-effect-free so they can be unit-tested
+ * without a filesystem or database. The worker (src/worker/index.ts) composes
+ * them with fs + the ingestion pipeline.
+ *
+ * Layout (per-tenant subfolders under a single mount root — Epic #3, Q2 default):
+ *
+ *   INBOX_ROOT/
+ *     <tenantId>/                 ← drop CVs here
+ *       alice-smith.pdf
+ *       .processed/               ← successfully ingested files moved here
+ *       .failed/                  ← files that failed validation/ingestion
+ */
+
+import { extname, join } from 'path'
+
+/** CV file extensions the inbox will ingest (mirrors @/lib/cv/store EXT_TO_TYPE). */
+export const SUPPORTED_EXTENSIONS = ['.pdf', '.docx', '.odt', '.rtf', '.txt', '.md'] as const
+
+/** Subdirectory names used to quarantine handled files so they are not re-ingested. */
+export const PROCESSED_DIRNAME = '.processed'
+export const FAILED_DIRNAME = '.failed'
+
+const SUPPORTED = new Set<string>(SUPPORTED_EXTENSIONS)
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/**
+ * True when a directory entry should be ingested: a supported CV extension and
+ * not a hidden/dot file (which also excludes the .processed / .failed dirs and
+ * editor temp files like `.~lock`).
+ */
+export function isEligibleFile(name: string): boolean {
+  if (!name || name.startsWith('.')) return false
+  return SUPPORTED.has(extname(name).toLowerCase())
+}
+
+/**
+ * True when a subfolder name under INBOX_ROOT looks like a tenant id (UUID).
+ * The worker only descends into tenant-shaped folders, ignoring stray dirs.
+ */
+export function isTenantFolder(name: string): boolean {
+  return UUID_RE.test(name)
+}
+
+/** Absolute (or root-relative) path to a tenant's inbox folder. */
+export function tenantInboxDir(root: string, tenantId: string): string {
+  return join(root, tenantId)
+}
+
+/** The `.processed` quarantine dir inside a tenant inbox. */
+export function processedDir(tenantDir: string): string {
+  return join(tenantDir, PROCESSED_DIRNAME)
+}
+
+/** The `.failed` quarantine dir inside a tenant inbox. */
+export function failedDir(tenantDir: string): string {
+  return join(tenantDir, FAILED_DIRNAME)
+}
+
+/**
+ * Collision-safe destination name for a handled file. Prefixing with a sortable
+ * timestamp stamp keeps re-drops of the same filename from overwriting an older
+ * archived copy. `stamp` is injected (not read from the clock) so this stays
+ * pure and testable.
+ */
+export function archivedFileName(originalName: string, stamp: string): string {
+  return `${stamp}__${originalName}`
+}

--- a/src/lib/ingestion/ingest-cv.ts
+++ b/src/lib/ingestion/ingest-cv.ts
@@ -1,0 +1,115 @@
+/**
+ * Session-less CV ingestion (issue #4 / Epic #3, Phase 1).
+ *
+ * Mirrors the bulk-upload API route's pipeline but takes a tenantId + Buffer
+ * directly instead of an authenticated request, so it can be driven by the
+ * host-folder worker (no HTTP session available). The Web `File` wrapper lets
+ * us reuse the exact validation in @/lib/cv/store rather than duplicating the
+ * MIME / magic-byte / size checks.
+ *
+ * When `roleId` is provided a pending score row is created and scoring is
+ * triggered; inbox drops are role-less archive intake, so they skip scoring and
+ * just run embedding + CV-profile extraction (same background steps the API
+ * route runs via `after()`).
+ */
+
+import { randomUUID } from 'crypto'
+import { eq } from 'drizzle-orm'
+import { withTenant } from '@/db'
+import { candidates, scores } from '@/db/schema'
+import { validateCvFile, parseCvBuffer, persistCvFile } from '@/lib/cv/store'
+import { triggerScoring } from '@/lib/ai/scoring'
+
+export type IngestCvResult =
+  | { ok: true; candidateId: string; name: string }
+  | { ok: false; error: string }
+
+/** Derive a (firstName, lastName) guess from the CV filename. */
+export function deriveNameFromFilename(originalName: string): { firstName: string; lastName: string } {
+  const baseName = originalName.replace(/\.[^.]+$/, '').replace(/[-_]+/g, ' ').trim()
+  const parts = baseName.split(/\s+/).filter(Boolean)
+  return {
+    firstName: parts[0] || 'Unknown',
+    lastName: parts.slice(1).join(' ') || 'Candidate',
+  }
+}
+
+export async function ingestCvFile(params: {
+  tenantId: string
+  buffer: Buffer
+  originalName: string
+  agencyId?: string | null
+  roleId?: string | null
+}): Promise<IngestCvResult> {
+  const { tenantId, buffer, originalName, agencyId = null, roleId = null } = params
+
+  // Reuse the canonical validation (size, extension/MIME, magic bytes).
+  // A Node Buffer isn't a valid BlobPart under the DOM lib types — wrap it in a
+  // Uint8Array (Buffer is a subclass, so this is a cheap view-compatible copy).
+  const file = new File([new Uint8Array(buffer)], originalName)
+  const validated = await validateCvFile(file)
+  if (!validated.ok) return { ok: false, error: validated.error }
+  const { fileType, buffer: validatedBuffer } = validated
+
+  let cvText: string
+  try {
+    ;({ cvText } = await parseCvBuffer(validatedBuffer, fileType))
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : 'Failed to extract text from CV' }
+  }
+
+  const { firstName, lastName } = deriveNameFromFilename(originalName)
+  const { filePath } = await persistCvFile(tenantId, validatedBuffer, fileType)
+  const candidateId = randomUUID()
+
+  await withTenant(tenantId, async (tx) => {
+    await tx.insert(candidates).values({
+      id: candidateId,
+      tenantId,
+      agencyId,
+      firstName,
+      lastName,
+      email: null,
+      phone: null,
+      cvText,
+      filePath,
+      fileType,
+    })
+
+    if (roleId) {
+      await tx.insert(scores).values({ tenantId, candidateId, roleId, scoreStatus: 'pending' })
+    }
+  })
+
+  // Scoring only makes sense against a role.
+  if (roleId) {
+    triggerScoring(candidateId, roleId, tenantId).catch((e) => console.error('[ingest] scoring failed', e))
+  }
+
+  // Background enrichment — embedding + CV-profile extraction. The worker has no
+  // request lifecycle, so we run these as a detached promise (fire-and-forget).
+  void (async () => {
+    try {
+      const { generateEmbedding } = await import('@/lib/ai/embeddings')
+      const embedding = await generateEmbedding(cvText, tenantId)
+      if (embedding) {
+        await withTenant(tenantId, async (tx) => {
+          await tx
+            .update(candidates)
+            .set({ embedding: JSON.stringify(embedding) })
+            .where(eq(candidates.id, candidateId))
+        })
+      }
+    } catch (e) {
+      console.error('[ingest] embedding failed for', candidateId, e)
+    }
+    try {
+      const { triggerCvProfileExtraction } = await import('@/lib/ai/cv-profile')
+      await triggerCvProfileExtraction(candidateId, tenantId)
+    } catch (e) {
+      console.error('[ingest] cv-profile extraction failed for', candidateId, e)
+    }
+  })()
+
+  return { ok: true, candidateId, name: `${firstName} ${lastName}` }
+}

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,0 +1,144 @@
+/**
+ * Host-folder inbox worker (issue #4 / Epic #3, Phase 1).
+ *
+ * Polls INBOX_ROOT/<tenantId>/ for dropped CVs, ingests each via the shared
+ * session-less pipeline, and quarantines handled files into `.processed`
+ * (success) or `.failed` (validation/ingestion error) so they are never
+ * re-ingested. Polling (not chokidar) is used deliberately: it adds no
+ * dependency and is reliable across Docker bind-mounts and network shares.
+ *
+ * Run:  npm run worker   (or `npx tsx src/worker/index.ts`)
+ * Env:  INBOX_ROOT      (default <cwd>/inbox)
+ *       INGEST_POLL_MS  (default 30000, floor 5000)
+ *
+ * Deployment: run as a single instance (docker-compose `worker`, scale=1). A
+ * Postgres advisory-lock leader election for multi-replica safety is deferred
+ * (Epic #3, Q9) — the in-process `running` guard only prevents overlapping
+ * ticks within one instance.
+ */
+
+import 'dotenv/config'
+import { readdir, mkdir, readFile, rename } from 'fs/promises'
+import { join } from 'path'
+import { eq } from 'drizzle-orm'
+import { withTenant } from '@/db'
+import { tenants } from '@/db/schema'
+import { ingestCvFile } from '@/lib/ingestion/ingest-cv'
+import {
+  isEligibleFile,
+  isTenantFolder,
+  tenantInboxDir,
+  processedDir,
+  failedDir,
+  archivedFileName,
+} from '@/lib/ingestion/inbox'
+
+const INBOX_ROOT = process.env.INBOX_ROOT || join(process.cwd(), 'inbox')
+const POLL_MS = Math.max(5000, parseInt(process.env.INGEST_POLL_MS || '30000', 10) || 30000)
+
+// Reentrancy guard: a slow tick must not overlap the next interval fire.
+let running = false
+
+async function tenantExists(tenantId: string): Promise<boolean> {
+  try {
+    return await withTenant(tenantId, async (tx) => {
+      const rows = await tx
+        .select({ id: tenants.id })
+        .from(tenants)
+        .where(eq(tenants.id, tenantId))
+        .limit(1)
+      return rows.length > 0
+    })
+  } catch {
+    return false
+  }
+}
+
+async function listSubdirs(root: string): Promise<string[]> {
+  try {
+    const entries = await readdir(root, { withFileTypes: true })
+    return entries.filter((e) => e.isDirectory()).map((e) => e.name)
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'ENOENT') return []
+    throw e
+  }
+}
+
+async function quarantine(targetDir: string, srcPath: string, fileName: string, stamp: string): Promise<void> {
+  await mkdir(targetDir, { recursive: true })
+  await rename(srcPath, join(targetDir, archivedFileName(fileName, stamp)))
+}
+
+async function processTenant(tenantId: string): Promise<void> {
+  const dir = tenantInboxDir(INBOX_ROOT, tenantId)
+
+  let entries
+  try {
+    entries = await readdir(dir, { withFileTypes: true })
+  } catch {
+    return
+  }
+  const files = entries.filter((e) => e.isFile() && isEligibleFile(e.name)).map((e) => e.name)
+  if (files.length === 0) return
+
+  if (!(await tenantExists(tenantId))) {
+    console.warn(`[worker] skipping folder for unknown tenant: ${tenantId}`)
+    return
+  }
+
+  for (const name of files) {
+    const srcPath = join(dir, name)
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-')
+    try {
+      const buffer = await readFile(srcPath)
+      const result = await ingestCvFile({ tenantId, buffer, originalName: name })
+      if (result.ok) {
+        await quarantine(processedDir(dir), srcPath, name, stamp)
+        console.log(`[worker] ingested "${name}" → candidate ${result.candidateId} (tenant ${tenantId})`)
+      } else {
+        await quarantine(failedDir(dir), srcPath, name, stamp)
+        console.warn(`[worker] rejected "${name}" (tenant ${tenantId}): ${result.error}`)
+      }
+    } catch (e) {
+      console.error(`[worker] error ingesting "${name}" (tenant ${tenantId}):`, e)
+      try {
+        await quarantine(failedDir(dir), srcPath, name, stamp)
+      } catch {
+        // Leave the file in place if even the move fails; next tick retries.
+      }
+    }
+  }
+}
+
+async function tick(): Promise<void> {
+  if (running) return
+  running = true
+  try {
+    const tenantDirs = (await listSubdirs(INBOX_ROOT)).filter(isTenantFolder)
+    for (const tenantId of tenantDirs) {
+      try {
+        await processTenant(tenantId)
+      } catch (e) {
+        console.error(`[worker] tenant ${tenantId} tick failed:`, e)
+      }
+    }
+  } catch (e) {
+    console.error('[worker] tick failed:', e)
+  } finally {
+    running = false
+  }
+}
+
+async function main(): Promise<void> {
+  console.log('[worker] host-folder inbox watcher starting')
+  console.log(`[worker] INBOX_ROOT=${INBOX_ROOT} poll=${POLL_MS}ms`)
+  await tick()
+  setInterval(() => {
+    void tick()
+  }, POLL_MS)
+}
+
+main().catch((e) => {
+  console.error('[worker] fatal:', e)
+  process.exit(1)
+})

--- a/tests/unit/lib/ingestion/inbox.test.ts
+++ b/tests/unit/lib/ingestion/inbox.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for src/lib/ingestion/inbox.ts — the pure host-folder helpers.
+ *
+ * No filesystem or DB touched: these are deterministic string/path functions.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  SUPPORTED_EXTENSIONS,
+  PROCESSED_DIRNAME,
+  FAILED_DIRNAME,
+  isEligibleFile,
+  isTenantFolder,
+  tenantInboxDir,
+  processedDir,
+  failedDir,
+  archivedFileName,
+} from '@/lib/ingestion/inbox'
+
+const TENANT = 'aaaaaaaa-1111-2222-3333-444444444444'
+
+describe('isEligibleFile', () => {
+  it('accepts every supported CV extension (case-insensitive)', () => {
+    for (const ext of SUPPORTED_EXTENSIONS) {
+      expect(isEligibleFile(`alice-smith${ext}`)).toBe(true)
+      expect(isEligibleFile(`BOB${ext.toUpperCase()}`)).toBe(true)
+    }
+  })
+
+  it('rejects unsupported extensions', () => {
+    expect(isEligibleFile('resume.exe')).toBe(false)
+    expect(isEligibleFile('photo.png')).toBe(false)
+    expect(isEligibleFile('archive.zip')).toBe(false)
+    expect(isEligibleFile('notes')).toBe(false) // no extension
+  })
+
+  it('rejects hidden / dot files (incl. quarantine dirs and editor locks)', () => {
+    expect(isEligibleFile('.processed')).toBe(false)
+    expect(isEligibleFile('.failed')).toBe(false)
+    expect(isEligibleFile('.~lock.cv.pdf#')).toBe(false)
+    expect(isEligibleFile('.hidden.pdf')).toBe(false)
+  })
+
+  it('rejects empty names', () => {
+    expect(isEligibleFile('')).toBe(false)
+  })
+})
+
+describe('isTenantFolder', () => {
+  it('accepts UUID-shaped folder names (either case)', () => {
+    expect(isTenantFolder(TENANT)).toBe(true)
+    expect(isTenantFolder(TENANT.toUpperCase())).toBe(true)
+  })
+
+  it('rejects non-UUID folder names', () => {
+    expect(isTenantFolder('.processed')).toBe(false)
+    expect(isTenantFolder('inbox')).toBe(false)
+    expect(isTenantFolder('not-a-uuid')).toBe(false)
+    expect(isTenantFolder('aaaaaaaa-1111-2222-3333')).toBe(false) // too short
+  })
+})
+
+describe('path helpers', () => {
+  it('builds the tenant inbox path under the root', () => {
+    expect(tenantInboxDir('/data/inbox', TENANT)).toBe(`/data/inbox/${TENANT}`)
+  })
+
+  it('builds .processed and .failed dirs inside the tenant inbox', () => {
+    const dir = tenantInboxDir('/data/inbox', TENANT)
+    expect(processedDir(dir)).toBe(`/data/inbox/${TENANT}/${PROCESSED_DIRNAME}`)
+    expect(failedDir(dir)).toBe(`/data/inbox/${TENANT}/${FAILED_DIRNAME}`)
+  })
+})
+
+describe('archivedFileName', () => {
+  it('prefixes the original name with the timestamp stamp (collision-safe)', () => {
+    const stamp = '2026-06-20T07-30-00-000Z'
+    expect(archivedFileName('alice-smith.pdf', stamp)).toBe(`${stamp}__alice-smith.pdf`)
+  })
+
+  it('keeps distinct re-drops of the same filename from colliding', () => {
+    const a = archivedFileName('cv.pdf', '2026-06-20T07-30-00-000Z')
+    const b = archivedFileName('cv.pdf', '2026-06-20T08-00-00-000Z')
+    expect(a).not.toBe(b)
+  })
+})


### PR DESCRIPTION
## What

**Phase 1 of the shared-folders epic (#3): the host-folder inbox worker** — drop CVs into a host-mounted folder and they're auto-ingested into the candidate archive, no web upload needed. This is the foundation the cloud phases (#5 Google Drive, #6 OneDrive) build on.

> **#4 was previously closed as "completed" but this foundation was not present on `core-mvp-foundation`** (no worker, no chokidar, no ingestion pipeline). I reopened #4 and implemented it here.

## How it works
- Drop a CV into `INBOX_ROOT/<tenantId>/`. Supported: PDF, DOCX, ODT, RTF, TXT, MD.
- The worker polls every `INGEST_POLL_MS` (default 30s), ingests each file via the **same pipeline as the bulk-upload route** (validate → parse → persist → candidate insert → embedding + CV-profile extraction), then moves it to `<tenantId>/.processed/` (success) or `<tenantId>/.failed/` (rejected) so it's never re-ingested.

## Files
- `src/lib/ingestion/inbox.ts` — **pure, unit-tested** helpers (eligible-file detection, tenant-folder UUID check, path routing, collision-safe archived names).
- `src/lib/ingestion/ingest-cv.ts` — **session-less** ingestion reusing `@/lib/cv/store` (`validateCvFile`/`parseCvBuffer`/`persistCvFile`) + `triggerScoring` (only when a roleId is supplied — inbox drops are role-less archive intake).
- `src/worker/index.ts` — dependency-free polling loop (no chokidar — reliable across bind-mounts, zero new runtime dep), reentrancy-guarded, per-file/per-tenant try-catch.
- **Docker:** new `worker` build stage + Compose service (shares `uploads_data`, adds `inbox_data`); `npm run worker` script; `tsx` pinned as a devDependency so the container needs no network at runtime.
- `docs/setup.md`: host-folder inbox worker section.

## Decisions on the open Epic #3 questions (documented in code)
- **Q2** per-tenant subfolders under one mount root.
- **Q7** 30s polling (no webhooks).
- **Q8** re-ingestion guarded by the `.processed`/`.failed` move; content-hash dedup deferred (needs a schema column).
- **Q9** single instance (`scale=1`); advisory-lock leader election deferred.
- **No DB schema changes.**

## Verified & tested
- ✅ `vitest` — **1067 passed / 0 failed** (incl. 10 new `inbox` tests)
- ✅ `tsc --noEmit` — 0 errors
- ✅ `eslint` — 0 errors
- ✅ `next build` — compiled successfully, 29/29 static pages

## Not included (require external setup / your decision — see issue comments)
- #5 Google Drive / #6 OneDrive — need OAuth consoles in your Google/Azure accounts + the remaining Epic #3 product answers.

Part of #3. Closes #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GpmSnQ7nL6sTdjgWRGvkDw