### PR TITLE
fix(ai): update retired gemini-2.0-flash → gemini-3.5-flash

### DIFF
--- a/src/content/help/ai-how-scoring-works.md
+++ b/src/content/help/ai-how-scoring-works.md
@@ -47,7 +47,7 @@ If the model returns anything that doesn't match this shape, the run fails and t
 ## Claude is the default; Gemini is the fallback
 
 - **Primary:** Anthropic Claude (`claude-sonnet-4-6`). Higher reasoning quality on nuanced judgement, structured-output guarantees baked into the API. This is what you get unless your tenant has switched.
-- **Secondary:** Google Gemini (`gemini-2.0-flash`). Cheaper for high-volume runs. Available as a per-tenant toggle in **Settings → AI**.
+- **Secondary:** Google Gemini (`gemini-3.5-flash`). Cheaper for high-volume runs. Available as a per-tenant toggle in **Settings → AI**.
 
 You don't pick the model per candidate. The choice is per-tenant — once an admin flips the toggle, every new score uses the selected model. Existing scores are not retroactively rerun.
 

--- a/src/content/help/tips-getting-better-rankings.md
+++ b/src/content/help/tips-getting-better-rankings.md
@@ -53,7 +53,7 @@ Two candidates can both score 78 overall and be wildly different — one strong 
 
 ## Compare Claude vs Gemini
 
-The model toggle (per-tenant, in settings) lets you switch the scoring engine. Claude (`claude-sonnet-4-6`) is the default and produces the most consistent rankings; Gemini (`gemini-2.0-flash`) is faster and cheaper for bulk runs. If you're unsure about a particular candidate, run them through both — disagreement is itself a signal.
+The model toggle (per-tenant, in settings) lets you switch the scoring engine. Claude (`claude-sonnet-4-6`) is the default and produces the most consistent rankings; Gemini (`gemini-3.5-flash`) is faster and cheaper for bulk runs. If you're unsure about a particular candidate, run them through both — disagreement is itself a signal.
 
 ## Don't fight the four dimensions
 

--- a/src/lib/ai/gemini.ts
+++ b/src/lib/ai/gemini.ts
@@ -1,7 +1,7 @@
 /**
  * Gemini API client for CV scoring
  *
- * Uses Gemini 2.0 Flash (gemini-2.0-flash) with structured JSON output
+ * Uses Gemini 3.5 Flash (gemini-3.5-flash) with structured JSON output
  * to return a CandidateScore matching the same schema used by Claude scoring.
  *
  * Falls back to tenant API key → GEMINI_API_KEY env var.
@@ -14,7 +14,10 @@ import { formatManagerPriorities } from './priorities'
 import { logAiUsage, geminiUsageToInput } from './usage-logger'
 import type { AiOperation } from '@/db/schema/ai-usage'
 
-const GEMINI_MODEL = 'models/gemini-2.0-flash'
+// gemini-2.0-flash retired Jul 2026 (404 no-longer-available); 3.5-flash is the
+// current cost-tier flash model. ponytail: hardcoded — make it a tenant setting
+// only if model churn becomes frequent.
+const GEMINI_MODEL = 'models/gemini-3.5-flash'
 
 const SCORE_RESPONSE_SCHEMA: Schema = {
   type: SchemaType.OBJECT,


### PR DESCRIPTION
## What
Google retired `gemini-2.0-flash` (`404 no longer available`), breaking candidate scoring for any tenant on the Gemini toggle. Bumps the single hardcoded model constant to `gemini-3.5-flash` and refreshes the two help docs that name the model.

## Verification
- Listed the account's available models via the live API; `gemini-3.5-flash` is the current non-preview flash tier.
- `POST …/models/gemini-3.5-flash:generateContent` → **HTTP 200** with the tenant's key.

## Notes
- Pre-existing, out-of-scope: Gemini cost logging passes the `models/…`-prefixed name to `calculateCost`, but `pricing.ts` keys are unprefixed → Gemini spend logs as $0. Separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)