### PR TITLE
fix(deploy): pin pgvector to a digest, so pg17 cannot move under a live database

### DIFF
--- a/deploy/k8s/job-migrate.yaml
+++ b/deploy/k8s/job-migrate.yaml
@@ -31,7 +31,13 @@ spec:
       restartPolicy: Never
       initContainers:
         - name: wait-for-db
-          image: pgvector/pgvector:pg17
+          # Same digest as statefulset-db.yaml, and pinned for the same reason
+          # (Factory#573 / Factory#588). This one is only here for `pg_isready`,
+          # so the version matters less -- but it is a second unpinned entry
+          # point for the same floating tag, and leaving it would mean the tag
+          # could still be repointed under the cluster through a Job Pod.
+          # Keep the two in step when bumping.
+          image: pgvector/pgvector:pg17@sha256:be400b50812ab2cc908ed78593fda2e51e3b45fe774fa637f1c7b16e68531d95
           imagePullPolicy: IfNotPresent
           command:
             - sh

--- a/deploy/k8s/statefulset-db.yaml
+++ b/deploy/k8s/statefulset-db.yaml
@@ -29,7 +29,23 @@ spec:
         fsGroup: 999
       containers:
         - name: postgres
-          image: pgvector/pgvector:pg17
+          # Pinned by digest: a tag is a pointer, and `pg17` is a floating
+          # major-line tag that moves on every PostgreSQL 17 patch release and
+          # every pgvector rebuild. Unpinned, any restart or reschedule of this
+          # Pod silently swaps the bytes under a live data directory, with no
+          # record. Factory#573 / Factory#588.
+          #
+          # This digest is the one ALREADY RUNNING on the cluster (measured
+          # 2026-08-07), not registry HEAD, so pinning re-pulls nothing and
+          # moves no version. Both carry PG_VERSION 17.10-1.pgdg12+1 and
+          # pgvector 0.8.2; HEAD (sha256:7ae6051e) is a later Debian base
+          # rebuild and adopting it is a deliberate upgrade of a live database,
+          # not a side effect of pinning.
+          #
+          # The tag is kept alongside the digest so the version stays legible
+          # without a registry round-trip. Bump both together; nothing
+          # refreshes this automatically (factory-gitops#139).
+          image: pgvector/pgvector:pg17@sha256:be400b50812ab2cc908ed78593fda2e51e3b45fe774fa637f1c7b16e68531d95
           imagePullPolicy: IfNotPresent
           ports:
             - name: postgres


### PR DESCRIPTION
fix(deploy): pin pgvector to a digest, so pg17 cannot move under a live database

pgvector/pgvector:pg17 is the twelfth of the twelve third-party images
Factory#573 found running on mutable tags in the `factory` namespace. The
other eleven were pinned in factory-gitops#140. This one could not be:
factory-gitops points ArgoCD at THIS repo for it, so the fix has to land here.

It had already drifted, and still has:

  running in cluster:  pgvector/pgvector@sha256:be400b50...
  registry HEAD pg17:  pgvector/pgvector@sha256:7ae6051e...

Same tag, two different images. `pg17` is a floating major-line tag that moves
on every PostgreSQL 17 patch release and every pgvector rebuild, so this is the
one on that list most likely to move. It is also a database, which makes a
silent swap a Postgres change under a live data directory.

Pinned to the RUNNING digest, not HEAD. Both carry PG_VERSION 17.10-1.pgdg12+1
and pgvector 0.8.2 (verified live: `select extversion from pg_extension`
returns 0.8.2, `show server_version` returns 17.10). HEAD is a later Debian
base rebuild (2026-07-29 vs 2026-06-18); adopting it is a deliberate upgrade
of a live database and should be its own change, not a side effect of pinning.
That matches how the other eleven were pinned.

Both call sites, not just the one the issue named. `job-migrate.yaml` uses the
same image as a `wait-for-db` init container; leaving it unpinned would keep a
second entry point through which the tag could still be repointed.

Verified:
- Both digests re-read with `crane manifest`: OCI image indexes, linux/amd64
  plus linux/arm64, so multi-arch portability survives the pin.
- `crane config` on the amd64 child of each: PG_VERSION identical, created
  dates 2026-06-18 and 2026-07-29.
- `kustomize build deploy/k8s`: the digest survives rendering. The
  `images:` transformer here touches only the two first-party refs, but
  factory-gitops#140 found one that silently stripped `@sha256:` on every
  build while the source file looked pinned, so this was checked rather than
  assumed.
- `kubectl apply --dry-run=server` against the live cluster and its Kyverno
  admission webhook: all seven resources clean.

Expect one restart of skillai-db-0 on the next ArgoCD sync: the image
reference string changes, so the StatefulSet pod template changes. Nothing is
re-pulled -- the digest is the bytes containerd already has for that Pod
(`imageID: docker.io/pgvector/pgvector@sha256:be400b50...`) and the pull policy
is IfNotPresent. This is the last uncontrolled restart; after it the bytes are
fixed.

Nothing refreshes this pin automatically. Renovate is configured in
factory-gitops but the GitHub App is not installed, and this repo has no
equivalent; a CVE fix on pg17 will not arrive on its own. Tracked as
factory-gitops#139.

Refs Factory#588, Factory#573, Factory#563, Factory#566

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019ZsjwEPE8XX52Pt2f32nQJ
