### PR TITLE
fix(docker): only su-exec when we actually started as root

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,8 +1,30 @@
 #!/bin/sh
 set -e
 
-# Fix ownership of uploads volume (Docker mounts as root)
-chown -R nextjs:nodejs /app/uploads 2>/dev/null || true
+# Two ways this container gets started, and they need different handling.
+#
+# 1. As root (docker compose, plain `docker run`). The bind-mounted uploads
+#    volume arrives owned by root, so it gets chowned, and then su-exec drops
+#    to nextjs so the app never runs privileged.
+#
+# 2. Already as nextjs, because the platform said so (Kubernetes runAsUser).
+#    Here su-exec is not just unnecessary, it is fatal: it calls setgroups(),
+#    which needs CAP_SETGID. Measured on the live cluster (Factory#624) --
+#    adding `capabilities: { drop: ["ALL"] }` to the Deployment, with or
+#    without a uid change, killed the pod on every start with:
+#
+#        su-exec: setgroups: Operation not permitted
+#
+#    which is why skillai-app was still running on container-runtime defaults:
+#    the obvious hardening patch crashloops it, and nothing said why.
+#
+# Branching on the uid we actually have keeps case 1 byte-for-byte unchanged,
+# so this is a no-op until a deployment starts us as non-root.
+if [ "$(id -u)" = "0" ]; then
+  # Fix ownership of uploads volume (Docker mounts as root)
+  chown -R nextjs:nodejs /app/uploads 2>/dev/null || true
+  exec su-exec nextjs node /app/server.js
+fi
 
-# Drop to nextjs user and run the app
-exec su-exec nextjs node /app/server.js
+# Already unprivileged: nothing to drop, nothing we are allowed to chown.
+exec node /app/server.js


### PR DESCRIPTION
Part 1 of Factory#624 (the image half). Part 2 is the `deploy/k8s` manifest, which **must land after this image is built**.

Base branch is `core-mvp-foundation`, because that is what ArgoCD syncs.

## The problem

`skillai-app` is the only Deployment left in the cluster's `factory` namespace running on pure container-runtime defaults — pod and container `securityContext` both `{}`, all 14 default capabilities, unconfined seccomp.

## Why it stayed that way

The obvious patch **crashloops it**. Measured on the live cluster, not guessed:

```
capabilities: { drop: ["ALL"] }
  -> su-exec: setgroups: Operation not permitted   (CrashLoopBackOff)
```

`docker/entrypoint.sh` is built to start as root and drop privileges itself, and `su-exec` calls `setgroups()`, which needs `CAP_SETGID`. `runAsUser` alone fails for the mirror reason — a non-root process cannot `setgroups()` either.

Worth stating plainly: **the hardening recommended on Factory#624 would have broken this service.** It recommends exactly the `drop: ["ALL"]` above. Applying it as written gives a CrashLoopBackOff, and the reason is inside the image, where a manifest-only change cannot see it.

## The fix

Kubernetes already does both jobs this entrypoint does — it starts the process as whatever uid you ask for, and the uploads volume is already `1001:1001` (measured across the whole tree, including existing uploads). So the entrypoint only needs to get out of the way when the platform has already done the work:

```sh
if [ "$(id -u)" = "0" ]; then
  chown -R nextjs:nodejs /app/uploads 2>/dev/null || true
  exec su-exec nextjs node /app/server.js
fi
exec node /app/server.js
```

The root path — docker compose, plain `docker run` — is byte-for-byte unchanged.

## Ordering — why this is a separate PR

This commit is a **no-op against today's deployment**, which is the point. The image has to ship before the manifest starts asking for uid 1001; the other order lands a manifest against an image that still calls `su-exec`, and the pod crashloops.

## Verification

Proved against the **real published image**, with no rebuild, by running exactly what the new non-root branch execs:

```
$ node /app/server.js   # uid 1001, capabilities dropped
uid=1001(nextjs) gid=1001(nodejs) groups=1001(nodejs),65533(nogroup)
CapEff: 0000000000000000
✓ Ready
GET /api/health -> 200
GET /           -> 307
```

Identical responses to the root pod it replaces (`/api/health` 200, `/` 307).

Related: #305 (nothing validates `deploy/k8s`) — Part 2 adds a check for this specific regression. Factory#624, Factory#521, Factory#42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZsjwEPE8XX52Pt2f32nQJ
