### PR TITLE
feat(k8s): harden skillai-app, and gate it here since factory-gitops cannot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,3 +177,34 @@ jobs:
           ENCRYPTION_KEY: 'ci-stub-encryption-key-placeholder'
           NEXT_TELEMETRY_DISABLED: '1'
         run: npm run build
+
+  # ---------------------------------------------------------------------------
+  # 5. k8s-hardening — pod securityContext ratchet for deploy/k8s
+  #
+  # ArgoCD syncs deploy/k8s straight from this repo, so factory-gitops' own
+  # hardening ratchet structurally cannot see these manifests. It reported
+  # "18/18 banked workloads" green for as long as skillai-app ran with no
+  # securityContext at all -- invisible, not passing (Factory#624).
+  #
+  # Kyverno admission in that cluster is Audit for all but one narrow rule, so
+  # it will ADMIT an unhardened pod too. This job is the only thing that
+  # refuses one, which is why it is here rather than there.
+  #
+  # Independent of the Node jobs, so it still reports on a manifest-only PR.
+  # ---------------------------------------------------------------------------
+  k8s-hardening:
+    name: Pod hardening (deploy/k8s)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install PyYAML
+        # Pinned deliberately: the assertion script exits 1 when it cannot
+        # import yaml, so a silent resolution change turns into a red build
+        # rather than a gate that parses nothing.
+        run: python3 -m pip install --upgrade 'PyYAML==6.0.2'
+
+      - name: Assert deploy/k8s workloads are still hardened
+        run: python3 scripts/assert-k8s-hardening.py deploy/k8s

--- a/deploy/k8s/deployment-app.yaml
+++ b/deploy/k8s/deployment-app.yaml
@@ -28,11 +28,47 @@ spec:
         app.kubernetes.io/name: skillai-app
         app.kubernetes.io/part-of: skillai
     spec:
+      # Factory#624. This Deployment was the last one in the cluster's `factory`
+      # namespace on pure container-runtime defaults: pod and container
+      # securityContext both {}, all 14 default capabilities, unconfined
+      # seccomp. The hardening sweep that fixed everything else (Factory#521)
+      # could not reach it, because those manifests live in factory-gitops and
+      # these do not -- ArgoCD syncs this path straight from this repo.
+      #
+      # No fsGroup, deliberately. The uploads PVC is ALREADY owned 1001:1001
+      # (measured across the whole tree, /app/uploads is drwxrwxrwx 1001:1001
+      # and every existing upload is 1001:1001), so there is nothing for a
+      # recursive fsGroup pass to fix, and adding one would mean a recursive
+      # chown of a user-data volume on every pod start for no benefit.
+      #
+      # readOnlyRootFilesystem is NOT set here, and that is a considered gap
+      # rather than an oversight. Measured: with it on, the app starts clean
+      # and serves /api/health 200, / 307, /login 200, /favicon.ico 200 with
+      # no EROFS in the logs. What was NOT exercised is the upload-and-parse
+      # path, which needs an authenticated session -- and this is a
+      # document-upload app, so that is exactly the path most likely to want a
+      # scratch write. Recorded so the next person starts from evidence
+      # instead of repeating the easy half.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         # ── App ───────────────────────────────────────────────────────────
         - name: app
           image: ghcr.io/olafkfreund/skillai:core-mvp-foundation
           imagePullPolicy: Always
+          # REQUIRES the image from #306. Until that entrypoint change is in
+          # the tag above, `drop: ["ALL"]` kills this pod on every start with
+          # `su-exec: setgroups: Operation not permitted` -- su-exec needs
+          # CAP_SETGID to drop privileges, and dropping ALL takes it away.
+          # Measured on the live cluster, twice, in both failure directions.
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           ports:
             - name: http
               containerPort: 3000

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,8 +1,30 @@
 #!/bin/sh
 set -e
 
-# Fix ownership of uploads volume (Docker mounts as root)
-chown -R nextjs:nodejs /app/uploads 2>/dev/null || true
+# Two ways this container gets started, and they need different handling.
+#
+# 1. As root (docker compose, plain `docker run`). The bind-mounted uploads
+#    volume arrives owned by root, so it gets chowned, and then su-exec drops
+#    to nextjs so the app never runs privileged.
+#
+# 2. Already as nextjs, because the platform said so (Kubernetes runAsUser).
+#    Here su-exec is not just unnecessary, it is fatal: it calls setgroups(),
+#    which needs CAP_SETGID. Measured on the live cluster (Factory#624) --
+#    adding `capabilities: { drop: ["ALL"] }` to the Deployment, with or
+#    without a uid change, killed the pod on every start with:
+#
+#        su-exec: setgroups: Operation not permitted
+#
+#    which is why skillai-app was still running on container-runtime defaults:
+#    the obvious hardening patch crashloops it, and nothing said why.
+#
+# Branching on the uid we actually have keeps case 1 byte-for-byte unchanged,
+# so this is a no-op until a deployment starts us as non-root.
+if [ "$(id -u)" = "0" ]; then
+  # Fix ownership of uploads volume (Docker mounts as root)
+  chown -R nextjs:nodejs /app/uploads 2>/dev/null || true
+  exec su-exec nextjs node /app/server.js
+fi
 
-# Drop to nextjs user and run the app
-exec su-exec nextjs node /app/server.js
+# Already unprivileged: nothing to drop, nothing we are allowed to chown.
+exec node /app/server.js

--- a/scripts/assert-k8s-hardening.py
+++ b/scripts/assert-k8s-hardening.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Assert the workloads in deploy/k8s keep their pod-hardening controls.
+
+Why this lives HERE and not in factory-gitops (Factory#624)
+-----------------------------------------------------------
+factory-gitops has a hardening ratchet covering 18 workloads. It cannot cover
+skillai-app: ArgoCD syncs these manifests from THIS repo, so that gate never
+renders them. It reported "18/18 banked workloads" green the whole time
+skillai-app was running with no securityContext at all -- not because it
+passed, but because it was invisible.
+
+Kyverno does not close the gap either: admission is Audit for everything but
+one narrowly scoped rule, so nothing in the cluster refuses an unhardened pod.
+
+So the check has to be here, next to the manifests it guards.
+
+Rule 4.7 (Factory standards): a gate that cannot do its work must FAIL, not
+pass silently. Discovering zero manifests, or zero workloads, is an error --
+that is the failure shape where a check quietly stops checking.
+
+Run: python3 scripts/assert-k8s-hardening.py [deploy/k8s]
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+
+try:
+    import yaml
+except ImportError:
+    print("::error::PyYAML missing -- this gate could not parse anything")
+    raise SystemExit(1)
+
+KINDS = {"Deployment", "StatefulSet", "DaemonSet"}
+
+# (workload, container) whose hardening has been measured and is now banked.
+# Losing a control here fails the build. Adding an entry is how a win is kept.
+HARDENED = {
+    ("skillai-app", "app"),
+}
+
+# Per-control carve-outs. Each is a line in a diff a reviewer has to look at.
+EXCEPTIONS: dict[tuple[str, str, str], str] = {}
+
+
+def missing(pod_sc: dict, sc: dict) -> list[str]:
+    out = []
+    # seccomp and runAsNonRoot are inheritable from the pod; either level counts.
+    seccomp = (sc.get("seccompProfile") or pod_sc.get("seccompProfile") or {}).get("type")
+    if seccomp not in ("RuntimeDefault", "Localhost"):
+        out.append("seccompProfile")
+    # allowPrivilegeEscalation is container-only; there is no pod-level form.
+    if sc.get("allowPrivilegeEscalation") is not False:
+        out.append("allowPrivilegeEscalation")
+    drop = [str(d).upper() for d in ((sc.get("capabilities") or {}).get("drop") or [])]
+    if "ALL" not in drop:
+        out.append("capabilities.drop[ALL]")
+    if sc.get("runAsNonRoot") is not True and pod_sc.get("runAsNonRoot") is not True:
+        out.append("runAsNonRoot")
+    return out
+
+
+def main() -> int:
+    root = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else "deploy/k8s")
+    files = sorted(root.glob("*.yaml")) + sorted(root.glob("*.yml"))
+    if not files:
+        print(f"::error::no manifests found under {root} -- this gate checked nothing")
+        return 1
+
+    docs = []
+    for f in files:
+        try:
+            docs.extend(d for d in yaml.safe_load_all(f.read_text()) if isinstance(d, dict))
+        except yaml.YAMLError as e:
+            print(f"::error::{f} is not parseable YAML, so it was not checked: {e}")
+            return 1
+
+    workloads = [d for d in docs if d.get("kind") in KINDS]
+    if not workloads:
+        print(f"::error::no Deployment/StatefulSet/DaemonSet rendered from {root} "
+              "-- discovery broke and this gate checked nothing")
+        return 1
+
+    seen, bad, unhardened = set(), 0, []
+    for d in workloads:
+        name = (d.get("metadata") or {}).get("name", "<unnamed>")
+        spec = ((d.get("spec") or {}).get("template") or {}).get("spec") or {}
+        pod_sc = spec.get("securityContext") or {}
+        for c in spec.get("containers") or []:
+            cname = c.get("name", "<unnamed>")
+            gaps = missing(pod_sc, c.get("securityContext") or {})
+            if (name, cname) not in HARDENED:
+                if gaps:
+                    unhardened.append(f"{name}/{cname}: {', '.join(gaps)}")
+                continue
+            seen.add((name, cname))
+            for control in gaps:
+                if (name, cname, control) in EXCEPTIONS:
+                    continue
+                print(f"::error::REGRESSION: {name}/{cname} no longer sets {control}. "
+                      "This workload was hardened deliberately (Factory#624) and the "
+                      "control has been removed. factory-gitops' ratchet CANNOT see "
+                      "this repo and Kyverno admission is Audit, so nothing downstream "
+                      "will catch it.")
+                bad = 1
+
+    # A banked workload that vanishes from the tree silently loosens the gate:
+    # a name asserted against a manifest that no longer exists passes vacuously.
+    for key in sorted(HARDENED - seen):
+        print(f"::error::{key[0]}/{key[1]} is in HARDENED but no such container "
+              "exists in deploy/k8s -- it was renamed or removed. Update HARDENED "
+              "deliberately; leaving it stale means this gate stops checking it.")
+        bad = 1
+
+    if unhardened:
+        print(f"note: {len(unhardened)} container(s) not yet in the ratchet "
+              "(informational, does not fail):")
+        for u in sorted(unhardened):
+            print(f"  -  {u}")
+
+    if bad:
+        print("hardening: REGRESSION -- see the ::error:: annotations above")
+    else:
+        print(f"hardening: {len(seen)}/{len(HARDENED)} banked workload(s) still carry "
+              "seccompProfile, allowPrivilegeEscalation, capabilities.drop[ALL], runAsNonRoot")
+    return bad
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Part 2 of Factory#624 — the manifest half, plus the gate that keeps it. Part 1 is #306.

> **DRAFT / BLOCKED.** Do not merge until #306 is merged and its image has been built and pushed to the `core-mvp-foundation` tag. Against the current image, `capabilities: { drop: ["ALL"] }` crashloops this pod with `su-exec: setgroups: Operation not permitted`.

Stacked on #306.

## What this adds

`runAsNonRoot: true`, `runAsUser/runAsGroup: 1001`, `seccompProfile: RuntimeDefault`, `allowPrivilegeEscalation: false`, `capabilities.drop: ["ALL"]`.

Measured on the **real published image**, by running exactly what #306's non-root branch execs:

```
uid=1001(nextjs) gid=1001(nodejs)
CapEff: 0000000000000000
GET /api/health -> 200
GET /           -> 307
```

Identical to the root pod it replaces.

## Two deliberate omissions, both with their evidence recorded in the manifest

**No `fsGroup`.** The uploads PVC is already `1001:1001` across the whole tree (`/app/uploads` is `drwxrwxrwx 1001:1001`, every existing upload `1001:1001`). A recursive fsGroup pass would chown a user-data volume on every pod start to change nothing — and Factory#621 is a fresh reminder that the recursive-walk semantics are a trap worth not walking into unnecessarily.

**No `readOnlyRootFilesystem`.** Measured: with it on, the app starts clean and serves `/api/health` 200, `/` 307, `/login` 200, `/favicon.ico` 200, no EROFS in the logs. What was **not** exercised is upload-and-parse, which needs an authenticated session — and on a document-upload app that is precisely the path most likely to want a scratch write. So the honest state is "promising, not proven", and the manifest says so rather than shipping an untested control into a live service.

## The gate, which is the durable half

Factory#624's real finding is structural. ArgoCD syncs `deploy/k8s` from **this** repo, so factory-gitops' hardening ratchet never renders these manifests. It reported `18/18 banked workloads` green for as long as `skillai-app` had no securityContext at all — **invisible, not passing**. Kyverno admission in that cluster is Audit for all but one narrow rule, so it will admit an unhardened pod too.

Without a check here, this PR rots the moment someone edits the file.

So this adds `scripts/assert-k8s-hardening.py` plus a `k8s-hardening` job in `ci.yml`. It follows the factory-gitops ratchet's shape, including the parts that are easy to leave out:

- absence is a failure — no manifests, no workloads, or unparseable YAML all exit 1, rather than passing vacuously;
- a banked workload that disappears from the tree is an **error**, not a silent pass;
- the summary line does not print a green count on a red run.

It also surfaces `skillai-db/postgres` as not-yet-hardened (informational, non-fatal) — a worklist rather than a wedged required check.

Partially addresses #305 (nothing validates `deploy/k8s`): this covers pod hardening specifically, not schema validity.

## Verification

Gate green locally at `1/1`. Mutation-checked in CI both directions — see the PR comment.

Refs Factory#624, Factory#521, Factory#42, #305, #306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZsjwEPE8XX52Pt2f32nQJ
