### PR TITLE
feat(ci): validate deploy/k8s, the directory ArgoCD syncs straight to the cluster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 #
 # Continuous integration gate for pull requests targeting core-mvp-foundation.
 #
-# Runs four jobs in parallel where possible:
+# Runs six jobs in parallel where possible:
 #   1. lint      — ESLint with --max-warnings=99999 (errors block, warnings allowed)
 #                  Baseline established in PR #178 ci/eslint-baseline:
 #                    • 0 errors required; warnings are non-blocking for v1
@@ -13,6 +13,11 @@
 #   4. build     — next build with stub env vars to catch compile-time errors
 #                  (depends on test + typecheck so we don't waste build minutes
 #                  on a branch that's already red)
+#   5. k8s-hardening  — securityContext ratchet for deploy/k8s (Factory#624)
+#   6. k8s-manifests  — deploy/k8s builds, schema-checks and stays digest-pinned
+#                       (#305). ArgoCD syncs that directory straight onto the
+#                       cluster, so these two jobs are the only thing between a
+#                       commit and production.
 #
 # Why stub env vars for build:
 #   next.config.ts uses `output: 'standalone'` and all routes carry
@@ -208,3 +213,75 @@ jobs:
 
       - name: Assert deploy/k8s workloads are still hardened
         run: python3 scripts/assert-k8s-hardening.py deploy/k8s
+
+  # ---------------------------------------------------------------------------
+  # 6. k8s-manifests — does deploy/k8s render, parse, and stay pinned (#305)
+  #
+  # deploy/k8s is a live production deployment target: factory-gitops
+  # apps/skillai/application.yaml points ArgoCD at this repo, branch
+  # core-mvp-foundation, path deploy/k8s, with automated prune + selfHeal. There
+  # is nothing between a commit here and the cluster. The k8s-hardening job
+  # above reads the source files for securityContext only; it does not build the
+  # kustomization, does not schema-check anything, and does not look at images.
+  # So until this job, a manifest that fails `kustomize build` or carries a
+  # typo'd key reached ArgoCD and surfaced as a sync error after the fact.
+  #
+  # That got more expensive on 2026-08-07, when the cluster's signature
+  # ClusterPolicy went to Enforce: a manifest that degraded quietly yesterday is
+  # a denied admission today.
+  #
+  # Separate job from k8s-hardening on purpose -- different failure, different
+  # red X, and it still reports if the hardening ratchet is what broke.
+  # ---------------------------------------------------------------------------
+  k8s-manifests:
+    name: Manifest validation (deploy/k8s)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install kustomize, kubeconform and PyYAML
+        run: |
+          set -euo pipefail
+          curl -sfL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.8.1/kustomize_v5.8.1_linux_amd64.tar.gz \
+            | tar -xz -C /usr/local/bin kustomize
+          curl -sfL https://github.com/yannh/kubeconform/releases/download/v0.7.0/kubeconform-linux-amd64.tar.gz \
+            | tar -xz -C /usr/local/bin kubeconform
+          python3 -m pip install --upgrade 'PyYAML==6.0.2'
+          # Rule 4.7: prove the tools are usable before claiming anything
+          # passed. A download that 404s into a 0-byte file still leaves a file
+          # behind, and `set -e` alone will not notice a gate that then runs
+          # nothing.
+          kustomize version
+          kubeconform -v
+
+      - name: Build, schema-check and assert digest pins
+        # `set -e` deliberately, matching the shell GitHub uses, but WITHOUT a
+        # pipeline that can swallow a failure: each stage writes a file and is
+        # checked on its own line. factory-gitops#140's gate broke on exactly
+        # this -- a step that looked sequential but lost an exit code in a pipe.
+        run: |
+          set -euo pipefail
+
+          # 1. It must build at all. This is the failure ArgoCD reports after
+          #    the fact today, on the only branch that matters.
+          kustomize build deploy/k8s > rendered.yaml
+
+          # 2. An empty build is not a passing build. kustomize exits 0 for a
+          #    kustomization that resources its way to nothing, and zero
+          #    documents then sail through every check below.
+          if [ ! -s rendered.yaml ]; then
+            echo "::error file=deploy/k8s/kustomization.yaml::kustomize build produced no output -- this gate validated nothing"
+            exit 1
+          fi
+
+          # 3. -strict rejects unknown fields, which is what catches a typo'd
+          #    key that Kubernetes would otherwise silently drop.
+          #    -ignore-missing-schemas skips KINDS with no upstream schema; every
+          #    core kind here is still checked strictly.
+          kubeconform -strict -ignore-missing-schemas -summary rendered.yaml
+
+          # 4. Digest pins, read from the RENDERED output rather than the source
+          #    files, because the `images:` transformer sits between them.
+          python3 scripts/assert-k8s-images-pinned.py < rendered.yaml

--- a/scripts/assert-k8s-images-pinned.py
+++ b/scripts/assert-k8s-images-pinned.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Assert every third-party image in the RENDERED deploy/k8s carries a digest.
+
+Why rendered, not source (#305)
+-------------------------------
+deploy/k8s/kustomization.yaml has an `images:` transformer. factory-gitops#140
+found one that stripped `@sha256:` on every build while the source file still
+read as correctly pinned -- the manifests looked right in review and the
+cluster ran an unpinned tag. This repo's transformer touches only the two
+first-party refs today, which is exactly the state that one was in before it
+did not. So this reads `kustomize build` output, which is what ArgoCD applies.
+
+Why third-party only
+--------------------
+The first-party `ghcr.io/olafkfreund/*` refs are bumped to an immutable
+`:<git-sha>` tag by deploy-image.yml on every merge, and the cluster's
+signature ClusterPolicy is now Enforce for them -- a substituted image fails
+admission. Third-party images have neither guard: `pgvector/pgvector:pg17`
+moved under a live database (#304) with nothing to say so.
+
+Rule 4.7 (Factory standards): a gate that cannot do its work must FAIL, not
+pass. Zero documents and zero images are both errors -- that is the shape
+where a check quietly stops checking.
+
+Run: kustomize build deploy/k8s | python3 scripts/assert-k8s-images-pinned.py
+"""
+from __future__ import annotations
+
+import sys
+
+try:
+    import yaml
+except ImportError:
+    print("::error::PyYAML missing -- this gate could not parse anything")
+    raise SystemExit(1)
+
+FIRST_PARTY = "ghcr.io/olafkfreund/"
+
+
+def images(node) -> list[str]:
+    """Every `image:` string anywhere in the tree.
+
+    ponytail: any key named `image` counts, rather than walking
+    containers/initContainers/ephemeralContainers paths. Shorter, and it also
+    covers CRDs and embedded pod templates a path walk would miss. A non-image
+    field named `image` would be a false positive -- loud, which is the right
+    direction to be wrong in. Narrow the walk if one ever shows up.
+    """
+    out = []
+    if isinstance(node, dict):
+        for k, v in node.items():
+            if k == "image" and isinstance(v, str):
+                out.append(v)
+            else:
+                out.extend(images(v))
+    elif isinstance(node, list):
+        for v in node:
+            out.extend(images(v))
+    return out
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        print("::error::no rendered manifests on stdin -- this gate checked nothing")
+        return 1
+
+    try:
+        docs = [d for d in yaml.safe_load_all(raw) if isinstance(d, dict)]
+    except yaml.YAMLError as e:
+        print(f"::error::rendered output is not parseable YAML, so it was not checked: {e}")
+        return 1
+
+    if not docs:
+        print("::error::rendered output contained no YAML documents -- this gate checked nothing")
+        return 1
+
+    found = images(docs)
+    if not found:
+        print("::error::no image references found in the rendered output -- discovery "
+              "broke and this gate checked nothing")
+        return 1
+
+    bad = [i for i in found if not i.startswith(FIRST_PARTY) and "@sha256:" not in i]
+    for i in sorted(set(bad)):
+        print(f"::error::{i} is a third-party image with no digest. ArgoCD syncs "
+              "deploy/k8s straight onto the cluster, so a moved tag reaches production "
+              "with nothing in the way -- which is how pgvector:pg17 came to be running "
+              "bytes its own tag no longer resolved to (#304). Pin it as "
+              "name:tag@sha256:<digest>.")
+
+    third_party = [i for i in found if not i.startswith(FIRST_PARTY)]
+    print(f"images: {len(found)} rendered ref(s), {len(third_party)} third-party, "
+          f"{len(bad)} unpinned")
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #305.

Targets `core-mvp-foundation` because that is the branch the `skillai` ArgoCD Application syncs (`factory-gitops apps/skillai/application.yaml`), and it is this repo default branch. A gate on any other branch would not sit between a commit and the cluster.

## What was missing

CI here ran Build, Lint, Typecheck and Tests -- all on the Next.js application. The `Pod hardening (deploy/k8s)` job added in #307 covers `deploy/k8s`, but only for `securityContext`, and it reads the source YAML files. It does not build the kustomization, does not schema-check anything, and does not look at images.

ArgoCD syncs `deploy/k8s` with `automated: {prune: true, selfHeal: true}`, so a kustomization that fails to build or a manifest with a bad schema reached the cluster with nothing in the way. That got more expensive when the signature ClusterPolicy went to Enforce: a manifest that degraded quietly yesterday is a denied admission today.

## The gate

New `k8s-manifests` job, independent of the Node jobs so it still reports on a manifest-only PR:

1. `kustomize build deploy/k8s` succeeds and produces non-empty output
2. `kubeconform -strict -ignore-missing-schemas` on the rendered output
3. `scripts/assert-k8s-images-pinned.py`: every third-party image in the **rendered** output carries `@sha256:`

Point 3 reads rendered output because the `images:` transformer sits between source and cluster. factory-gitops#140 found one that stripped `@sha256:` on every build while the source file read as correctly pinned.

First-party `ghcr.io/olafkfreund/*` is exempt: `deploy-image.yml` bumps it to an immutable `:<git-sha>` on every merge and the signature policy is Enforce for it. Third-party images have neither guard.

## Mutation check

Baseline, unmutated:

```
images: 4 rendered ref(s), 2 third-party, 0 unpinned
exit=0
```

**A. Unpin pgvector in `statefulset-db.yaml`:**

```
::error::pgvector/pgvector:pg17 is a third-party image with no digest. ...
images: 4 rendered ref(s), 2 third-party, 1 unpinned
exit=1
```

**B. The one that matters -- `images:` transformer strips the digest, source file untouched:**

```
--- source file still reads as pinned: ---
1                                   # grep -c pg17@sha256:be400b50 statefulset-db.yaml
--- rendered: ---
        image: pgvector/pgvector:pg17
        image: pgvector/pgvector:pg17
::error::pgvector/pgvector:pg17 is a third-party image with no digest. ...
images: 4 rendered ref(s), 2 third-party, 2 unpinned
exit=1
```

A source-reading gate passes B. That is why point 3 reads the render.

**C. Kustomization references a missing resource:**

```
kustomize exit=1
Error: accumulating resources: ... service-does-not-exist.yaml ... no such file or directory
```

**D. Typo a key Kubernetes would silently drop (`replicas` -> `replicaCount`):**

```
kustomize exit=0 (builds fine - this is why schema-check is separate)
/tmp/rD.yaml - Deployment skillai-app is invalid: ... additional properties 'replicaCount' not allowed
Summary: 7 resources found in 1 file - Valid: 6, Invalid: 1, Errors: 0, Skipped: 0
kubeconform exit=1
```

**Restored after each:**

```
images: 4 rendered ref(s), 2 third-party, 0 unpinned      exit=0
kustomize exit=0
Summary: 7 resources found in 1 file - Valid: 7, Invalid: 0, Errors: 0, Skipped: 0   exit=0
```

## Rule 4.7 zero-guards, each verified

```
=== empty stdin ===
::error::no rendered manifests on stdin -- this gate checked nothing
exit=1
=== valid YAML, no images ===
::error::no image references found in the rendered output -- discovery broke and this gate checked nothing
exit=1
=== PyYAML absent ===
::error::PyYAML missing -- this gate could not parse anything
exit=1
```

The tool-install step also runs `kustomize version` and `kubeconform -v` before anything claims to pass -- a download that 404s into a 0-byte file still leaves a file behind.

Refs #304, Factory#588, Factory#573, factory-gitops#140